### PR TITLE
feat: include /review-readme in /deep-review and flag README drift in /audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You don't need every gate every time. For small fixes, `/audit` alone is enough.
 
 Separate from the feature flow: periodic reviews that assess overall project health. These run against main, not feature branches.
 
-`/deep-review` dispatches all 4 review agents in parallel and compiles a master summary: it cross-references findings across reviews, produces a prioritized action plan, and proposes updates to your context docs for approval. Metrics are captured each run for trend tracking.
+`/deep-review` dispatches all 5 review agents in parallel and compiles a master summary: it cross-references findings across reviews, produces a prioritized action plan, and proposes updates to your context docs for approval. Metrics are captured each run for trend tracking.
 
 Run any review on its own when you don't need the full sweep:
 
@@ -79,7 +79,7 @@ Run any review on its own when you don't need the full sweep:
 | `/review-architecture` | Module boundaries, complexity, evolution readiness | Quarterly or pre-major-feature |
 | `/review-product-health` | PRODUCT.md accuracy, persona drift, scope creep | Monthly or when it feels off |
 | `/review-readme` | README drift: stale claims, broken commands, voice | After a release or feature batch |
-| `/deep-review` | All 4, plus a compiled summary | Monthly |
+| `/deep-review` | All 5, plus a compiled summary | Monthly |
 
 `/backlog-hygiene` scans open GitHub issues against recent commits, PRODUCT.md, and review reports, then flags the ones that are resolved/obsolete/duplicated. Run it after a `/deep-review` to catch what that cycle's fixes resolved. It reports, never modifies.
 

--- a/agents/doc-auditor.md
+++ b/agents/doc-auditor.md
@@ -33,6 +33,9 @@ Find documentation gaps.
 - Outdated environment variable docs
 - Missing architecture overview
 - Incomplete contribution guidelines
+- README drift: documented commands, flags, scripts, or paths that no longer exist or behave differently
+- Features or install/run steps described in the README that the changeset renamed or removed
+- When auditing a branch, scope this to drift the changeset introduced — does the diff contradict what the README still claims?
 
 ### Inline Quality
 - Functions >20 lines without comments

--- a/commands/audit.md
+++ b/commands/audit.md
@@ -19,7 +19,7 @@ Spawn all of the following as subagents simultaneously — do not run them seque
 
 2. **@agent-code-auditor** — Review the full changeset for code duplication, complexity, naming consistency, and error handling patterns.
 
-3. **@agent-doc-auditor** — Analyze documentation gaps. Are new APIs documented? Are inline comments adequate? Is the README current?
+3. **@agent-doc-auditor** — Analyze documentation gaps. Are new APIs documented? Are inline comments adequate? Do this branch's new, changed, or removed commands, install steps, flags, or file paths contradict what the README claims? Flag README drift introduced by the changeset, not just missing sections.
 
 4. **@agent-architect-reviewer** — Review architectural decisions in this changeset. Does it fit existing patterns? Any coupling concerns? Scalability issues?
 

--- a/commands/deep-review.md
+++ b/commands/deep-review.md
@@ -1,5 +1,5 @@
 ---
-description: Run all four periodic reviews in parallel — codebase health, frontend health, architecture, and product health — then compile a master summary with prioritized actions
+description: Run all five periodic reviews in parallel — codebase health, frontend health, architecture, product health, and README drift — then compile a master summary with prioritized actions
 allowed-tools: Read, Glob, Grep, Bash, Task, Write, Edit
 ---
 
@@ -9,9 +9,9 @@ Run every periodic review against the current codebase on main. This is the "run
 
 Read CLAUDE.md, PRODUCT.md, and DESIGN.md first.
 
-## Phase 1 — Run all four reviews in parallel
+## Phase 1 — Run all five reviews in parallel
 
-Spawn all four as subagents simultaneously using the Agent tool — do not run them sequentially.
+Spawn all five as subagents simultaneously using the Agent tool — do not run them sequentially.
 
 Use these exact `subagent_type` values:
 
