### PR TITLE
refactor: rename /audit to /gate-audit and drop Gate N labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,8 @@ templates/    — Scaffold files created by /jaqal-init
 Names encode two things — whether something is an action or a role, and what scope it works at. Follow the existing shape; the prefix/suffix split is deliberate, not drift.
 
 - **Commands are actions** — an action prefix plus its target: `gate-` (per-change checkpoints), `review-`/`deep-review` (periodic health), `extract-` (one-time scaffolding), `backlog-` (issue triage). The verb goes in front.
-- **Agents are either a 1:1 reviewer or a role.** Periodic, project-scoped reviewers share their command's `review-*` name (currently spawned by `/deep-review`). Changeset specialists spawned by a fan-out command (`/audit`, the gates) are named by role: `<domain>-auditor` for technical/rule checks (security, code, doc, architecture), `<domain>-reviewer` for human-judgment checks (product, ux, frontend).
-- **One fan-out command, many subagents.** Parallel checks belong to subagents under a single entry point (`/audit`, `/deep-review`), not to their own top-level commands. Don't add a command per check.
+- **Agents are either a 1:1 reviewer or a role.** Periodic, project-scoped reviewers share their command's `review-*` name (currently spawned by `/deep-review`). Changeset specialists spawned by a fan-out command (`/gate-audit`, the gates) are named by role: `<domain>-auditor` for technical/rule checks (security, code, doc, architecture), `<domain>-reviewer` for human-judgment checks (product, ux, frontend).
+- **One fan-out command, many subagents.** Parallel checks belong to subagents under a single entry point (`/gate-audit`, `/deep-review`), not to their own top-level commands. Don't add a command per check.
 
 ## Model assignments
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Jaqal wraps feature development in quality gates. Between them you build, and Ja
 - Pick what to build with `/backlog-priorities` (ranks your open GitHub issues by severity/alignment/unblocking potential) or `/gate-should-we-build [idea]` (scores a raw idea against PRODUCT.md and the smallest version worth shipping). Catches building the wrong thing.
 - Gate the design with `/gate-design-review`. It walks your design doc as your primary persona would and flags where they'd get confused or frustrated. Catches a bad design before you spend build effort on it.
 - Build it with your own workflow. Superpowers gives you plan/execute with TDD and review checkpoints. Jaqal steps back here.
-- Audit before merge with `/audit`: 6 auditors in parallel (security, code quality, docs, architecture, UX, frontend), each staying in its lane, plus an accessibility pass via the Web Interface Guidelines skill when it's installed. Frontend auditors skip automatically on branches with no frontend changes.
+- Audit before merge with `/gate-audit`: 6 auditors in parallel (security, code quality, docs, architecture, UX, frontend), each staying in its lane, plus an accessibility pass via the Web Interface Guidelines skill when it's installed. Frontend auditors skip automatically on branches with no frontend changes.
 - Gate acceptance with `/gate-acceptance`. Product review, not code review: does the implementation actually deliver the experience? It walks every user-facing change, checks error states for human-friendly messaging, and regression-tests the critical journeys in PRODUCT.md.
 
 ```
@@ -55,14 +55,14 @@ Jaqal wraps feature development in quality gates. Between them you build, and Ja
          ↓
    implement
          ↓
-   /audit
+   /gate-audit
          ↓
    /gate-acceptance
          ↓
        merge
 ```
 
-You don't need every gate every time. For small fixes, `/audit` alone is enough. The gates exist to catch building the wrong thing or shipping a bad experience. Use judgment about when that risk applies.
+You don't need every gate every time. For small fixes, `/gate-audit` alone is enough. The gates exist to catch building the wrong thing or shipping a bad experience. Use judgment about when that risk applies.
 
 ## Keeping the project healthy
 

--- a/agents/product-reviewer.md
+++ b/agents/product-reviewer.md
@@ -9,7 +9,7 @@ You are a product reviewer. You evaluate features from the user's perspective, n
 
 Before reviewing anything, read PRODUCT.md at the project root. This contains the product's purpose, user personas, product principles, feature map, and critical user journeys. Every judgment you make should reference this context.
 
-## When reviewing a DESIGN DOC (Gate 2 — before implementation):
+## When reviewing a DESIGN DOC (design-review gate — before implementation):
 
 Evaluate against these questions:
 
@@ -25,7 +25,7 @@ Evaluate against these questions:
 
 6. **User mental model**: Will the user understand this feature without explanation? If it requires onboarding, a tooltip, or documentation, it's probably too complex for the stated principles.
 
