### PR TITLE
feat: remediate the behavioral audit — hook fix, idiom enforcement, gate-contract repairs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,8 @@ Open an issue for bugs, unclear documentation, or suggestions. Include:
 agents/       — Agent definitions (name, description, tools, model in frontmatter)
 commands/     — Slash commands (description, allowed-tools in frontmatter)
 skills/       — Natural-language trigger shims (skills/<name>/SKILL.md)
-hooks/        — Shipped hook scripts (e.g. the PR-time gate reminder)
+hooks/        — Shipped hook scripts + hooks.json (e.g. the PR-time gate reminder)
+reference/    — Curated rubrics agents read at audit time (e.g. reference/idioms/<lang>.md)
 templates/    — Scaffold files created by /jaqal-init
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then, in any project:
 /jaqal-init
 ```
 
-This creates your context documents (PRODUCT.md and DESIGN.md, extracted from the codebase as it actually is), scaffolds the `docs/jaqal/` review directories, wires the workflow reference into CLAUDE.md so every future session knows the process, and installs a non-blocking hook that reminds you to run the gates when you open a PR. Review PRODUCT.md first. The extraction is evidence-based, but product principles and your "not building" list need your voice.
+This creates your context documents (PRODUCT.md and DESIGN.md, extracted from the codebase as it actually is), scaffolds the `docs/jaqal/` review directories, and wires the workflow reference into CLAUDE.md so every future session knows the process. Review PRODUCT.md first. The extraction is evidence-based, but product principles and your "not building" list need your voice.
 
 ## Building a feature
 

--- a/agents/backlog-hygiene.md
+++ b/agents/backlog-hygiene.md
@@ -13,9 +13,9 @@ Identify open GitHub issues that should be closed because they've been resolved,
 
 1. Read PRODUCT.md and CLAUDE.md for product context.
 2. Fetch all open issues via `gh issue list --json number,title,body,labels,createdAt`.
-3. Read the most recent review reports in `docs/jaqal/health-reviews/`, `docs/jaqal/architecture-reviews/`, `docs/jaqal/product-reviews/`, `docs/jaqal/frontend-reviews/` for context on what's been addressed.
+3. Read the most recent review reports in `docs/jaqal/health-reviews/`, `docs/jaqal/architecture-reviews/`, `docs/jaqal/product-reviews/`, `docs/jaqal/frontend-reviews/`, `docs/jaqal/readme-reviews/` for context on what's been addressed.
 4. For each open issue, evaluate:
-   - **Resolved?** Search `git log --oneline -50` for commits that reference the issue number or describe fixing the stated problem. Check whether the code, behavior, or file referenced in the issue body now reflects the desired state (via Grep/Read on the specific files mentioned).
+   - **Resolved?** Search `git log --oneline -200` for commits that reference the issue number or describe fixing the stated problem. Check whether the code, behavior, or file referenced in the issue body now reflects the desired state (via Grep/Read on the specific files mentioned).
    - **Obsolete?** Compare against PRODUCT.md "what we're NOT building" list — does the issue request something we've decided not to build? Check if the feature area has been replaced or redesigned since the issue was filed. Check if the issue describes a problem with code that no longer exists.
    - **Duplicate?** Flag issues whose titles and descriptions overlap substantially with another open issue. Only flag clear duplicates, not related-but-distinct issues.
 5. Compile report.

--- a/agents/code-auditor.md
+++ b/agents/code-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: code-auditor
-description: Code quality auditor. Reviews patterns, maintainability, complexity, consistency.
+description: Code quality auditor. Reviews patterns, maintainability, complexity, consistency, language idioms, and error handling.
 tools: Read, Grep, Glob, Bash
 model: inherit
 ---
@@ -9,6 +9,8 @@ model: inherit
 
 Find code quality issues. NOT for security (use security-auditor) or runtime bugs.
 
+Read CLAUDE.md first for the project's documented technical conventions. They are authoritative — enforce them, and where they document a deviation from a general best practice, honor the deviation rather than flagging it.
+
 ## Scope
 
 **code-auditor checks:**
@@ -16,9 +18,11 @@ Find code quality issues. NOT for security (use security-auditor) or runtime bug
 - Code complexity (function length, nesting depth)
 - Maintainability (file size, code duplication)
 - Consistency (naming, patterns, API shapes)
+- Idiomatic style (language conventions, stdlib usage)
+- Error handling patterns
 - Dead code and unused imports
 - Console.log/debug statements
-- TODO/FIXME accumulation
+- TODO/FIXME accumulation (the raw count and growth; doc-auditor judges whether individual TODOs are actionable)
 - DRY violations
 
 **Does NOT check:**
@@ -53,6 +57,19 @@ Find code quality issues. NOT for security (use security-auditor) or runtime bug
 - Mixed async patterns (callbacks vs promises)
 - API response shape inconsistency
 - Mixed import styles
+
+### Idiomatic style
+CLAUDE.md's documented conventions are authoritative and override everything below. Then:
+- Detect the changed files' language(s) by extension.
+- **Run the language's idiom linter read-only** if one is configured or available, and fold its findings in. Never pass a fix/`--fix` flag — this audit reports, it doesn't modify. Examples: Python — `ruff check --select C4,SIM,PERF,B,RUF,PIE`; JS/TS — `eslint` or `biome check`; Go — `golangci-lint run`; Rust — `cargo clippy`; Ruby — `rubocop`. If no linter is available, say so and recommend adding one.
+- **Apply the judgment-level idioms a linter can't catch** using the language rubric in `reference/idioms/<language>.md` (shipped with Jaqal). Flag non-idiomatic constructs — e.g. in Python: manual index loops that should be a comprehension/`enumerate`/`zip`, hand-rolled logic that's a one-liner with `collections`/`itertools`/`functools`, key-existence branches that should be `dict.get`/`defaultdict`, string concatenation in loops, mutable default arguments.
+- Honor any deviation CLAUDE.md documents (e.g. "explicit loops in hot paths") and don't flag it.
+
+### Error handling
+- Swallowed exceptions — bare `except:`, empty catch blocks, catches that log-and-continue where they shouldn't.
+- Over-broad catches that hide real bugs.
+- Inconsistent error propagation — some paths raise, others return error sentinels, for the same class of failure.
+- Missing cleanup on error paths (unclosed files, connections, locks).
 
 ### Code Hygiene
 - Console.log in production code

--- a/agents/doc-auditor.md
+++ b/agents/doc-auditor.md
@@ -14,7 +14,7 @@ Find documentation gaps.
 ### Code Comments
 - Missing JSDoc/TSDoc/docstrings on exported functions
 - Outdated comments that don't match code
-- TODO/FIXME/HACK comments needing action
+- TODO/FIXME/HACK comments needing action (judge whether each is actionable/stale; code-auditor owns the raw count)
 - Complex logic without explanatory comments
 
 ### API Documentation

--- a/agents/frontend-reviewer.md
+++ b/agents/frontend-reviewer.md
@@ -68,6 +68,6 @@ For each finding, name the file, describe the problem, and show the fix.
 ## What you do NOT review
 
 - Visual design, layout, spacing, colors — ux-reviewer handles this
-- Accessibility, ARIA, keyboard navigation — accessibility plugins handle this
+- Accessibility, ARIA, keyboard navigation — the web-design-guidelines accessibility check (auditor 7 in `/gate-audit`) handles this
 - Backend code — out of scope
 - Product decisions — product-reviewer handles this

--- a/agents/product-reviewer.md
+++ b/agents/product-reviewer.md
@@ -41,12 +41,12 @@ Evaluate against these questions:
 
 ## Output format
 
-Classify every finding as:
+Classify every finding by severity (stage-neutral — the gate that invoked you maps these to its own verdict):
 
-- **BLOCKS SHIP**: This will confuse, frustrate, or lose users. Must fix before merge.
-- **SHOULD FIX**: Noticeable quality gap. Fix in this cycle if possible.
+- **BLOCKER**: Fundamental — a user will be confused, frustrated, or lost. Must be resolved before this work proceeds (before implementation in a design review; before merge in an acceptance review).
+- **SHOULD FIX**: Noticeable quality gap. Address this cycle.
 - **MINOR**: Polish item. Track for later.
-- **OBSERVATION**: Not a problem — just something to be aware of for future features.
+- **OBSERVATION**: Not a problem — just something to be aware of for future work.
 
 For each finding, reference the specific product principle, persona, or journey it relates to. Never give abstract feedback — always ground it in the product context.
 

--- a/agents/review-readme.md
+++ b/agents/review-readme.md
@@ -1,7 +1,7 @@
 ---
 name: review-readme
 description: README drift review — compare README against PRODUCT.md and the codebase, flag stale claims, broken commands, and voice drift, propose a diff. Recommend-only, never writes README.
-tools: Read, Glob, Grep, Bash
+tools: Read, Glob, Grep, Bash, Write
 model: inherit
 ---
 

--- a/agents/ux-reviewer.md
+++ b/agents/ux-reviewer.md
@@ -66,7 +66,7 @@ Classify every finding as:
 
 ## What you do NOT review
 
-- Accessibility (WCAG, ARIA, keyboard nav) — accessibility agents handle this
+- Accessibility (WCAG, ARIA, keyboard nav) — the web-design-guidelines accessibility check (auditor 7 in `/gate-audit`) handles this
 - Frontend code quality (component structure, state management) — frontend-reviewer handles this
 - Security — security-auditor handles this
 - Backend logic — out of scope entirely

--- a/commands/backlog-hygiene.md
+++ b/commands/backlog-hygiene.md
@@ -16,7 +16,7 @@ Read PRODUCT.md and CLAUDE.md first for product context.
 Spawn @agent-backlog-hygiene to:
 
 1. Fetch all open issues via `gh issue list`.
-2. Read the most recent review reports in `docs/jaqal/health-reviews/`, `docs/jaqal/architecture-reviews/`, `docs/jaqal/product-reviews/`, `docs/jaqal/frontend-reviews/` for context on what's been addressed.
+2. Read the most recent review reports in `docs/jaqal/health-reviews/`, `docs/jaqal/architecture-reviews/`, `docs/jaqal/product-reviews/`, `docs/jaqal/frontend-reviews/`, `docs/jaqal/readme-reviews/` for context on what's been addressed.
 3. For each open issue, check:
    - **Resolved?** — Search git log for commits that reference the issue or fix the stated problem. Check if the code now reflects the desired state.
    - **Obsolete?** — Compare against PRODUCT.md "what we're NOT building." Check if the feature area has been replaced or redesigned.

--- a/commands/deep-review.md
+++ b/commands/deep-review.md
@@ -25,13 +25,13 @@ If `$ARGUMENTS` is non-empty but matches no keyword, list the valid keywords and
 
 ## Single-area run (argument given)
 
-Spawn the one matching agent via the Agent tool. It already knows its full workflow — just tell it the project path and today's date. When it returns, surface its report. Skip Phase 2 — there's nothing to cross-reference in a single review.
+Spawn the one matching agent with the Task tool. It already knows its full workflow — just tell it the project path and today's date. When it returns, surface its report. Skip Phase 2 — there's nothing to cross-reference in a single review.
 
 ## Full sweep (no argument)
 
 ### Phase 1 — Run all five reviews in parallel
 
-Spawn all five as subagents simultaneously using the Agent tool — do not run them sequentially. Use the `subagent_type` values from the table above. Each agent already knows its full workflow — just tell it the project path and today's date. Run all five with `run_in_background: true`.
+Spawn all five subagents simultaneously with the Task tool — do not run them sequentially. Use the `subagent_type` values from the table above. Each agent already knows its full workflow — just tell it the project path and today's date. Run all five with `run_in_background: true`.
 
 ### Phase 2 — Compile master summary
 
@@ -72,16 +72,21 @@ Do NOT apply these changes. Present them as proposed diffs for the user to revie
 
 Pull the metrics snapshots from the codebase health and frontend health reports into a single table for easy trend tracking:
 
-| Metric | Value | Trend vs last review |
-|--------|-------|---------------------|
-| Lines of code | — | — |
-| Test coverage | — | — |
-| TODO/FIXME count | — | — |
-| Outdated deps | — | — |
-| Known vulnerabilities | — | — |
-| Component count | — | — |
-| Bundle size | — | — |
-| Design system deviations | — | — |
+| Metric | Value | Trend vs last review | Source |
+|--------|-------|---------------------|--------|
+| Lines of code | — | — | codebase health |
+| Test coverage | — | — | codebase health |
+| TODO/FIXME count | — | — | codebase health |
+| Outdated deps | — | — | codebase health |
+| Known vulnerabilities | — | — | codebase health |
+| Largest file (lines) | — | — | codebase health |
+| Deepest dependency chain | — | — | codebase health |
+| Component count | — | — | frontend health |
+| Largest CSS file | — | — | frontend health |
+| Accessibility issues (by severity) | — | — | frontend health |
+| Design system deviations | — | — | frontend health |
+
+Every row maps to a metric one of the two health reports actually emits — don't add rows no agent produces.
 
 If previous review reports exist in the `docs/jaqal/` subdirectories, compare against the most recent one and fill in the trend column. Otherwise mark as "baseline".
 

--- a/commands/gate-acceptance.md
+++ b/commands/gate-acceptance.md
@@ -29,8 +29,10 @@ Walk through every user-facing change on this branch:
 
 ## Part 3 — Verdict
 
-- **SHIP** — implementation delivers the intended experience, no user-facing issues
-- **FIX AND RE-CHECK** — specific user-facing issues to address (list them with severity), then re-run this gate
-- **HOLD** — fundamental gap between design intent and implementation, needs rework beyond quick fixes
+Map the product-reviewer's severities to this gate's verdict:
+
+- **SHIP** — implementation delivers the intended experience; only MINOR/OBSERVATION findings.
+- **FIX AND RE-CHECK** — one or more SHOULD FIX findings, or a BLOCKER fixable with targeted work. List them with severity, then re-run this gate.
+- **HOLD** — a BLOCKER that's a fundamental gap between design intent and implementation, needing rework beyond quick fixes.
 
 For FIX AND RE-CHECK items, be specific enough that they can go directly into the engineering chain as fix tasks.

--- a/commands/gate-audit.md
+++ b/commands/gate-audit.md
@@ -9,9 +9,11 @@ Run every auditor in parallel against the current branch. This combines the back
 
 Read CLAUDE.md, PRODUCT.md, and DESIGN.md first.
 
+Establish the changeset under review before spawning anyone: compute the merge-base with the default branch (`git merge-base HEAD origin/main`, falling back to `origin/master` or the repo's default branch) and treat the diff from that base to `HEAD` as the changeset. Pass this explicit scope to every auditor so "this branch" / "this changeset" means the same diff for all of them.
+
 ## Launch all auditors in parallel
 
-Spawn auditors 1–6 as subagents simultaneously — do not run them sequentially. Auditor 7 is an inline external check, described below.
+Spawn auditors 1–6 as subagents simultaneously — do not run them sequentially. Auditor 7 is an inline external check, described below. If the changeset has no frontend changes (no modified template, component, CSS, or JS files), skip auditors 5–7 and note "No frontend changes detected — frontend audits skipped."
 
 ### Backend auditors
 
@@ -29,11 +31,23 @@ Spawn auditors 1–6 as subagents simultaneously — do not run them sequentiall
 
 6. **@agent-frontend-reviewer** — Review frontend code changes for component architecture, state management patterns, data fetching, render performance, and bundle impact.
 
-7. **Web Interface Guidelines (external, optional)** — This check depends on the `web-design-guidelines` skill, which ships separately, not with Jaqal. If it's installed, run `/web-interface-guidelines` against all modified frontend files (components, pages, layouts) to check accessibility, keyboard support, form behavior, focus management, semantic HTML, and animation. Unlike auditors 1–6, this runs inline rather than as a parallel subagent. If the skill isn't available, note "accessibility check skipped — web-design-guidelines not installed" and move on.
+7. **Web Interface Guidelines (external, optional)** — This check depends on the `web-design-guidelines` skill, which ships separately, not with Jaqal. If it's installed, invoke the `web-design-guidelines` skill against all modified frontend files (components, pages, layouts) to check accessibility, keyboard support, form behavior, focus management, semantic HTML, and animation. Unlike auditors 1–6, this runs inline rather than as a parallel subagent. If the skill isn't available, note "accessibility check skipped — web-design-guidelines not installed" and move on.
 
 ## After all auditors return
 
-Compile a unified audit report:
+The auditors don't share a severity vocabulary — map each one's labels into the report's three tiers before compiling:
+
+| Auditor | → Critical (blocks merge) | → Important (should fix) | → Minor (track) |
+|---------|---------------------------|--------------------------|-----------------|
+| security-auditor | Critical, High | Medium | Low |
+| code-auditor | Critical | High, Medium | Low |
+| architecture-auditor | Critical | High, Medium | Low |
+| doc-auditor | — (docs rarely block; escalate only if a wrong command/path ships) | High | Medium, Low |
+| ux-reviewer | VISUAL BUG | INCONSISTENCY, IMPROVEMENT | SUGGESTION |
+| frontend-reviewer | BUG | PERFORMANCE, ARCHITECTURE | CLEANUP |
+| web-design-guidelines (a11y) | blocking a11y failures (no keyboard access, contrast failures on core flows) | other a11y gaps | polish |
+
+Then compile a unified audit report:
 
 ### Summary
 One line per auditor: agent name, number of findings by severity, pass/fail.
@@ -42,7 +56,7 @@ One line per auditor: agent name, number of findings by severity, pass/fail.
 All findings classified as critical/blocking across all auditors, grouped by file. If multiple auditors flag the same file, consolidate their findings together.
 
 ### Important findings (should fix)
-All non-critical but important findings, grouped by category (security, code quality, UX, accessibility, architecture).
+All non-critical but important findings, grouped by category (security, code quality, documentation, architecture, UX, frontend, accessibility).
 
 ### Minor findings (track for later)
 Everything else. Don't expand on these — just list them.
@@ -52,5 +66,3 @@ Based on the findings, recommend one of:
 - **PASS** — No critical findings. Safe to proceed to product acceptance gate.
 - **FIX AND RE-AUDIT** — Critical findings listed. Fix these, then re-run `/gate-audit`.
 - **NEEDS DISCUSSION** — Architectural or product-level concerns that aren't simple fixes.
-
-If the branch has no frontend changes (no modified template, component, CSS, or JS files), skip auditors 5-7 and note "No frontend changes detected — frontend audits skipped."

--- a/commands/gate-design-review.md
+++ b/commands/gate-design-review.md
@@ -1,13 +1,18 @@
 ---
 description: Product review of a design doc before implementation begins
-allowed-tools: Read, Glob, Grep, Task
+allowed-tools: Read, Glob, Grep, Bash, Task
 ---
 
 # Does this design serve users?
 
 Read PRODUCT.md at the project root first.
 
-Then find the most recent design doc or spec for the current feature branch.
+Then find the design doc or spec under review:
+- Check the branch's added/changed docs: `git diff --name-only $(git merge-base HEAD origin/main)...HEAD` and look for design/spec Markdown (e.g. under `docs/`, `specs/`, `design/`).
+- If nothing turns up there, take the most recently modified Markdown under those locations.
+- If still ambiguous or there are several candidates, ask the user which doc to review rather than guessing.
+
+Pass the resolved doc path explicitly into the product review below.
 
 ## Part 1 — Product review
 
@@ -28,10 +33,8 @@ Be honest. If any step feels forced or unnatural, say so.
 
 ## Part 3 — Verdict
 
-Synthesize the product-reviewer findings and the persona walkthrough into a clear recommendation:
+Synthesize the product-reviewer findings and the persona walkthrough into a clear recommendation. Map the product-reviewer's severities to this gate's verdict:
 
-- **PROCEED TO PLAN** — design is sound, no product concerns
-- **REVISE** — specific issues need to be addressed before implementation (list them)
-- **RETHINK** — fundamental product misalignment, go back to brainstorm (explain why)
-
-If the recommendation is REVISE, list the specific changes needed in priority order.
+- **PROCEED TO PLAN** — design is sound; only MINOR/OBSERVATION findings.
+- **REVISE** — one or more SHOULD FIX findings, or a BLOCKER that's a fixable design flaw (missing state, confusing step). List the specific changes needed in priority order.
+- **RETHINK** — a BLOCKER rooted in problem validity, principle conflict, or scope ("what we're NOT building"). Go back to brainstorm and explain why.

--- a/commands/jaqal-init.md
+++ b/commands/jaqal-init.md
@@ -169,6 +169,14 @@ Add this section:
 - **PRODUCT.md** — product context, personas, principles, feature map. Read before any product decision.
 - **DESIGN.md** — design system, colors, typography, component patterns. Read before any UI work.
 
+### Code conventions
+
+Language conventions `code-auditor` enforces at `/gate-audit`. Document the rules and any deliberate deviations here — they override Jaqal's built-in idiom rubric.
+
+- **<language>** — <conventions, e.g. "Python 3.11+. Prefer comprehensions, generator expressions, and stdlib (functools, itertools, collections) over explicit loops. Type hints required.">
+- **Linter** — <the idiom linter and its rule selection, e.g. "Ruff with C4,SIM,PERF,B,RUF,PIE; run `ruff check` before pushing.">
+- **Deliberate deviations** — <conventions you intentionally break and why, e.g. "explicit loops in hot paths.">
+
 ### Quality gates
 
 | Gate | When | Command |
@@ -201,34 +209,9 @@ Add this section:
    - `/deep-review readme` proposes a README.md diff
 ```
 
