### PR TITLE
ci: push-notify marketplace on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,30 @@ jobs:
         run: pip install python-semantic-release
 
       - name: Compute version and push tag
-        run: semantic-release version
+        id: version
+        run: |
+          BEFORE=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
+          semantic-release version
+          AFTER=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
+          if [ "$BEFORE" != "$AFTER" ]; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "Released $AFTER (was $BEFORE)"
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            echo "No release (still $AFTER)"
+          fi
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Publish GitHub release
         run: semantic-release publish
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+      # Push-notify the marketplace to re-pin this plugin's SHA immediately.
+      # The marketplace's nightly poll remains the self-healing backstop.
+      - name: Notify marketplace to update pins
+        if: steps.version.outputs.released == 'true'
+        run: gh workflow run update-pins.yml --repo jacquardlabs/marketplace
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Adds a push path so the marketplace re-pins a plugin within ~1 min of a release instead of waiting up to ~26h for the nightly poll.

After a successful `semantic-release`, the release job detects whether a new tag was actually created (compares `git describe` before/after) and, only then, fires `gh workflow run update-pins.yml` against `jacquardlabs/marketplace`. No-op pushes (docs, chore commits with no version bump) skip the dispatch.

The nightly poll in the marketplace stays as the self-healing backstop, so a dropped or failed dispatch is reconciled within a day. Cross-repo dispatch uses the existing org-scoped `RELEASE_TOKEN`; no new secret.