### PR TITLE
feat: marketplace install + semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Semantic release
+    runs-on: ubuntu-latest
+    concurrency: release
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install python-semantic-release
+        run: pip install python-semantic-release
+
+      - name: Compute version and push tag
+        run: semantic-release version
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Publish GitHub release
+        run: semantic-release publish
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -8,8 +8,18 @@ It handles the **what** and the **whether** — what to work on, whether a desig
 
 ## Getting started
 
+Install via the Jacquard Labs marketplace:
+
 ```bash
-claude install github:jacquardlabs/jaqal
+/plugin marketplace add jacquardlabs/marketplace
+/plugin install jaqal@jacquardlabs-marketplace
+```
+
+Or install this plugin directly:
+
+```bash
+/plugin marketplace add jacquardlabs/jaqal
+/plugin install jaqal@jaqal
 ```
 
 Then, in any project:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.semantic_release]
+version_variables = [".claude-plugin/plugin.json:version"]
+tag_format = "v{version}"
+commit_message = "chore(release): v{version} [skip ci]"
+major_on_zero = false
+build_command = ""
+upload_to_vcs_release = true
+
+[tool.semantic_release.branches.main]
+match = "main"


### PR DESCRIPTION
## Summary
- Replace legacy \`claude install\` command in README with plugin system install paths (org marketplace + direct)
- Add \`pyproject.toml\` with \`[tool.semantic_release]\` config (no Python package — config only)
- Add \`.github/workflows/release.yml\` — triggers on push to main, uses python-semantic-release

## After merge
Manually trigger the release workflow once to create the initial \`v1.0.0\` release (current plugin.json version is 1.0.0).