### PR TITLE
refactor: pin agent models by stakes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,15 @@ Names encode two things — whether something is an action or a role, and what s
 - **Agents are either a 1:1 reviewer or a role.** Periodic, project-scoped reviewers share their command's `review-*` name (currently spawned by `/deep-review`). Changeset specialists spawned by a fan-out command (`/audit`, the gates) are named by role: `<domain>-auditor` for technical/rule checks (security, code, doc, architecture), `<domain>-reviewer` for human-judgment checks (product, ux, frontend).
 - **One fan-out command, many subagents.** Parallel checks belong to subagents under a single entry point (`/audit`, `/deep-review`), not to their own top-level commands. Don't add a command per check.
 
+## Model assignments
+
+Pin by stakes, not by habit. An agent's `model` is `opus` when its core job is high-stakes reasoning or human judgment — where a weaker model ships worse decisions — and `inherit` (the session model) for mechanical, rule-based, or inventory work.
+
+- **`opus`** — security, architecture, and product/UX judgment: `security-auditor`, `architecture-auditor`, `product-reviewer`, `ux-reviewer`, `review-architecture`, `review-product-health`.
+- **`inherit`** — code hygiene, docs, frontend code, inventory sweeps, and triage: `code-auditor`, `doc-auditor`, `frontend-reviewer`, `review-codebase-health`, `review-frontend-health`, `review-readme`, `backlog-priorities`, `backlog-hygiene`.
+
+Don't pin to a bare tier like `sonnet` — use `inherit` so the agent tracks the user's session model.
+
 ## What we won't merge
 
 - Changes that make agents modify issues, PRs, or external state without explicit user action

--- a/agents/architecture-auditor.md
+++ b/agents/architecture-auditor.md
@@ -2,7 +2,7 @@
 name: architecture-auditor
 description: Architecture auditor. Reviews a changeset for structural fit, coupling, complexity, and scalability. Stays in its lane — audits and reports, does not fix or orchestrate.
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: opus
 ---
 
 # Architecture audit

--- a/agents/frontend-reviewer.md
+++ b/agents/frontend-reviewer.md
@@ -2,7 +2,7 @@
 name: frontend-reviewer
 description: Reviews frontend code for component architecture, state management, performance, bundle size, and frontend-specific patterns. Invoked during feature audits or periodic frontend reviews.
 tools: Read, Glob, Grep, Bash
-model: sonnet
+model: inherit
 ---
 
 You are a frontend code reviewer. You evaluate the technical quality of frontend code — component structure, state management, performance, and build health. You are not reviewing visual design or accessibility — other agents handle those.

--- a/agents/review-architecture.md
+++ b/agents/review-architecture.md
@@ -2,7 +2,7 @@
 name: review-architecture
 description: Deep architecture review — evaluate system structure, boundaries, and evolution path
 tools: Read, Glob, Grep, Bash, Write
-model: inherit
+model: opus
 ---
 
 # Architecture review

--- a/agents/review-product-health.md
+++ b/agents/review-product-health.md
@@ -2,7 +2,7 @@
 name: review-product-health
 description: Periodic product review — evaluate product coherence, scope drift, and roadmap alignment
 tools: Read, Glob, Grep, Bash, Write
-model: inherit
+model: opus
 ---
 
 # Product health review

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -2,7 +2,7 @@
 name: security-auditor
 description: Comprehensive security analysis. OWASP Top 10, injection, auth, secrets, headers.
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: opus
 ---
 
 # Security Audit


### PR DESCRIPTION
Resolves #11. Model assignments were arbitrary — UX and product were on `opus` while **security and architecture inherited the session model**, exactly backwards on stakes.

New rule (documented in CONTRIBUTING): `opus` for high-stakes reasoning and human judgment; `inherit` for mechanical, rule-based, or inventory work.

| Model | Agents |
|-------|--------|
| `opus` | security-auditor, architecture-auditor, product-reviewer, ux-reviewer, review-architecture, review-product-health |
| `inherit` | code-auditor, doc-auditor, frontend-reviewer, review-codebase-health, review-frontend-health, review-readme, backlog-priorities, backlog-hygiene |

Changes this PR makes: `security-auditor` and `architecture-auditor` inherit → opus; `review-architecture` and `review-product-health` inherit → opus; `frontend-reviewer` was pinned to a bare `sonnet` → inherit (so it tracks the session model). `product-reviewer`/`ux-reviewer` were already opus.

Closes #11.