-## Step 7 — Wire the PR-time gate reminder hook
+When writing the **Code conventions** block, detect the project's primary language(s) from the codebase and pre-fill sensible defaults plus the matching idiom linter — Ruff for Python, ESLint/Biome for JS/TS, golangci-lint for Go, Clippy for Rust, RuboCop for Ruby — then flag it for the user to refine.
 
-Add a `PreToolUse` hook so opening a pull request prompts a reminder to run the gates. It's a non-blocking confirmation — it asks, it never hard-blocks — and it's unconditional: it always asks at `gh pr create` time rather than trying to detect whether a gate ran.
-
-Read `.claude/settings.json` if it exists (create the `.claude/` directory and the file if not). Merge in the hook below — preserve any existing `hooks` and other settings, and don't add it twice if an equivalent entry is already present:
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "if": "Bash(gh pr create *)",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gate-reminder.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-If a `PreToolUse` array already exists, append this entry rather than replacing the array. Tell the user the hook was added and that they can delete it from `.claude/settings.json` if they don't want the reminder.
-
-## Step 8 — Summary
+## Step 7 — Summary
 
 Report what was created, what was populated, and what the user should review:
 - PRODUCT.md — auto-populated sections and sections that need human input
@@ -236,6 +219,7 @@ Report what was created, what was populated, and what the user should review:
 - README.md — created from scratch, or skipped because one already exists
 - CLAUDE.md — sections added
 - Review directories created
