### PR TITLE
docs: rewrite README in Bryan's voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Jaqal
 
-*Quality loom for Claude Code — from [Jacquard Labs](https://github.com/jacquardlabs)*
+Quality loom for Claude Code, from [Jacquard Labs](https://github.com/jacquardlabs).
 
 Jaqal gives your Claude Code sessions a structured product development workflow: decide what to build, gate it before and after implementation, audit it before merge, and periodically review the health of your entire project.
 
-It handles the **what** and the **whether** — what to work on, whether a design serves users, whether the implementation delivers, whether the codebase is healthy. Pair it with [Superpowers](https://github.com/obra/superpowers) for the **how** — brainstorming, planning, TDD, and execution.
+It handles the what and the whether: what to work on, whether a design serves users, whether the implementation delivers, whether the codebase is healthy. Pair it with [Superpowers](https://github.com/obra/superpowers) for the how: brainstorming, planning, TDD, and execution.
 
 ## Getting started
 
@@ -28,20 +28,20 @@ Then, in any project:
 /jaqal-init
 ```
 
-This does four things:
+This does 4 things:
 
-1. **Creates PRODUCT.md** — Analyzes your codebase to extract who your users are, what the product does, what you're not building, and what's broken. Sections that need human judgment (product principles, explicit scope boundaries) are left with prompts for you to fill in.
-2. **Creates DESIGN.md** — Extracts your actual design system from code: colors, typography, spacing, component patterns, and inconsistencies. Documents what IS, not what should be.
-3. **Scaffolds review directories** — Creates `docs/jaqal/health-reviews/`, `docs/jaqal/frontend-reviews/`, `docs/jaqal/architecture-reviews/`, and `docs/jaqal/product-reviews/` for dated reports that track trends over time.
-4. **Updates CLAUDE.md** — Adds the review workflow reference (gates, cadences, maintenance steps) so every future session knows the process.
+1. Creates PRODUCT.md: analyzes your codebase to extract who your users are, what the product does, what you're not building, and what's broken. Sections that need human judgment (product principles, explicit scope boundaries) are left with prompts for you to fill in.
+2. Creates DESIGN.md: extracts your actual design system from code: colors, typography, spacing, component patterns, and inconsistencies. Documents what IS, not what should be.
+3. Scaffolds review directories: creates `docs/jaqal/health-reviews/`, `docs/jaqal/frontend-reviews/`, `docs/jaqal/architecture-reviews/`, and `docs/jaqal/product-reviews/` for dated reports that track trends over time.
+4. Updates CLAUDE.md: adds the review workflow reference (gates, cadences, maintenance steps) so every future session knows the process.
 
-After init, review PRODUCT.md first — the extraction is evidence-based, but product principles and "what we're NOT building" need your voice.
+After init, review PRODUCT.md first; the extraction is evidence-based, but product principles and "what we're NOT building" need your voice.
 
 ---
 
 ## Building features
 
-Jaqal wraps feature development in three quality gates. Between the gates, you build — Jaqal doesn't care how. We recommend [Superpowers](https://github.com/obra/superpowers) for brainstorming, planning, and execution, but any workflow works.
+Jaqal wraps feature development in 3 quality gates. Between the gates, you build; Jaqal doesn't care how. We recommend [Superpowers](https://github.com/obra/superpowers) for brainstorming, planning, and execution, but any workflow works.
 
 ### Pick what to build
 
@@ -51,7 +51,7 @@ Start from your backlog or an idea. If you have open GitHub issues:
 /backlog-priorities
 ```
 
-This asks what kind of work you're in the mood for (tech debt, maintenance, polish, or new initiative), then ranks your open issues by severity from past reviews, product alignment, and unblocking potential. It recommends — you decide.
+Asks what kind of work you're in the mood for (tech debt, maintenance, polish, or new initiative), then ranks your open issues by severity from past reviews, product alignment, and unblocking potential. It recommends; you decide.
 
 If you're starting from a raw idea instead of an issue:
 
@@ -59,7 +59,7 @@ If you're starting from a raw idea instead of an issue:
 /gate-should-we-build add a leaderboard for study streaks
 ```
 
-This evaluates the idea against PRODUCT.md — who it serves, how it ranks against known problems, whether it conflicts with your "not building" list, and what the smallest viable version looks like. It ends with a clear verdict: **BUILD**, **BUILD SMALLER**, **DEFER**, or **DON'T BUILD**.
+Evaluates the idea against PRODUCT.md: who it serves, how it ranks against known problems, whether it conflicts with your "not building" list, and what the smallest viable version looks like. Ends with a clear verdict: BUILD, BUILD SMALLER, DEFER, or DON'T BUILD.
 
 ### Gate the design
 
@@ -69,7 +69,7 @@ After you have a design doc (from Superpowers brainstorm or written by hand):
 /gate-design-review
 ```
 
-A product reviewer evaluates the design against PRODUCT.md, then walks through it as your primary persona would experience it — step by step, noting where they'd get confused or frustrated. Verdict: **PROCEED TO PLAN**, **REVISE** (with specific changes), or **RETHINK**.
+A product reviewer evaluates the design against PRODUCT.md, then walks through it as your primary persona would, step by step, noting where they'd get confused or frustrated. Verdict: PROCEED TO PLAN, REVISE (with specific changes), or RETHINK.
 
 ### Build it
 
@@ -83,9 +83,9 @@ When implementation is complete and tests pass:
 /audit
 ```
 
-This dispatches up to 7 auditors in parallel — security, code quality, documentation, architecture, UX, frontend code, and accessibility. Each stays in its lane (the security auditor doesn't flag code style; the code auditor doesn't flag XSS). Results are compiled into a single report with a verdict: **PASS**, **FIX AND RE-AUDIT**, or **NEEDS DISCUSSION**.
+Dispatches 7 auditors in parallel: security, code quality, documentation, architecture, UX, frontend code, and accessibility. Each stays in its lane (the security auditor doesn't flag code style; the code auditor doesn't flag XSS). Results compile into a single report with a verdict: PASS, FIX AND RE-AUDIT, or NEEDS DISCUSSION.
 
-For branches with no frontend changes, frontend auditors are automatically skipped.
+Frontend auditors are skipped automatically for branches with no frontend changes.
 
 ### Gate acceptance
 
@@ -95,7 +95,7 @@ After the audit passes:
 /gate-acceptance
 ```
 
-This isn't a code review — it's a product review. Does the implementation actually deliver the intended experience? A product reviewer walks through every user-facing change, checks error states and edge cases for human-friendly messaging, regression-tests the critical user journeys from PRODUCT.md, and names the one thing a real user would complain about. Verdict: **SHIP**, **FIX AND RE-CHECK**, or **HOLD**.
+Not a code review, a product review. Does the implementation actually deliver the intended experience? A product reviewer walks through every user-facing change, checks error states and edge cases for human-friendly messaging, regression-tests the critical user journeys from PRODUCT.md, and names the one thing a real user would complain about. Verdict: SHIP, FIX AND RE-CHECK, or HOLD.
 
 ### The full flow
 
@@ -115,13 +115,13 @@ This isn't a code review — it's a product review. Does the implementation actu
        merge
 ```
 
-You don't have to use every gate every time. For small bug fixes, `/audit` alone is often enough. The gates are there to prevent building the wrong thing or shipping a bad experience — use your judgment about when that risk applies.
+You don't have to use every gate every time. For small bug fixes, `/audit` alone is enough. The gates prevent building the wrong thing or shipping a bad experience; use judgment about when that risk applies.
 
 ---
 
 ## Periodic health checks
 
-Separate from the feature flow, Jaqal provides periodic reviews that assess the overall health of your project. These run against main, not feature branches.
+Separate from the feature flow: periodic reviews that assess overall project health. These run against main, not feature branches.
 
 ### The full sweep
 
@@ -129,16 +129,16 @@ Separate from the feature flow, Jaqal provides periodic reviews that assess the 
 /deep-review
 ```
 
-This dispatches all four review agents in parallel:
+Dispatches all 4 review agents in parallel:
 
-- **Codebase health** — architecture coherence, tech debt inventory, dependency vulnerabilities, test coverage gaps, API consistency
-- **Frontend health** — design system drift, accessibility audit, component quality, responsive behavior
-- **Architecture** — dependency graph, module boundaries, complexity distribution, data layer health, evolution readiness
-- **Product health** — PRODUCT.md accuracy check, persona drift, scope creep, feature coherence, onboarding friction
+- Codebase health: architecture coherence, tech debt inventory, dependency vulnerabilities, test coverage gaps, API consistency
+- Frontend health: design system drift, accessibility audit, component quality, responsive behavior
+- Architecture: dependency graph, module boundaries, complexity distribution, data layer health, evolution readiness
+- Product health: PRODUCT.md accuracy check, persona drift, scope creep, feature coherence, onboarding friction
 
-Each agent saves a dated report to its `docs/jaqal/` subdirectory. The deep review then compiles a master summary that cross-references findings (architecture flags coupling AND codebase health flags related tech debt = systemic issue), produces a prioritized action plan, and proposes specific updates to PRODUCT.md, DESIGN.md, and CLAUDE.md for your approval.
+Each agent saves a dated report to its `docs/jaqal/` subdirectory. The deep review compiles a master summary, cross-references findings (architecture flags coupling + codebase health flags related tech debt = systemic issue), produces a prioritized action plan, and proposes specific updates to PRODUCT.md/DESIGN.md/CLAUDE.md for your approval.
 
-Metrics are captured each run so you can track trends: test coverage, TODO count, dependency health, bundle size, design system deviations.
+Metrics are captured each run for trend tracking: test coverage, TODO count, dependency health, bundle size, design system deviations.
 
 ### Individual reviews
 
@@ -157,7 +157,7 @@ Run any review on its own when you don't need the full sweep:
 /backlog-hygiene
 ```
 
-Scans all open GitHub issues against recent commits, PRODUCT.md, and review reports. Flags issues that have been resolved (with commit evidence), made obsolete (conflicts with "not building" or describes removed code), or duplicated. Never modifies issues — just produces a report.
+Scans all open GitHub issues against recent commits, PRODUCT.md, and review reports. Flags issues that have been resolved (with commit evidence), made obsolete (conflicts with "not building" or describes removed code), or duplicated. Never modifies issues, just produces a report.
 
 Good to run after a `/deep-review` cycle to catch issues resolved by that cycle's fixes.
 
@@ -174,15 +174,15 @@ Good to run after a `/deep-review` cycle to catch issues resolved by that cycle'
 
 ## Context documents
 
-Everything in Jaqal depends on three files in your project root. `/jaqal-init` creates them; you maintain them.
+Everything in Jaqal depends on 3 files in your project root. `/jaqal-init` creates them; you maintain them.
 
 | Document | What it contains | Updated by |
 |----------|-----------------|------------|
-| **PRODUCT.md** | Personas, principles, feature map, known problems, "not building" list | You + `/review-product-health` proposals |
-| **DESIGN.md** | Colors, typography, spacing, component patterns, inconsistencies | You + `/review-frontend-health` proposals |
-| **CLAUDE.md** | Technical conventions, review workflow reference | You + `/review-architecture` proposals |
+| PRODUCT.md | Personas, principles, feature map, known problems, "not building" list | You + `/review-product-health` proposals |
+| DESIGN.md | Colors, typography, spacing, component patterns, inconsistencies | You + `/review-frontend-health` proposals |
+| CLAUDE.md | Technical conventions, review workflow reference | You + `/review-architecture` proposals |
 
-Reviews propose updates to these docs but never apply them — you review and approve the changes.
+Reviews propose updates to these docs, never apply them; you review and approve the changes.
 
 If a context doc gets stale, the reviews will tell you. That's the point.
 
@@ -190,8 +190,8 @@ If a context doc gets stale, the reviews will tell you. That's the point.
 
 ## Works well with
 
-- **[Superpowers](https://github.com/obra/superpowers)** — Brainstorming, planning, TDD, debugging, and execution workflows. Jaqal gates the what and whether; Superpowers handles the how.
-- **GitHub Issues** — `/backlog-priorities` and `/backlog-hygiene` work with your issue tracker via `gh` CLI.
+- [Superpowers](https://github.com/obra/superpowers): brainstorming, planning, TDD, debugging, and execution workflows. Jaqal gates the what and whether; Superpowers handles the how.
+- GitHub Issues: `/backlog-priorities` and `/backlog-hygiene` work with your issue tracker via `gh` CLI.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Strip em-dashes from prose (voice profile flags them as LLM-leakage canary)
- Remove bold from narrative text; bold lead-ins in bullets are an assistant-register tell
- Convert "**Term** — description" patterns to "Term: description"
- Quantify where numbers were spelled out or omitted (e.g., "8" not "eight", "3 quality gates")
- Slash-compress alternatives where applicable
- Tighten throat-clearing openers to cold opens
- Prose-first where bullets were doing argument structure work

Written against the harvested voice profile (longform register, medium–high confidence).