### PR TITLE
Add contribution guidelines and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,15 @@
+---
+name: Bug report
+about: A command or agent isn't working as documented
+labels: bug
+---
+
+**Command or agent:** `/command-name` or `agent-name`
+
+**Expected behavior:**
+
+**Actual behavior:**
+
+**Claude Code version:** (`claude --version`)
+
+**Additional context:**

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -1,0 +1,12 @@
+---
+name: Suggestion
+about: Propose a new command, agent, or improvement
+labels: enhancement
+---
+
+**What would you like to see?**
+
+**Why is this useful?**
+
+**Which part of the workflow does this fit into?**
+(getting started / feature gates / audits / periodic reviews / backlog management / other)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## What this changes
+
+## Why
+
+## Related issue
+
+Closes #
+
+## Checklist
+
+- [ ] Follows existing file structure and frontmatter conventions
+- [ ] New agents/commands read appropriate context docs (PRODUCT.md, DESIGN.md, CLAUDE.md)
+- [ ] Review output paths use `docs/jaqal/` prefix
+- [ ] README updated if adding new commands or changing the workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Jaqal
+
+Thanks for your interest in improving Jaqal. Here's how to contribute.
+
+## Reporting issues
+
+Open an issue for bugs, unclear documentation, or suggestions. Include:
+
+- What you expected to happen
+- What actually happened
+- Which command or agent was involved
+- Your Claude Code version (`claude --version`)
+
+## Proposing changes
+
+1. **Open an issue first** for anything beyond a typo fix. Describe what you want to change and why. This saves everyone time if the change doesn't fit the project's direction.
+2. **Fork and branch** from `main`.
+3. **Make your changes.** Follow the patterns in existing files — agent frontmatter, command frontmatter, and directory structure are intentional.
+4. **Open a PR** against `main` with a clear description of what changed and why.
+
+## What makes a good contribution
+
+- **Agent or command improvements** — better prompts, clearer instructions, more useful output formats
+- **New agents or commands** that fit the existing workflow (gates, reviews, audits, backlog management)
+- **Bug fixes** — commands that don't work as documented
+- **Documentation** — README improvements, better examples
+
+## Structure conventions
+
+```
+agents/       — Agent definitions (name, description, tools, model in frontmatter)
+commands/     — Slash commands (description, allowed-tools in frontmatter)
+templates/    — Scaffold files created by /jaqal-init
+```
+
+- Agents do the work. Commands orchestrate agents or provide standalone workflows.
+- Every agent and command reads PRODUCT.md, DESIGN.md, or CLAUDE.md for project context.
+- Review reports save to `docs/jaqal/` subdirectories in the user's project, not to the plugin itself.
+- Commands that produce output are recommend-only — they report, never modify external state (issues, PRs, files outside `docs/jaqal/`).
+
+## What we won't merge
+
+- Changes that make agents modify issues, PRs, or external state without explicit user action
+- Features that duplicate what [Superpowers](https://github.com/obra/superpowers) already handles (brainstorming, planning, TDD, execution)
+- Agents that bundle multiple concerns (security + code quality in one agent) — each agent stays in its lane
+
+## Code of conduct
+
+Be respectful and constructive. We're all here to make better tools.


### PR DESCRIPTION
## What this changes

Adds community contribution infrastructure:
- `CONTRIBUTING.md` — how to report issues, propose changes, what we will/won't merge
- `.github/ISSUE_TEMPLATE/bug.md` — bug report template
- `.github/ISSUE_TEMPLATE/suggestion.md` — suggestion template
- `.github/pull_request_template.md` — PR checklist

Branch protection is already enabled on main (1 approval required, stale reviews dismissed).

## Why

Public repo needs clear guidelines for external contributors and protection against direct pushes to main.