-- PR-time gate reminder hook — added to `.claude/settings.json`
+
+Note that the plugin's PR-time gate reminder is already active (it ships with Jaqal as a `PreToolUse` hook — no per-project wiring needed) and fires a non-blocking confirmation when you run `gh pr create`.
 
 Suggest the user review PRODUCT.md first (product principles and "not building" sections need human judgment), then DESIGN.md (anti-patterns section needs human input), then README.md if one was generated.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Jaqal PR-time gate reminder — non-blocking 'ask' before `gh pr create`",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/gate-reminder.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/reference/idioms/python.md
+++ b/reference/idioms/python.md
@@ -1,0 +1,45 @@
+# Python idioms — judgment layer
+
+The linter (`ruff --select C4,SIM,PERF,B,RUF,PIE`) catches the mechanical cases. This rubric is for the structural recognitions a linter misses — where the code works but a Python developer would write it differently. CLAUDE.md conventions override anything here.
+
+## Reach for the stdlib before hand-rolling
+
+- A loop that counts occurrences into a dict → `collections.Counter`.
+- A dict whose values are appended-to lists/sets → `collections.defaultdict(list)`.
+- A manual `lru`/memo dict on a pure function → `functools.lru_cache` / `functools.cache`.
+- Manual cache of an expensive instance property → `functools.cached_property`.
+- Nested loops over the product of two sequences → `itertools.product`.
+- A running accumulation / flatten of nested iterables → `itertools.chain.from_iterable`, `itertools.accumulate`.
+- Sorting then grouping adjacent equal keys → `itertools.groupby` (sort first).
+- Sliding-window pairs → `itertools.pairwise`.
+- A fixed-size FIFO/LIFO with `list.pop(0)` → `collections.deque`.
+
+## Loops that aren't loops
+
+- Building a list/set/dict by appending in a `for` → comprehension. Use a generator expression when the result is only iterated once (streaming, `sum()`, `any()`, `max()`).
+- `for i in range(len(xs))` → `enumerate(xs)`; two parallel sequences → `zip`.
+- `sum`/`min`/`max`/`any`/`all` over a hand-written accumulator loop.
+
+## Structured data
+
+- Parallel lists or dicts-of-fixed-keys passed around together → a `@dataclass` (or `typing.NamedTuple` for immutable). Bare tuples indexed by position (`row[3]`) are a smell.
+- Returning a multi-field dict that callers index by string key → a dataclass with typed fields.
+
+## Control flow & access
+
+- `if k in d: x = d[k] else: x = default` → `d.get(k, default)`; accumulate-into-key → `d.setdefault` / `defaultdict`.
+- Nested `if` pyramids → early `return`/`continue` (guard clauses).
+- LBYL existence checks around an operation that could just be tried → EAFP (`try/except`) where it reads cleaner.
+- `len(x) == 0` / `len(x) > 0` → truthiness (`if not x` / `if x`).
+
+## Resources, paths, strings
+
+- Manual `open()`/`close()` or `try/finally` cleanup → `with` context managers; write your own with `contextlib.contextmanager` when a cleanup pair recurs.
+- `os.path.join`/`os.path.exists` string-wrangling → `pathlib.Path`.
+- `%`-formatting or `.format()` → f-strings.
+
+## Traps
+
+- Mutable default arguments (`def f(x=[])`) — flag always.
+- Returning `None` vs raising for the same failure mode in different branches — pick one.
+- Building large lists in memory that are consumed once — prefer a generator.

