### PR TITLE
feat: add /review-readme drift review and README creation in /jaqal-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Run any review on its own when you don't need the full sweep:
 | `/review-frontend-health` | Design drift, accessibility, component quality | Monthly or post-UI work |
 | `/review-architecture` | Module boundaries, complexity, evolution readiness | Quarterly or pre-major-feature |
 | `/review-product-health` | PRODUCT.md accuracy, persona drift, scope creep | Monthly or when it feels off |
+| `/review-readme` | README drift: stale claims, broken commands, voice | After a release or feature batch |
 | `/deep-review` | All 4, plus a compiled summary | Monthly |
 
 `/backlog-hygiene` scans open GitHub issues against recent commits, PRODUCT.md, and review reports, then flags the ones that are resolved/obsolete/duplicated. Run it after a `/deep-review` to catch what that cycle's fixes resolved. It reports, never modifies.

--- a/agents/review-readme.md
+++ b/agents/review-readme.md
@@ -1,0 +1,58 @@
+---
+name: review-readme
+description: README drift review — compare README against PRODUCT.md and the codebase, flag stale claims, broken commands, and voice drift, propose a diff. Recommend-only, never writes README.
+tools: Read, Glob, Grep, Bash
+model: inherit
+---
+
+# README drift review
+
+Check whether README.md still tells the truth about the product. A README goes stale the same way PRODUCT.md does — features ship, commands change, paths move — and nobody updates the front door. This review finds the drift and proposes a fix. It never writes README.md.
+
+## Workflow
+
+1. Read README.md. If none exists, report that and stop — creation belongs in `/jaqal-init`, not here.
+2. Read PRODUCT.md, DESIGN.md, and CLAUDE.md for ground truth and the project's writing style.
+3. Scan the codebase to verify what the README claims: package manifest (name, scripts, version), install/run commands, config files, `.env.example`, route/command/feature definitions, and the actual directory structure.
+4. Evaluate drift in five categories:
+   - **Stale claims** — features, behavior, or commands the README describes that were removed, renamed, or changed. Cross-reference recent `git log --oneline -30` for changes the README never absorbed.
+   - **Missing** — shipped capabilities, commands, or config the README never mentions. Compare against PRODUCT.md's feature surface and the actual codebase.
+   - **Broken** — install/run commands that fail, file paths or filenames that don't exist, env vars not in `.env.example`, and dead or wrong links. Verify paths with Grep/Read; verify links resolve where checkable.
+   - **Voice drift** — measure the prose against CLAUDE.md's writing-style guidance and PRODUCT.md's voice. Flag emoji headers, decorative badges, marketing fluff, em-dash leakage, spelled-out numbers where numerals belong, and assistant-register tells (bolded triads, reflexive bullets). Only flag against the project's stated style — don't impose a generic one.
+   - **Structure gaps** — anything a new user needs that's absent: install, quick start, a runnable usage example, license.
+5. Propose a diff that fixes the findings, in the project's voice.
+
+## Output format
+
+```markdown
+## README drift report
+
+### Stale claims
+- [section/line] — [what the README says] vs [what's true now]. Evidence: [commit/file].
+
+### Missing
+- [capability] — shipped in [file/command], absent from README.
+
+### Broken
+- [command/path/link] — [why it fails or what it should be]. Evidence: [file].
+
+### Voice drift
+- [section] — [the tell] vs [project style per CLAUDE.md/PRODUCT.md].
+
+### Structure gaps
+- [missing section] — [what a new user needs].
+
+### Proposed diff
+[unified diff or section-by-section before/after, in the project's voice]
+
+### Summary
+[N] findings: [breakdown by category]. Overall: README is [current / lightly stale / significantly out of date].
+```
+
+Save the report to `docs/jaqal/readme-reviews/YYYY-MM-DD-readme-review.md` (create the directory if it doesn't exist). If previous README reviews exist there, compare against the most recent one.
+
+## What this agent does NOT do
+
+- Write, overwrite, or create README.md — it proposes a diff; the human applies it.
+- Generate a README from scratch — that's `/jaqal-init` when no README exists.
+- Review code quality, architecture, or product strategy — other reviews own those.

--- a/commands/jaqal-init.md
+++ b/commands/jaqal-init.md
@@ -12,6 +12,7 @@ Set up the full product review workflow in this project. This creates the contex
 Before creating anything, check what already exists:
 - Does PRODUCT.md exist? Is it populated or empty?
 - Does DESIGN.md exist? Is it populated or empty?
+- Does README.md exist?
 - Does CLAUDE.md exist?
 - Do any `docs/` review directories exist?
 
@@ -130,17 +131,31 @@ If DESIGN.md doesn't exist, create it from the template:
 
 Then run `/extract-design-system` to populate it from the codebase.
 
-## Step 4 — Scaffold review directories
+## Step 4 — Create README.md (if needed)
+
+If README.md already exists, skip this step — leave it alone and tell the user to run `/review-readme` to check it for drift. Never overwrite an existing README.
+
+If README.md doesn't exist, generate one now. PRODUCT.md exists at this point, so draw from it directly:
+
+- **Source the content** from PRODUCT.md (what the product does, who it's for), the codebase (install/run commands, real file paths, config, `.env.example`), and the package manifest (name, scripts, license).
+- **Match the project's voice.** Follow CLAUDE.md's writing-style guidance if present. Lead with what the product does and why. Keep it lean and direct.
+- **No template decoration.** No emoji headers, no decorative badges, no marketing fluff. Standard Markdown, real headers, code blocks with language labels.
+- **Only claim what's true.** Every command, path, and filename must match the codebase. Don't invent placeholders or aspirational features.
+
+Cover, at minimum: what it is, install, a runnable usage example, and license. Write the file, then flag it for the user's review — the same way PRODUCT.md needs a human pass.
+
+## Step 5 — Scaffold review directories
 
 Create these directories if they don't exist:
 - `docs/jaqal/health-reviews/`
 - `docs/jaqal/frontend-reviews/`
 - `docs/jaqal/architecture-reviews/`
 - `docs/jaqal/product-reviews/`
+- `docs/jaqal/readme-reviews/`
 
 Add a `.gitkeep` to each empty directory so they're tracked in git.
 
-## Step 5 — Update CLAUDE.md
+## Step 6 — Update CLAUDE.md
 
 If CLAUDE.md exists, append the review workflow section (if not already present). If it doesn't exist, create it with just this section. Check for existing content first — don't duplicate.
 
@@ -171,6 +186,7 @@ Add this section:
 | Frontend health | Monthly or post-UI-sprint | `/review-frontend-health` |
 | Architecture | Quarterly or pre-major-feature | `/review-architecture` |
 | Product health | Monthly | `/review-product-health` |
+| README drift | After a release or feature batch | `/review-readme` |
 | All reviews | As needed | `/deep-review` |
 
 ### After each review
@@ -184,12 +200,13 @@ Add this section:
    - `/review-architecture` updates CLAUDE.md
 ```
 
-## Step 6 — Summary
+## Step 7 — Summary
 
 Report what was created, what was populated, and what the user should review:
 - PRODUCT.md — auto-populated sections and sections that need human input
 - DESIGN.md — auto-populated sections and inconsistencies found
+- README.md — created from scratch, or skipped because one already exists
 - CLAUDE.md — sections added
 - Review directories created
 
-Suggest the user review PRODUCT.md first (product principles and "not building" sections need human judgment), then DESIGN.md (anti-patterns section needs human input).
+Suggest the user review PRODUCT.md first (product principles and "not building" sections need human judgment), then DESIGN.md (anti-patterns section needs human input), then README.md if one was generated.

--- a/commands/review-readme.md
+++ b/commands/review-readme.md
@@ -1,0 +1,30 @@
+---
+description: README drift review — flag stale claims, broken commands, and voice drift against the codebase, then propose a diff. Recommend-only, never writes README.
+allowed-tools: Read, Glob, Grep, Bash, Task
+---
+
+# README drift review
+
+Check whether README.md still tells the truth about the product. Run it after a release, after a batch of features, or whenever the README feels behind. It proposes a diff; you apply it.
+
+Read PRODUCT.md, DESIGN.md, and CLAUDE.md first for product context and the project's writing style.
+
+## Run the analysis
+
+Spawn @agent-review-readme to:
+
+1. Read README.md. If none exists, report that and stop — creation belongs in `/jaqal-init`.
+2. Scan the codebase to verify what the README claims: manifest, install/run commands, config, `.env.example`, feature definitions, directory structure.
+3. Flag drift in five categories:
+   - **Stale claims** — described features or commands that were removed, renamed, or changed
+   - **Missing** — shipped capabilities the README never mentions
+   - **Broken** — commands, paths, env vars, or links that don't match the codebase
+   - **Voice drift** — prose that breaks CLAUDE.md's writing style or PRODUCT.md's voice (emoji, badges, marketing fluff, em-dash leakage)
+   - **Structure gaps** — install, usage, or license a new user needs
+4. Propose a diff that fixes the findings, in the project's voice.
+
+## Output
+
+A drift report grouped by the five categories, a proposed diff, and a summary verdict (current / lightly stale / significantly out of date). Saved to `docs/jaqal/readme-reviews/YYYY-MM-DD-readme-review.md`.
+
+This command is recommend-only. It never writes, overwrites, or creates README.md — it proposes the diff for you to apply.


### PR DESCRIPTION
## Summary

A README goes stale the same way PRODUCT.md does — features ship, commands change, paths move, and nobody updates the front door. Jaqal already catches that drift for PRODUCT.md (the "13 releases out of date" finding that kicked this off); this extends the same recommend-only pattern to the README, at three points in the workflow.

Split along Jaqal's existing seam: **creation is setup-time, maintenance is recommend-only.** No always-on generator.

## What's added

**`/review-readme`** (`commands/review-readme.md` + `agents/review-readme.md`)
- Drift review against PRODUCT.md and the codebase across 5 categories: stale claims, missing features, broken commands/paths/links, voice drift, structure gaps
- Proposes a diff, saves a dated report to `docs/jaqal/readme-reviews/`, **never writes README.md**

**README creation in `/jaqal-init`**
- Generates a README when none exists, drawn from PRODUCT.md (created earlier in the same run) + codebase + CLAUDE.md voice
- Lean, no badge/emoji template, only claims what's true in the code
- Skips and points to `/review-readme` when a README already exists — never overwrites
- Sanctioned because init already writes root files (PRODUCT.md, DESIGN.md, CLAUDE.md) as one-time opt-in setup

## Workflow integration

- **`/deep-review` now runs 5 agents** — `review-readme` joins the monthly sweep; counts, cross-review examples, and the context-doc-update list updated
- **`/audit` doc-auditor sharpened for README drift** — flags when a PR's new/changed/removed commands, install steps, or paths contradict the README (diff-scoped per-PR catch, complements the periodic `/review-readme`)
- `docs/jaqal/readme-reviews/` added to `/jaqal-init` scaffolding
- Rows added to the README reviews table and the CLAUDE.md workflow table init writes

## Coverage at three altitudes

| When | Tool | Scope |
|------|------|-------|
| Per-PR, before merge | `/audit` (doc-auditor) | Did this changeset make the README wrong? |
| Monthly sweep | `/deep-review` | Full README drift, alongside the 4 health reviews |
| On demand / after a release | `/review-readme` | Full README drift, standalone |
| Project init | `/jaqal-init` | Create one if missing |

## Test plan

- [ ] `/review-readme` on a repo with a stale README — flags drift, proposes a diff, writes no README
- [ ] `/review-readme` on a repo with no README — reports and stops
- [ ] `/jaqal-init` with no README — generates a lean, badge-free README after PRODUCT.md
- [ ] `/jaqal-init` with an existing README — skips, points to `/review-readme`
- [ ] `/deep-review` — dispatches 5 agents including `review-readme`
- [ ] `/audit` on a branch that renames a command — doc-auditor flags the README mismatch