@@ -23,11 +23,13 @@ Use these exact `subagent_type` values:
 
 4. **`review-product-health`** — PRODUCT.md accuracy, product coherence, onboarding path, proposed PRODUCT.md updates. Saves to `docs/jaqal/product-reviews/YYYY-MM-DD-product-review.md`.
 
-Each agent already knows its full workflow — just tell it the project path and today's date. Run all four with `run_in_background: true`.
+5. **`review-readme`** — README drift against PRODUCT.md and the codebase: stale claims, missing features, broken commands/paths/links, voice drift, structure gaps, proposed README diff. Saves to `docs/jaqal/readme-reviews/YYYY-MM-DD-readme-review.md`.
+
+Each agent already knows its full workflow — just tell it the project path and today's date. Run all five with `run_in_background: true`.
 
 ## Phase 2 — Compile master summary
 
-After all four reviews complete, read all four reports and synthesize a single master summary.
+After all five reviews complete, read all five reports and synthesize a single master summary.
 
 ### Cross-review findings
 
@@ -35,10 +37,11 @@ Identify findings that appear in multiple reviews. These are systemic issues, no
 - Architecture review flags coupling AND codebase health flags related tech debt = systemic issue
 - Product review flags a feature as low-value AND frontend review flags its code as complex = removal candidate
 - Frontend review flags design drift AND product review flags persona drift = alignment problem
+- README review flags a documented feature that no longer exists AND product review flags scope creep = the product moved and nothing tracked it
 
 ### Prioritized action plan
 
-Compile a single prioritized list across all four reviews:
+Compile a single prioritized list across all five reviews:
 
 **Critical (this week)**
 All critical findings from every review, deduplicated and ordered by impact.
@@ -55,6 +58,7 @@ Based on the reviews, list specific updates needed for each context doc (per the
 - **PRODUCT.md** — changes proposed by product health review
 - **DESIGN.md** — changes proposed by frontend health review
 - **CLAUDE.md** — changes proposed by architecture review
+- **README.md** — diff proposed by README drift review
 
 Do NOT apply these changes. Present them as proposed diffs for the user to review and approve.
 

--- a/commands/jaqal-init.md
+++ b/commands/jaqal-init.md
@@ -198,6 +198,7 @@ Add this section:
    - `/review-product-health` updates PRODUCT.md
    - `/review-frontend-health` updates DESIGN.md
    - `/review-architecture` updates CLAUDE.md
+   - `/review-readme` proposes a README.md diff
 ```
 
 ## Step 7 — Summary


### PR DESCRIPTION
## Summary

Follow-up to #6, which added `/review-readme` and README creation in `/jaqal-init`. That PR landed the standalone review; this wires it into the rest of the workflow so README drift is caught at every altitude, not just on demand.

(These changes were authored alongside #6 but missed its squash merge — re-applied here on their own PR.)

## What changed

- **`/deep-review` now dispatches 5 agents** — `review-readme` joins the monthly sweep. Updated counts, the cross-review examples, and the context-doc-update list (README.md added).
- **`/audit` doc-auditor sharpened for README drift** — flags when a branch's new, changed, or removed commands, install steps, or paths contradict the README, not just missing sections. Diff-scoped per-PR catch that complements the periodic `/review-readme`.
- **README + `/jaqal-init` wording** — "all 5", and `/review-readme` listed among the reviews that propose context-doc updates.

## Coverage at three altitudes

| When | Tool | Scope |
|------|------|-------|
| Per-PR, before merge | `/audit` (doc-auditor) | Did this changeset make the README wrong? |
| Monthly sweep | `/deep-review` | Full README drift, alongside the 4 health reviews |
| On demand / after a release | `/review-readme` | Full README drift, standalone |

## Test plan

- [ ] `/deep-review` dispatches 5 agents including `review-readme`
- [ ] `/audit` on a branch that renames a command — doc-auditor flags the README mismatch