### PR TITLE
Use issue tracker as source of truth for individual features

### DIFF
--- a/agents/review-product-health.md
+++ b/agents/review-product-health.md
@@ -11,17 +11,29 @@ A periodic check on the product itself, not the code. Run this monthly or when y
 
 Read PRODUCT.md first. This review evaluates whether PRODUCT.md is still accurate and whether the product is evolving coherently.
 
+## Detect issue tracker
+
+Before reviewing the feature map, determine whether this project has a live issue tracker:
+
+- **GitHub Issues**: run `gh issue list --limit 1 2>/dev/null` — exit 0 means GitHub Issues is active
+- **PRODUCT.md**: check if PRODUCT.md has a `## Feature tracker` section with an explicit tracker link
+- **Fallback**: if neither signal is present, assume no tracker
+
+**If a tracker is active:** PRODUCT.md is not the source of truth for individual features — the tracker owns that. Adjust Part 1.3 accordingly (see below).
+
 ## Part 1 — Is PRODUCT.md still true?
 
 1. **Persona check.** Read the personas in PRODUCT.md, then scan the recent feature history (git log, recent commits). Are we still building for the stated personas, or have we drifted toward building for ourselves / edge cases / hypothetical users?
 
 2. **Principles check.** Read the product principles. For each one, find one recent feature decision that honored it and one that bent it. Are the principles still the right principles, or has the product evolved past them?
 
-3. **Feature map accuracy.** Compare the feature map in PRODUCT.md against what actually exists in the codebase. Are there shipped features missing from the map? Are there features listed that were removed or never completed?
+3. **Feature inventory check.**
+   - *Tracker active:* The tracker owns individual features — PRODUCT.md should not contain a feature table. If it has a stale Feature map section, flag it as a sync hazard and recommend removing it. Instead, scan the tracker: run `gh issue list --state open 2>/dev/null` and check recent closed issues. Are there shipped features that conflict with PRODUCT.md's principles or "not building" list? Are there open issues requesting things that are explicitly out of scope?
+   - *No tracker:* Compare any Feature map in PRODUCT.md against what actually exists in the codebase. Are there shipped features missing from the map? Are there features listed that were removed or never completed?
 
-4. **"Not building" check.** Has anything from the "what we're NOT building" list crept in? Check recent features for scope that arguably crosses those boundaries.
+4. **"Not building" check.** Has anything from the "what we're NOT building" list crept in? Check recent commits and, if a tracker is active, scan open issues for out-of-scope requests that are being entertained.
 
-5. **Known problems freshness.** Are the known problems still the real problems? Have any been fixed but not removed from the list? Are there new problems that should be added?
+5. **Known problems freshness.** Are the known problems still the real problems? Have any been fixed but not removed? If a tracker is active, cross-reference with open bug issues — problems tracked there but absent from PRODUCT.md should be evaluated for inclusion.
 
 ## Part 2 — Product coherence
 
@@ -35,13 +47,18 @@ Read PRODUCT.md first. This review evaluates whether PRODUCT.md is still accurat
 
 ## Part 3 — Update PRODUCT.md
 
-Based on this review, propose specific updates to PRODUCT.md:
+PRODUCT.md owns the strategic layer — personas, principles, product direction, critical journeys, and explicit scope boundaries. It does not track individual features when a tracker is active.
+
+Propose specific updates:
 
 - Personas that need updating (changed needs, new context)
 - Principles that need revision or addition
-- Features to add or remove from the map
-- Items to add or remove from "not building"
+- Items to add or remove from "what we're NOT building"
 - Known problems to add, remove, or reprioritize
+- **If PRODUCT.md has a stale Feature map and a tracker is active:** propose removing the Feature map section and replacing it with a `## Feature tracker` link
+
+If no tracker is active, also propose:
+- Features to add or remove from the feature map
 
 Present the changes as a diff against the current PRODUCT.md. Don't apply them — present them for review.
 

--- a/commands/extract-product-context.md
+++ b/commands/extract-product-context.md
@@ -22,7 +22,18 @@ Before touching the code, check for context that already exists:
 
 Extract a first-draft understanding of what this product claims to be.
 
-## Step 2 — Map the feature surface
+## Step 2 — Detect issue tracker
+
+Before mapping features, check whether this project has a live issue tracker:
+
+- Run `gh issue list --limit 1 2>/dev/null` — exit 0 means GitHub Issues is active
+- Check for a GitHub remote: `git remote get-url origin 2>/dev/null | grep github.com`
+
+**If a tracker is active:** skip Step 3 (feature surface mapping). In Step 9, write a `## Feature tracker` section with a link to the tracker (`gh repo view --json url --jq .url 2>/dev/null`) instead of a Feature map table. The tracker is the source of truth for individual features.
+
+**If no tracker:** continue with the full feature map in Step 3.
+
+## Step 3 — Map the feature surface (skip if tracker active)
 
 Discover what users can actually do by examining:
 