--- a/reference/idioms/typescript.md
+++ b/reference/idioms/typescript.md
@@ -1,0 +1,39 @@
+# TypeScript / JavaScript idioms — judgment layer
+
+The linter (`eslint` with `eslint-plugin-unicorn`, or `biome check`) catches the mechanical cases. This rubric is for the structural recognitions a linter misses. CLAUDE.md conventions override anything here.
+
+## Types
+
+- `any` → `unknown` plus narrowing, or a precise type. `as` assertions that bypass the checker are a smell; prefer type guards.
+- Boolean flags that are mutually exclusive or drive a shape change → a discriminated union (`{ kind: 'a'; ... } | { kind: 'b'; ... }`).
+- A bag of optional fields where only some combinations are valid → model the valid states as a union, not one wide object.
+- `as const` for literal tuples/objects; `readonly` for arrays/props that shouldn't mutate.
+- A union of string literals usually beats an `enum`.
+
+## Loops that aren't loops
+
+- Building an array by `push` in a `for` → `map`/`filter`/`flatMap`/`reduce`.
+- Existence/aggregate checks → `some`/`every`/`find`/`includes`, not a manual loop with a flag.
+- `Object.keys/values/entries` + iteration over manual `for...in`.
+
+## Access & control flow
+
+- Nested null checks → optional chaining `?.` and nullish coalescing `??` (not `||`, which swallows `0`/`''`/`false`).
+- Nested `if` pyramids → early return guard clauses.
+- Destructuring for multi-field access and for default values, over repeated `obj.x` / `x = obj.x ?? d`.
+
+## Data structures
+
+- An object used as a keyed map with non-string keys, or that needs ordered iteration / frequent add-remove → `Map`. A set of unique values → `Set`.
+- Spreading (`{...a, ...b}`, `[...xs, y]`) over `Object.assign`/`concat` for the common immutable cases.
+
+## Async
+
+- `async/await` over `.then()` chains; `Promise.all` for independent awaits instead of awaiting in sequence.
+- Don't swallow rejections — every `await` that can throw is in a `try/catch` or has a deliberate boundary.
+
+## Traps
+
+- `==` where `===` is meant.
+- `||` for defaulting when the value can legitimately be `0`/`''`/`false` → `??`.
+- Mutating function arguments or shared state where a pure transform is clearer.


