### PR TITLE
feat: add natural-language trigger skills for the three product gates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,12 @@ Open an issue for bugs, unclear documentation, or suggestions. Include:
 ```
 agents/       — Agent definitions (name, description, tools, model in frontmatter)
 commands/     — Slash commands (description, allowed-tools in frontmatter)
+skills/       — Natural-language trigger shims (skills/<name>/SKILL.md)
 templates/    — Scaffold files created by /jaqal-init
 ```
 
 - Agents do the work. Commands orchestrate agents or provide standalone workflows.
+- Skills are trigger shims: a tightly-scoped `description` lets a gate fire from natural language, and the body delegates to the matching command instead of duplicating it.
 - Every agent and command reads PRODUCT.md, DESIGN.md, or CLAUDE.md for project context.
 - Review reports save to `docs/jaqal/` subdirectories in the user's project, not to the plugin itself.
 - Commands that produce output are recommend-only — they report, never modify external state (issues, PRs, files outside `docs/jaqal/`).
@@ -45,6 +47,7 @@ Names encode two things — whether something is an action or a role, and what s
 - **Commands are actions** — an action prefix plus its target: `gate-` (per-change checkpoints), `review-`/`deep-review` (periodic health), `extract-` (one-time scaffolding), `backlog-` (issue triage). The verb goes in front.
 - **Agents are either a 1:1 reviewer or a role.** Periodic, project-scoped reviewers share their command's `review-*` name (currently spawned by `/deep-review`). Changeset specialists spawned by a fan-out command (`/gate-audit`, the gates) are named by role: `<domain>-auditor` for technical/rule checks (security, code, doc, architecture), `<domain>-reviewer` for human-judgment checks (product, ux, frontend).
 - **One fan-out command, many subagents.** Parallel checks belong to subagents under a single entry point (`/gate-audit`, `/deep-review`), not to their own top-level commands. Don't add a command per check.
+- **Skills are named for the intent they detect** — `evaluate-feature-idea`, `review-design-before-build`, `acceptance-check-before-merge` — not for the command they call. The `description` carries the trigger; keep it conservative (fire on explicit intent, list what it should NOT match) so a gate never interrupts when it isn't wanted.
 
 ## Model assignments
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Jaqal wraps feature development in quality gates. Between them you build, and Ja
 
 You don't need every gate every time. For small fixes, `/gate-audit` alone is enough. The gates exist to catch building the wrong thing or shipping a bad experience. Use judgment about when that risk applies.
 
+The three product gates also fire from natural language, not just the slash command — asking "should we build this?", "review this design before I build it", or "does this actually deliver?" routes to the matching gate. Triggers are deliberately conservative, so you'll still reach for the commands directly most of the time.
+
 ## Keeping the project healthy
 
 Separate from the feature flow: periodic reviews that assess overall project health. These run against main, not feature branches.

--- a/skills/acceptance-check-before-merge/SKILL.md
+++ b/skills/acceptance-check-before-merge/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: acceptance-check-before-merge
+description: Use when an implementation is complete and the user is checking whether it actually delivers the intended experience before merge — "did we ship the right thing", "does this deliver", "acceptance check", "is this ready to merge". This routes to Jaqal's acceptance gate. Do NOT use for code review, security or quality audits (that's /gate-audit), or for work still in progress.
+---
+
+# Does the result deliver?
+
+This is the natural-language entry to Jaqal's acceptance gate. The build is done and the user wants to know whether it delivers — route that to the gate.
+
+Invoke the `/gate-acceptance` command. Do not reimplement its logic here — the command owns it. This is a product acceptance review, not code review: it walks every user-facing change, checks error states for human-friendly messaging, regression-tests the critical journeys in PRODUCT.md, and returns **SHIP / FIX AND RE-CHECK / HOLD**.
+
+Surface the verdict. This gate runs after `/gate-audit` passes — if the audit hasn't run, say so.

--- a/skills/evaluate-feature-idea/SKILL.md
+++ b/skills/evaluate-feature-idea/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: evaluate-feature-idea
+description: Use when the user is explicitly deciding whether to build a specific feature — asking "should we build X", "is this worth building", "is this a good idea", or weighing a feature idea against what else matters. This routes the decision to Jaqal's should-we-build gate. Do NOT use for general feature brainstorming, for shaping a design once the decision to build is already made, or for prioritizing existing issues (that's /backlog-priorities).
+---
+
+# Should we build this?
+
+This is the natural-language entry to Jaqal's first quality gate. The user is questioning whether a feature is worth building — route that to the gate instead of answering from the hip.
+
+Invoke the `/gate-should-we-build` command, passing the feature idea the user described as its argument. Do not reimplement the gate's logic here — the command owns it. It scores the idea against PRODUCT.md (persona fit, priority vs. known problems, scope conflicts, the simplest viable version) and returns **BUILD / BUILD SMALLER / DEFER / DON'T BUILD**.
+
+Only the user decides. Surface the gate's recommendation and its reasoning; do not start building.

--- a/skills/review-design-before-build/SKILL.md
+++ b/skills/review-design-before-build/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: review-design-before-build
+description: Use when a design doc or spec for a feature is ready and the user is about to start implementing — they want the design checked before build effort goes in. Triggers on "review this design", "is this design sound", "any problems with this design before I build it". This routes to Jaqal's design-review gate. Do NOT use for code review, after implementation has already started, or for evaluating whether to build at all (that's the should-we-build gate).
+---
+
+# Does this design serve users?
+
+This is the natural-language entry to Jaqal's design-review gate. A design is on the table and the user wants it vetted before spending build effort — route that to the gate.
+
+Invoke the `/gate-design-review` command. Do not reimplement its logic here — the command owns it. It product-reviews the most recent design doc against PRODUCT.md and walks the design as the primary persona would experience it, returning **PROCEED TO PLAN / REVISE / RETHINK**.
+
+Surface the recommendation; do not begin implementation until the design is sound.


### PR DESCRIPTION
Resolves #9. Until now every gate fired only on an explicit slash command — "is this worth building?" couldn't route to `/gate-should-we-build`. This adds a thin trigger layer.

Three `SKILL.md` shims, each a tightly-scoped `description` that auto-fires on intent and **delegates to its gate command** (no logic duplication):

| Skill | Fires on | Routes to |
|-------|----------|-----------|
| `evaluate-feature-idea` | "should we build X", "is this worth building" | `/gate-should-we-build` |
| `review-design-before-build` | "review this design before I build it" | `/gate-design-review` |
| `acceptance-check-before-merge` | "does this deliver", "ready to merge?" | `/gate-acceptance` |

Triggers are **deliberately conservative** — each description fires on explicit intent and lists what it should NOT match (general brainstorming, code review, etc.) so a gate never interrupts when it isn't wanted. Easy to widen later.

Also documents the new `skills/` artifact type and its naming rule in CONTRIBUTING (named for the intent they detect, body delegates to the command), and adds a short natural-language-entry note to the README.

No shim for `/gate-audit` — it's a mechanical "run the checks" step, not a judgment call you'd phrase as a question.

Closes #9.