@@ -45,7 +56,7 @@ Discover what users can actually do by examining:
 
 Write the feature map as: feature name > what users can do > current state (shipped/beta/hidden/broken).
 
-## Step 3 — Identify the users
+## Step 4 — Identify the users
 
 Look for evidence of who uses this product:
 
@@ -68,7 +79,7 @@ Look for evidence of who uses this product:
 
 Draft the persona based on what the code reveals, not what you think it should be.
 
-## Step 4 — Discover the business model
+## Step 5 — Discover the business model
 
 Look for revenue and pricing signals:
 
@@ -82,7 +93,7 @@ Look for revenue and pricing signals:
 
 If none found, note "No monetization logic found in codebase."
 
-## Step 5 — Trace the critical user journeys
+## Step 6 — Trace the critical user journeys
 
 Identify the 2-3 most important flows by looking at:
 
@@ -103,7 +114,7 @@ Identify the 2-3 most important flows by looking at:
 
 Document each journey as: trigger > steps > outcome.
 
-## Step 6 — Find what's NOT being built
+## Step 7 — Find what's NOT being built
 
 Look for explicit boundaries:
 
@@ -121,7 +132,7 @@ Also infer boundaries from what's absent:
 
 Note these as "Likely out of scope (inferred)" vs "Explicitly out of scope (documented)."
 
-## Step 7 — Identify known problems
+## Step 8 — Identify known problems
 
 Scan for evidence of things that are broken or painful:
 
@@ -134,7 +145,7 @@ Scan for evidence of things that are broken or painful:
 
 Prioritize by likely user impact, not code severity.
 
-## Step 8 — Write PRODUCT.md
+## Step 9 — Write PRODUCT.md
 
 Populate each section with what you found. For each section:
 

--- a/commands/jaqal-init.md
+++ b/commands/jaqal-init.md
@@ -43,13 +43,18 @@ If PRODUCT.md doesn't exist, create it from the template:
 <!-- 3-5 principles that guide product decisions. Format: "Principle name — explanation" -->
 <!-- Example: "Speed over completeness — a fast approximate answer beats a slow perfect one" -->
 
-## Feature map
+## Feature tracker
 