### PR DESCRIPTION
Implements the full remediation from the per-step behavioral audit. Five thematic commits.

## Blocking
- **B1 — PR hook never fired.** `jaqal-init` injected `${CLAUDE_PLUGIN_ROOT}` into the *project's* settings.json, where it doesn't resolve (confirmed against every installed plugin + the docs). Re-declared the hook the canonical way in a plugin-level `hooks/hooks.json`; dropped the dead init Step 7. It now works on install (fires in any jaqal-enabled project — acceptable for a non-blocking `gh pr create` nudge).
- **B2 — `/gate-audit` couldn't route half its findings.** Added a severity-mapping table so the 6 auditors' incompatible scales (Critical/High, VISUAL BUG, BUG, …) land in Critical/Important/Minor; added documentation + frontend to the Important category list.

## Important
- **I1** — auditor 7 invoked a nonexistent `/web-interface-guidelines`; now invokes the `web-design-guidelines` skill by name.
- **I2** — `/gate-audit` now establishes an explicit diff base (merge-base with default branch) so every auditor scopes to the same changeset.
- **I3** — `code-auditor` gained the Error handling section the gate already asked it for.
- **I4 — language idiom enforcement.** `code-auditor` now reads CLAUDE.md (it never did), runs the language's idiom linter read-only (`ruff --select C4,SIM,PERF,B`, eslint/biome, clippy, …), and applies a judgment-level rubric for what linters miss. Ships `reference/idioms/{python,typescript}.md`; `jaqal-init` writes a Code conventions block + pre-fills the detected linter.
- **I5** — `product-reviewer` verdicts were ship/merge-flavored and undefined for design-review. Made stage-neutral (BLOCKER/SHOULD FIX/MINOR/OBSERVATION) with an explicit crosswalk in each gate.
- **I6** — `gate-design-review` had no way to find the design doc; added a Bash discovery method and granted Bash.
- **I7** — `backlog-hygiene` now reads `docs/jaqal/readme-reviews/` (the dir it missed).
- **I8** — `/deep-review` dashboard dropped the phantom `Bundle size` row, added the produced-but-dropped metrics, and tags each row's source.
- **I9** — `review-readme` gained the `Write` tool it needs to save its report.

## Minor
Accessibility-owner naming fixed in ux/frontend reviewers (real owner, not "accessibility agents"); TODO/FIXME ownership split between code- and doc-auditor; deep-review tool-naming unified on the Task tool; frontend-skip rule moved next to the launch step; hygiene commit-scan widened to 200.

## Deliberately not changed
The **voice split** (terse imperative auditors vs. "You are a…" reviewers) — it tracks a real difference (rule-checks vs. judgment), and rewriting five working prompts for cosmetic uniformity is churn-for-churn. Flagging the decision rather than silently skipping.

## Verification
hooks.json valid + hook smoke-tested (valid `ask` JSON); zero stale command/agent refs; `jaqal-init` clean (Steps 1–7, no settings.json injection); model pins untouched.