### PR TITLE
feat: add a PR-time gate reminder hook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ Open an issue for bugs, unclear documentation, or suggestions. Include:
 agents/       — Agent definitions (name, description, tools, model in frontmatter)
 commands/     — Slash commands (description, allowed-tools in frontmatter)
 skills/       — Natural-language trigger shims (skills/<name>/SKILL.md)
+hooks/        — Shipped hook scripts (e.g. the PR-time gate reminder)
 templates/    — Scaffold files created by /jaqal-init
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then, in any project:
 /jaqal-init
 ```
 
-This creates your context documents (PRODUCT.md and DESIGN.md, extracted from the codebase as it actually is), scaffolds the `docs/jaqal/` review directories, and wires the workflow reference into CLAUDE.md so every future session knows the process. Review PRODUCT.md first. The extraction is evidence-based, but product principles and your "not building" list need your voice.
+This creates your context documents (PRODUCT.md and DESIGN.md, extracted from the codebase as it actually is), scaffolds the `docs/jaqal/` review directories, wires the workflow reference into CLAUDE.md so every future session knows the process, and installs a non-blocking hook that reminds you to run the gates when you open a PR. Review PRODUCT.md first. The extraction is evidence-based, but product principles and your "not building" list need your voice.
 
 ## Building a feature
 

--- a/commands/jaqal-init.md
+++ b/commands/jaqal-init.md
@@ -201,7 +201,34 @@ Add this section:
    - `/deep-review readme` proposes a README.md diff
 ```
 
-## Step 7 — Summary
+## Step 7 — Wire the PR-time gate reminder hook
+
+Add a `PreToolUse` hook so opening a pull request prompts a reminder to run the gates. It's a non-blocking confirmation — it asks, it never hard-blocks — and it's unconditional: it always asks at `gh pr create` time rather than trying to detect whether a gate ran.
+
+Read `.claude/settings.json` if it exists (create the `.claude/` directory and the file if not). Merge in the hook below — preserve any existing `hooks` and other settings, and don't add it twice if an equivalent entry is already present:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(gh pr create *)",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gate-reminder.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+If a `PreToolUse` array already exists, append this entry rather than replacing the array. Tell the user the hook was added and that they can delete it from `.claude/settings.json` if they don't want the reminder.
+
+## Step 8 — Summary
 
 Report what was created, what was populated, and what the user should review:
 - PRODUCT.md — auto-populated sections and sections that need human input
@@ -209,5 +236,6 @@ Report what was created, what was populated, and what the user should review:
 - README.md — created from scratch, or skipped because one already exists
 - CLAUDE.md — sections added
 - Review directories created
+- PR-time gate reminder hook — added to `.claude/settings.json`
 
 Suggest the user review PRODUCT.md first (product principles and "not building" sections need human judgment), then DESIGN.md (anti-patterns section needs human input), then README.md if one was generated.

--- a/hooks/gate-reminder.sh
+++ b/hooks/gate-reminder.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Jaqal gate reminder — a PreToolUse hook that fires before `gh pr create`.
+#
+# It surfaces a non-blocking confirmation at PR-create time so you don't merge
+# work that skipped the gates. It is unconditional by design: it always asks,
+# it does not try to detect whether a gate actually ran. Answer "yes" if the
+# gates passed or don't apply to this change.
+#
+# Wired into a project's .claude/settings.json by `/jaqal-init`, scoped to
+# `gh pr create` via the hook's `if` rule. The grep below is defense in depth
+# in case the hook is ever invoked on a broader matcher.
+
+input=$(cat)
+
+if printf '%s' "$input" | grep -q 'gh pr create'; then
+  cat <<'JSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "Jaqal: opening a PR. Did /gate-audit and /gate-acceptance run on this branch? Proceed if the gates passed or don't apply to this change."
+  }
+}
+JSON
+fi
+
+exit 0


### PR DESCRIPTION
Resolves #10 — the last item from the re-evaluation backlog. Gates relied entirely on memory; nothing prompted you at merge time.

Adds a `PreToolUse` hook (`hooks/gate-reminder.sh`) that fires on `gh pr create` and surfaces a **non-blocking `ask` confirmation**: "Did /gate-audit and /gate-acceptance run on this branch? Proceed if the gates passed or don't apply." It's **unconditional by design** — it always asks rather than trying to detect whether a gate ran, so it never falsely asserts you skipped one. (You chose unconditional; markers can come later.)

`jaqal-init` (new Step 7) wires it into the project's `.claude/settings.json`:
```json
{ "matcher": "Bash", "hooks": [
  { "type": "command", "if": "Bash(gh pr create *)", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gate-reminder.sh" }
] }
```
It merges rather than clobbering existing settings, and tells the user the hook was added (and how to remove it).

Schema verified against the official [hooks reference](https://code.claude.com/docs/en/hooks.md): command-content scoping uses the `if` field (matcher is tool-name only), the non-blocking prompt is exit 0 + `permissionDecision: "ask"`, and plugin scripts resolve via `${CLAUDE_PLUGIN_ROOT}`. Smoke-tested: `gh pr create` → ask JSON (valid), other commands → silent allow.

Also documents the `hooks/` artifact in CONTRIBUTING and notes the hook in the README.

Closes #10.