-<!-- What exists today. Format: Feature name — what users can do — current state -->
+<!-- If this project uses an issue tracker (GitHub Issues, Linear, Jira, etc.), replace this section with a link:
+     Issue tracker: [GitHub Issues](https://github.com/org/repo/issues)
 
-| Feature | What users can do | Status |
-|---------|-------------------|--------|
-| | | |
+     The tracker owns individual features. PRODUCT.md owns strategic context only.
+
+     If no issue tracker, list major capability areas here (not a per-release inventory):
+     | Capability | What users can do |
+     |------------|-------------------|
+     |            |                   |
+-->
 
 ## Critical user journeys
 

--- a/commands/review-product-health.md
+++ b/commands/review-product-health.md
@@ -1,6 +1,6 @@
 ---
 description: Periodic product review — evaluate product coherence, scope drift, and roadmap alignment
-allowed-tools: Read, Glob, Grep, Task
+allowed-tools: Read, Glob, Grep, Bash, Task
 ---
 
 # Product health review
@@ -9,17 +9,29 @@ A periodic check on the product itself, not the code. Run this monthly or when y
 
 Read PRODUCT.md first. This review evaluates whether PRODUCT.md is still accurate and whether the product is evolving coherently.
 
+## Detect issue tracker
+
+Before reviewing the feature map, determine whether this project has a live issue tracker:
+
+- **GitHub Issues**: run `gh issue list --limit 1 2>/dev/null` — exit 0 means GitHub Issues is active
+- **PRODUCT.md**: check if PRODUCT.md has a `## Feature tracker` section with an explicit tracker link
+- **Fallback**: if neither signal is present, assume no tracker
+
+**If a tracker is active:** PRODUCT.md is not the source of truth for individual features — the tracker owns that. Adjust Part 1.3 accordingly (see below).
+
 ## Part 1 — Is PRODUCT.md still true?
 
 1. **Persona check.** Read the personas in PRODUCT.md, then scan the recent feature history (git log, recent commits). Are we still building for the stated personas, or have we drifted toward building for ourselves / edge cases / hypothetical users?
 
 2. **Principles check.** Read the product principles. For each one, find one recent feature decision that honored it and one that bent it. Are the principles still the right principles, or has the product evolved past them?
 
-3. **Feature map accuracy.** Compare the feature map in PRODUCT.md against what actually exists in the codebase. Are there shipped features missing from the map? Are there features listed that were removed or never completed?
+3. **Feature inventory check.**
+   - *Tracker active:* The tracker owns individual features — PRODUCT.md should not contain a feature table. If it has a stale Feature map section, flag it as a sync hazard and recommend removing it. Instead, scan the tracker: run `gh issue list --state open 2>/dev/null` and check recent closed issues. Are there shipped features that conflict with PRODUCT.md's principles or "not building" list? Are there open issues requesting things that are explicitly out of scope?
+   - *No tracker:* Compare any Feature map in PRODUCT.md against what actually exists in the codebase. Are there shipped features missing from the map? Are there features listed that were removed or never completed?
 
-4. **"Not building" check.** Has anything from the "what we're NOT building" list crept in? Check recent features for scope that arguably crosses those boundaries.
+4. **"Not building" check.** Has anything from the "what we're NOT building" list crept in? Check recent commits and, if a tracker is active, scan open issues for out-of-scope requests that are being entertained.
 
-5. **Known problems freshness.** Are the known problems still the real problems? Have any been fixed but not removed from the list? Are there new problems that should be added?
+5. **Known problems freshness.** Are the known problems still the real problems? Have any been fixed but not removed? If a tracker is active, cross-reference with open bug issues — problems tracked there but absent from PRODUCT.md should be evaluated for inclusion.
 
 ## Part 2 — Product coherence
 
@@ -33,13 +45,18 @@ Read PRODUCT.md first. This review evaluates whether PRODUCT.md is still accurat
 
 ## Part 3 — Update PRODUCT.md
 
-Based on this review, propose specific updates to PRODUCT.md:
+PRODUCT.md owns the strategic layer — personas, principles, product direction, critical journeys, and explicit scope boundaries. It does not track individual features when a tracker is active.
+
+Propose specific updates:
 
 - Personas that need updating (changed needs, new context)
 - Principles that need revision or addition
-- Features to add or remove from the map
-- Items to add or remove from "not building"
+- Items to add or remove from "what we're NOT building"
 - Known problems to add, remove, or reprioritize
+- **If PRODUCT.md has a stale Feature map and a tracker is active:** propose removing the Feature map section and replacing it with a `## Feature tracker` link
+
+If no tracker is active, also propose:
+- Features to add or remove from the feature map
 
 Present the changes as a diff against the current PRODUCT.md. Don't apply them — present them for review.
 

--- a/templates/PRODUCT.md
+++ b/templates/PRODUCT.md
@@ -19,13 +19,18 @@
 <!-- 3-5 principles that guide product decisions. Format: "Principle name — explanation" -->
 <!-- Example: "Speed over completeness — a fast approximate answer beats a slow perfect one" -->
 
-## Feature map
+## Feature tracker
 
-<!-- What exists today. Format: Feature name — what users can do — current state -->
+<!-- If this project uses an issue tracker (GitHub Issues, Linear, Jira, etc.), replace this section with a link:
+     Issue tracker: [GitHub Issues](https://github.com/org/repo/issues)
 
-| Feature | What users can do | Status |
-|---------|-------------------|--------|
-| | | |
+     The tracker owns individual features. PRODUCT.md owns strategic context only.
+
+     If no issue tracker, list major capability areas here (not a per-release inventory):
+     | Capability | What users can do |
+     |------------|-------------------|
+     |            |                   |
+-->
 
 ## Critical user journeys
 


### PR DESCRIPTION
## Summary

- Replace the "Feature map" section in `PRODUCT.md` (template + `jaqal-init`) with a "Feature tracker" section — either a link to the active tracker or a coarse capability list, never a per-release inventory
- Add tracker detection to `review-product-health`: when GitHub Issues is active, skip the stale feature-map-vs-codebase diff and scan open issues for scope drift instead; flag any remaining Feature map table as a sync hazard
- Add tracker detection to `extract-product-context`: link to the tracker in PRODUCT.md instead of building a feature table when one is active

## Why

`review-product-health` was comparing PRODUCT.md's Feature map against the codebase and reliably finding it out of date (13 releases behind in one run). The root cause: PRODUCT.md was being asked to own something it can't — a live feature inventory. When a project has an issue tracker, that's the source of truth for individual features. PRODUCT.md owns stable strategic context (personas, principles, journeys, explicit scope boundaries) that doesn't drift release-to-release.

## Test plan

- [ ] Run `/review-product-health` on a project with GitHub Issues active — confirm it detects the tracker and skips the feature-map diff
- [ ] Run `/review-product-health` on a project with no tracker — confirm it still does the original feature-map accuracy check
- [ ] Run `/extract-product-context` on a GitHub-hosted project — confirm it writes `## Feature tracker` with a link instead of a table
- [ ] Run `/jaqal-init` on a fresh project — confirm PRODUCT.md is created with `## Feature tracker` section, not `## Feature map`