### PR TITLE
docs: fix a11y audit claim, flag backlog GitHub-only, clarify init chaining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 .DS_Store
+.gg/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Jaqal wraps feature development in quality gates. Between them you build, and Ja
 - Pick what to build with `/backlog-priorities` (ranks your open GitHub issues by severity/alignment/unblocking potential) or `/gate-should-we-build [idea]` (scores a raw idea against PRODUCT.md and the smallest version worth shipping). Catches building the wrong thing.
 - Gate the design with `/gate-design-review`. It walks your design doc as your primary persona would and flags where they'd get confused or frustrated. Catches a bad design before you spend build effort on it.
 - Build it with your own workflow. Superpowers gives you plan/execute with TDD and review checkpoints. Jaqal steps back here.
-- Audit before merge with `/audit`: 7 auditors in parallel (security, code quality, docs, architecture, UX, frontend, accessibility), each staying in its lane. Frontend auditors skip automatically on branches with no frontend changes.
+- Audit before merge with `/audit`: 6 auditors in parallel (security, code quality, docs, architecture, UX, frontend), each staying in its lane, plus an accessibility pass via the Web Interface Guidelines skill when it's installed. Frontend auditors skip automatically on branches with no frontend changes.
 - Gate acceptance with `/gate-acceptance`. Product review, not code review: does the implementation actually deliver the experience? It walks every user-facing change, checks error states for human-friendly messaging, and regression-tests the critical journeys in PRODUCT.md.
 
 ```

--- a/commands/audit.md
+++ b/commands/audit.md
@@ -1,5 +1,5 @@
 ---
-description: Run all auditors in parallel — security, code quality, docs, architecture, UX, frontend, and accessibility
+description: Run the audit suite — security, code quality, docs, architecture, UX, and frontend in parallel, plus an optional accessibility pass
 allowed-tools: Read, Glob, Grep, Bash, Task, Write
 ---
 
@@ -11,7 +11,7 @@ Read CLAUDE.md, PRODUCT.md, and DESIGN.md first.
 
 ## Launch all auditors in parallel
 
-Spawn all of the following as subagents simultaneously — do not run them sequentially:
+Spawn auditors 1–6 as subagents simultaneously — do not run them sequentially. Auditor 7 is an inline external check, described below.
 
 ### Backend auditors
 
@@ -29,7 +29,7 @@ Spawn all of the following as subagents simultaneously — do not run them seque
 
 6. **@agent-frontend-reviewer** — Review frontend code changes for component architecture, state management patterns, data fetching, render performance, and bundle impact.
 
-7. **Web Interface Guidelines** — Run `/web-interface-guidelines` against all modified frontend files (components, pages, layouts). Check accessibility, keyboard support, form behavior, focus management, semantic HTML, and animation.
+7. **Web Interface Guidelines (external, optional)** — This check depends on the `web-design-guidelines` skill, which ships separately, not with Jaqal. If it's installed, run `/web-interface-guidelines` against all modified frontend files (components, pages, layouts) to check accessibility, keyboard support, form behavior, focus management, semantic HTML, and animation. Unlike auditors 1–6, this runs inline rather than as a parallel subagent. If the skill isn't available, note "accessibility check skipped — web-design-guidelines not installed" and move on.
 
 ## After all auditors return
 

--- a/commands/backlog-hygiene.md
+++ b/commands/backlog-hygiene.md
@@ -7,6 +7,8 @@ allowed-tools: Read, Glob, Grep, Bash, Task
 
 Identify open GitHub issues that should be closed because they've been resolved, made obsolete, or duplicated by other issues. Run weekly or before milestones.
 
+> Requires GitHub Issues via the `gh` CLI. PRODUCT.md may link a different tracker (Linear, Jira) — this command only reads GitHub Issues. If the project tracks work elsewhere, it doesn't apply.
+
 Read PRODUCT.md and CLAUDE.md first for product context.
 
 ## Run the analysis

--- a/commands/backlog-priorities.md
+++ b/commands/backlog-priorities.md
@@ -7,6 +7,8 @@ allowed-tools: Read, Glob, Grep, Bash, Task
 
 Help decide what to work on next by curating a ranked shortlist from open issues.
 
+> Requires GitHub Issues via the `gh` CLI. PRODUCT.md may link a different tracker (Linear, Jira) — this command only reads GitHub Issues. If the project tracks work elsewhere, it doesn't apply.
+
 Read PRODUCT.md and CLAUDE.md first for product context.
 
 ## Run the analysis

--- a/commands/jaqal-init.md
+++ b/commands/jaqal-init.md
@@ -74,7 +74,7 @@ If PRODUCT.md doesn't exist, create it from the template:
 <!-- How this makes money (or will). Pricing, plans, monetization approach. -->
 ```
 
-Then run `/extract-product-context` to populate it from the codebase.
+Then populate it as part of init — run the `/extract-product-context` workflow inline now. Don't stop and hand this back as a separate step; extract the product context from the codebase and continue. (Users can re-run `/extract-product-context` on its own later to refresh.)
 
 ## Step 3 — Create DESIGN.md (if needed)
 
@@ -129,7 +129,7 @@ If DESIGN.md doesn't exist, create it from the template:
 <!-- Fill in as you discover patterns that hurt the product -->
 ```
 
-Then run `/extract-design-system` to populate it from the codebase.
+Then populate it as part of init — run the `/extract-design-system` workflow inline now. Don't stop and hand this back as a separate step; extract the design system from the codebase and continue. (Users can re-run `/extract-design-system` on its own later to refresh.)
 
 ## Step 4 — Create README.md (if needed)
 


### PR DESCRIPTION
Three documentation-accuracy fixes from the re-evaluation backlog. No behavior change.

- **#13 — accessibility auditor claim vs mechanism.** `/audit`'s 7th "auditor" is the external `web-design-guidelines` skill run inline, not a parallel jaqal subagent. Softened the README claim from "7 auditors in parallel" to "6 in parallel, plus an accessibility pass via the Web Interface Guidelines skill when installed," and marked auditor 7 as external/optional with a skip path in the command.
- **#14 — backlog tools are GitHub-only.** Added a note to both `backlog-priorities` and `backlog-hygiene` that they only read GitHub Issues via `gh`, even when PRODUCT.md links a Linear/Jira tracker.
- **#15 — jaqal-init extract chaining.** Made it explicit that `/extract-product-context` and `/extract-design-system` run inline as part of init, not as a separate user step.

Closes #13, #14, #15.