-## When reviewing an IMPLEMENTATION (Gate 3 — after build):
+## When reviewing an IMPLEMENTATION (acceptance gate — after build):
 
 Evaluate against these questions:
 

--- a/commands/gate-acceptance.md
+++ b/commands/gate-acceptance.md
@@ -3,7 +3,7 @@ description: Product acceptance review after implementation, before merge
 allowed-tools: Read, Glob, Grep, Bash, Task
 ---
 
-# Gate 3: Does the result deliver?
+# Does the result deliver?
 
 Code is built, tests pass, audits are clean. This gate checks whether the implementation actually delivers the intended experience. Clean code that ships a bad feature is still a bad feature.
 

--- a/commands/gate-audit.md
+++ b/commands/gate-audit.md
@@ -3,7 +3,7 @@ description: Run the audit suite — security, code quality, docs, architecture,
 allowed-tools: Read, Glob, Grep, Bash, Task, Write
 ---
 
-# Full audit — all agents
+# Audit gate — all auditors
 
 Run every auditor in parallel against the current branch. This combines the backend audit suite, frontend audit suite, and accessibility checks into a single pass.
 
@@ -50,7 +50,7 @@ Everything else. Don't expand on these — just list them.
 ### Verdict
 Based on the findings, recommend one of:
 - **PASS** — No critical findings. Safe to proceed to product acceptance gate.
-- **FIX AND RE-AUDIT** — Critical findings listed. Fix these, then re-run `/audit`.
+- **FIX AND RE-AUDIT** — Critical findings listed. Fix these, then re-run `/gate-audit`.
 - **NEEDS DISCUSSION** — Architectural or product-level concerns that aren't simple fixes.
 
 If the branch has no frontend changes (no modified template, component, CSS, or JS files), skip auditors 5-7 and note "No frontend changes detected — frontend audits skipped."

--- a/commands/gate-design-review.md
+++ b/commands/gate-design-review.md
@@ -3,7 +3,7 @@ description: Product review of a design doc before implementation begins
 allowed-tools: Read, Glob, Grep, Task
 ---
 
-# Gate 2: Does this design serve users?
+# Does this design serve users?
 
 Read PRODUCT.md at the project root first.
 

--- a/commands/gate-should-we-build.md
+++ b/commands/gate-should-we-build.md
@@ -3,7 +3,7 @@ description: Evaluate whether a feature idea is worth building before any engine
 allowed-tools: Read, Glob, Grep
 ---
 
-# Gate 1: Should we build this?
+# Should we build this?
 
 Read PRODUCT.md at the project root before doing anything else. You need the full product context — personas, principles, known problems, what we're not building.
 

--- a/commands/jaqal-init.md
+++ b/commands/jaqal-init.md
@@ -175,7 +175,7 @@ Add this section:
 |------|------|---------|
 | Should we build? | Before any engineering | `/gate-should-we-build [idea]` |
 | Design review | After design doc, before implementation | `/gate-design-review` |
-| Audit | After implementation, before acceptance | `/audit` |
+| Audit | After implementation, before acceptance | `/gate-audit` |
 | Acceptance | After audit passes, before merge | `/gate-acceptance` |
 
 ### Periodic reviews


### PR DESCRIPTION
Resolves #12. `/audit` was described as a gate everywhere — the README, the flow diagram, the `/jaqal-init` CLAUDE.md gate table — but it was the only gate not prefixed `gate-`. And the gate command titles carried "Gate 1/2/3" numbers that skipped audit, so the numbering didn't match the real flow.

- Renamed `commands/audit.md` → `commands/gate-audit.md`. All four checkpoints now share the prefix: `/gate-should-we-build → /gate-design-review → /gate-audit → /gate-acceptance`.
- Dropped the "Gate N" numeric labels. Titles are now descriptive (`# Should we build this?`, `# Does this design serve users?`, `# Audit gate — all auditors`, `# Does the result deliver?`).
- `product-reviewer`'s "Gate 2 / Gate 3" context labels became "design-review gate" / "acceptance gate" so they don't reference dead numbering.
- Updated all references: README (description, flow diagram, small-fixes note), CONTRIBUTING conventions, the `/jaqal-init` gate table.

**Breaking:** `/audit` no longer exists — it's `/gate-audit`. It's a published command, so this changes muscle memory for existing users.

Closes #12.

> Note: titled `refactor:` (no release). If you want this to cut a version, retitle to `feat!:` for a major bump (2.0.0) given the breaking command rename.