### PR TITLE
feat!: rename plugin from Jaqal to Studious

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
-  "name": "jaqal",
-  "description": "Jaqal (jackal) — quality loom for Claude Code. Periodic health reviews, quality gates, design system extraction, and pre-deploy audits.",
+  "name": "studious",
+  "description": "Studious — a product-judgment workflow for Claude Code. It examines each piece of work: whether to build it, whether the design serves users, and whether the result holds up. Quality gates, periodic health reviews, and pre-merge audits.",
   "version": "1.5.0",
   "author": {
     "name": "Jacquard Labs"
   },
-  "repository": "https://github.com/jacquardlabs/jaqal",
+  "repository": "https://github.com/jacquardlabs/studious",
   "license": "MIT",
   "keywords": [
     "review",

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,5 +10,5 @@ Closes #
 
 - [ ] Follows existing file structure and frontmatter conventions
 - [ ] New agents/commands read appropriate context docs (PRODUCT.md, DESIGN.md, CLAUDE.md)
-- [ ] Review output paths use `docs/jaqal/` prefix
+- [ ] Review output paths use `docs/studious/` prefix
 - [ ] README updated if adding new commands or changing the workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Jaqal
+# Contributing to Studious
 
-Thanks for your interest in improving Jaqal. Here's how to contribute.
+Thanks for your interest in improving Studious. Here's how to contribute.
 
 ## Reporting issues
 
@@ -33,14 +33,14 @@ commands/     — Slash commands (description, allowed-tools in frontmatter)
 skills/       — Natural-language trigger shims (skills/<name>/SKILL.md)
 hooks/        — Shipped hook scripts + hooks.json (e.g. the PR-time gate reminder)
 reference/    — Curated rubrics agents read at audit time (e.g. reference/idioms/<lang>.md)
-templates/    — Scaffold files created by /jaqal-init
+templates/    — Scaffold files created by /studious-init
 ```
 
 - Agents do the work. Commands orchestrate agents or provide standalone workflows.
 - Skills are trigger shims: a tightly-scoped `description` lets a gate fire from natural language, and the body delegates to the matching command instead of duplicating it.
 - Every agent and command reads PRODUCT.md, DESIGN.md, or CLAUDE.md for project context.
-- Review reports save to `docs/jaqal/` subdirectories in the user's project, not to the plugin itself.
-- Commands that produce output are recommend-only — they report, never modify external state (issues, PRs, files outside `docs/jaqal/`).
+- Review reports save to `docs/studious/` subdirectories in the user's project, not to the plugin itself.
+- Commands that produce output are recommend-only — they report, never modify external state (issues, PRs, files outside `docs/studious/`).
 
 ## Naming conventions
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Jaqal
+# Studious
 
 A product development workflow for Claude Code, from [Jacquard Labs](https://github.com/jacquardlabs).
 
@@ -6,11 +6,11 @@ A product development workflow for Claude Code, from [Jacquard Labs](https://git
 
 Claude Code made building cheap. That moved the bottleneck. The hard part is no longer *can we build it*. It's *should we build it, and did we build it right*.
 
-Jaqal adds that judgment back as lightweight gates and reviews woven around the building. It owns the *what* and the *whether*: what to work on, whether a design serves users, whether the implementation delivers, whether the codebase stays healthy. Pair it with [Superpowers](https://github.com/obra/superpowers) for the *how*: brainstorming, planning, TDD, and execution.
+Studious adds that judgment back as lightweight gates and reviews woven around the building. It owns the *what* and the *whether*: what to work on, whether a design serves users, whether the implementation delivers, whether the codebase stays healthy. Pair it with [Superpowers](https://github.com/obra/superpowers) for the *how*: brainstorming, planning, TDD, and execution.
 
 ## How it works
 
-Jaqal runs on 2 rhythms. A per-feature gate flow that checks each piece of work before and after you build it, and a per-project health loop that reviews the whole on a cadence. Both read from 3 context documents (PRODUCT.md, DESIGN.md, CLAUDE.md) that hold your product's through-lines, so every judgment is grounded in the same context. That's the whole system.
+Studious runs on 2 rhythms. A per-feature gate flow that checks each piece of work before and after you build it, and a per-project health loop that reviews the whole on a cadence. Both read from 3 context documents (PRODUCT.md, DESIGN.md, CLAUDE.md) that hold your product's through-lines, so every judgment is grounded in the same context. That's the whole system.
 
 ## Install
 
@@ -18,31 +18,31 @@ Via the Jacquard Labs marketplace:
 
 ```bash
 /plugin marketplace add jacquardlabs/marketplace
-/plugin install jaqal@jacquardlabs-marketplace
+/plugin install studious@jacquardlabs-marketplace
 ```
 
 Or directly:
 
 ```bash
-/plugin marketplace add jacquardlabs/jaqal
-/plugin install jaqal@jaqal
+/plugin marketplace add jacquardlabs/studious
+/plugin install studious@studious
 ```
 
 Then, in any project:
 
 ```
-/jaqal-init
+/studious-init
 ```
 
-This creates your context documents (PRODUCT.md and DESIGN.md, extracted from the codebase as it actually is), scaffolds the `docs/jaqal/` review directories, and wires the workflow reference into CLAUDE.md so every future session knows the process. Review PRODUCT.md first. The extraction is evidence-based, but product principles and your "not building" list need your voice.
+This creates your context documents (PRODUCT.md and DESIGN.md, extracted from the codebase as it actually is), scaffolds the `docs/studious/` review directories, and wires the workflow reference into CLAUDE.md so every future session knows the process. Review PRODUCT.md first. The extraction is evidence-based, but product principles and your "not building" list need your voice.
 
 ## Building a feature
 
-Jaqal wraps feature development in quality gates. Between them you build, and Jaqal doesn't care how. Each gate exists to catch a specific failure:
+Studious wraps feature development in quality gates. Between them you build, and Studious doesn't care how. Each gate exists to catch a specific failure:
 
 - Pick what to build with `/backlog-priorities` (ranks your open GitHub issues by severity/alignment/unblocking potential) or `/gate-should-we-build [idea]` (scores a raw idea against PRODUCT.md and the smallest version worth shipping). Catches building the wrong thing.
 - Gate the design with `/gate-design-review`. It walks your design doc as your primary persona would and flags where they'd get confused or frustrated. Catches a bad design before you spend build effort on it.
-- Build it with your own workflow. Superpowers gives you plan/execute with TDD and review checkpoints. Jaqal steps back here.
+- Build it with your own workflow. Superpowers gives you plan/execute with TDD and review checkpoints. Studious steps back here.
 - Audit before merge with `/gate-audit`: 6 auditors in parallel (security, code quality, docs, architecture, UX, frontend), each staying in its lane, plus an accessibility pass via the Web Interface Guidelines skill when it's installed. Frontend auditors skip automatically on branches with no frontend changes.
 - Gate acceptance with `/gate-acceptance`. Product review, not code review: does the implementation actually deliver the experience? It walks every user-facing change, checks error states for human-friendly messaging, and regression-tests the critical journeys in PRODUCT.md.
 
@@ -87,7 +87,7 @@ Aim it at one area when you don't need the full sweep — each review has its ow
 
 ## Context documents
 
-Everything in Jaqal reads from 3 files in your project root. `/jaqal-init` creates them; you maintain them.
+Everything in Studious reads from 3 files in your project root. `/studious-init` creates them; you maintain them.
 
 | Document | What it holds | Updated by |
 |----------|---------------|------------|
@@ -99,7 +99,7 @@ Reviews propose updates to these docs. They never apply them. You review and app
 
 ## Works well with
 
-- [Superpowers](https://github.com/obra/superpowers): brainstorming, planning, TDD, debugging, and execution. Jaqal gates the what and whether; Superpowers handles the how.
+- [Superpowers](https://github.com/obra/superpowers): brainstorming, planning, TDD, debugging, and execution. Studious gates the what and whether; Superpowers handles the how.
 - GitHub Issues: `/backlog-priorities` and `/backlog-hygiene` work with your tracker via the `gh` CLI.
 
 ## License

--- a/agents/backlog-hygiene.md
+++ b/agents/backlog-hygiene.md
@@ -13,7 +13,7 @@ Identify open GitHub issues that should be closed because they've been resolved,
 
 1. Read PRODUCT.md and CLAUDE.md for product context.
 2. Fetch all open issues via `gh issue list --json number,title,body,labels,createdAt`.
-3. Read the most recent review reports in `docs/jaqal/health-reviews/`, `docs/jaqal/architecture-reviews/`, `docs/jaqal/product-reviews/`, `docs/jaqal/frontend-reviews/`, `docs/jaqal/readme-reviews/` for context on what's been addressed.
+3. Read the most recent review reports in `docs/studious/health-reviews/`, `docs/studious/architecture-reviews/`, `docs/studious/product-reviews/`, `docs/studious/frontend-reviews/`, `docs/studious/readme-reviews/` for context on what's been addressed.
 4. For each open issue, evaluate:
    - **Resolved?** Search `git log --oneline -200` for commits that reference the issue number or describe fixing the stated problem. Check whether the code, behavior, or file referenced in the issue body now reflects the desired state (via Grep/Read on the specific files mentioned).
    - **Obsolete?** Compare against PRODUCT.md "what we're NOT building" list — does the issue request something we've decided not to build? Check if the feature area has been replaced or redesigned since the issue was filed. Check if the issue describes a problem with code that no longer exists.

--- a/agents/backlog-priorities.md
+++ b/agents/backlog-priorities.md
@@ -13,7 +13,7 @@ Help the user decide what to work on next by curating a ranked shortlist from op
 
 1. Read PRODUCT.md and CLAUDE.md for product context.
 2. Fetch all open issues via `gh issue list --json number,title,body,labels,createdAt`.
-3. Read the most recent deep review summary (`docs/jaqal/health-reviews/*-deep-review-summary.md`) and any individual review reports for cross-referencing severity and findings.
+3. Read the most recent deep review summary (`docs/studious/health-reviews/*-deep-review-summary.md`) and any individual review reports for cross-referencing severity and findings.
 4. **Ask the user** to pick a work mode:
    - **Tech debt** — code quality, refactoring, dependency upgrades, test coverage gaps, architectural cleanup
    - **Maintenance** — bug fixes, security patches, performance improvements, accessibility fixes

--- a/agents/code-auditor.md
+++ b/agents/code-auditor.md
@@ -62,7 +62,7 @@ Read CLAUDE.md first for the project's documented technical conventions. They ar
 CLAUDE.md's documented conventions are authoritative and override everything below. Then:
 - Detect the changed files' language(s) by extension.
 - **Run the language's idiom linter read-only** if one is configured or available, and fold its findings in. Never pass a fix/`--fix` flag — this audit reports, it doesn't modify. Examples: Python — `ruff check --select C4,SIM,PERF,B,RUF,PIE`; JS/TS — `eslint` or `biome check`; Go — `golangci-lint run`; Rust — `cargo clippy`; Ruby — `rubocop`. If no linter is available, say so and recommend adding one.
-- **Apply the judgment-level idioms a linter can't catch** using the language rubric in `reference/idioms/<language>.md` (shipped with Jaqal). Flag non-idiomatic constructs — e.g. in Python: manual index loops that should be a comprehension/`enumerate`/`zip`, hand-rolled logic that's a one-liner with `collections`/`itertools`/`functools`, key-existence branches that should be `dict.get`/`defaultdict`, string concatenation in loops, mutable default arguments.
+- **Apply the judgment-level idioms a linter can't catch** using the language rubric in `reference/idioms/<language>.md` (shipped with Studious). Flag non-idiomatic constructs — e.g. in Python: manual index loops that should be a comprehension/`enumerate`/`zip`, hand-rolled logic that's a one-liner with `collections`/`itertools`/`functools`, key-existence branches that should be `dict.get`/`defaultdict`, string concatenation in loops, mutable default arguments.
 - Honor any deviation CLAUDE.md documents (e.g. "explicit loops in hot paths") and don't flag it.
 
 ### Error handling

--- a/agents/review-architecture.md
+++ b/agents/review-architecture.md
@@ -59,6 +59,6 @@ For each finding, classify as:
 
 End with a recommended priority order for any refactoring work.
 
-If previous architecture reviews exist in `docs/jaqal/architecture-reviews/`, compare against the most recent one.
+If previous architecture reviews exist in `docs/studious/architecture-reviews/`, compare against the most recent one.
 
-Save the report to `docs/jaqal/architecture-reviews/YYYY-MM-DD-architecture-review.md`.
+Save the report to `docs/studious/architecture-reviews/YYYY-MM-DD-architecture-review.md`.

--- a/agents/review-codebase-health.md
+++ b/agents/review-codebase-health.md
@@ -83,6 +83,6 @@ Capture these numbers so you can track trends across reviews:
 - Largest file (lines)
 - Deepest dependency chain
 
-If previous health reviews exist in `docs/jaqal/health-reviews/`, compare against the most recent one and note trends (up/down/flat).
+If previous health reviews exist in `docs/studious/health-reviews/`, compare against the most recent one and note trends (up/down/flat).
 
-Save the report to `docs/jaqal/health-reviews/YYYY-MM-DD-health-review.md`.
+Save the report to `docs/studious/health-reviews/YYYY-MM-DD-health-review.md`.

--- a/agents/review-frontend-health.md
+++ b/agents/review-frontend-health.md
@@ -79,6 +79,6 @@ Polish items, minor inconsistencies, potential future problems.
 ### DESIGN.md updates
 Propose any updates to DESIGN.md based on findings — new patterns that have emerged, decisions that should be codified, anti-patterns to add.
 
-If previous frontend reviews exist in `docs/jaqal/frontend-reviews/`, compare against the most recent one and note trends.
+If previous frontend reviews exist in `docs/studious/frontend-reviews/`, compare against the most recent one and note trends.
 
-Save the report to `docs/jaqal/frontend-reviews/YYYY-MM-DD-frontend-review.md`.
+Save the report to `docs/studious/frontend-reviews/YYYY-MM-DD-frontend-review.md`.

--- a/agents/review-product-health.md
+++ b/agents/review-product-health.md
@@ -62,6 +62,6 @@ If no tracker is active, also propose:
 
 Present the changes as a diff against the current PRODUCT.md. Don't apply them — present them for review.
 
-If previous product reviews exist in `docs/jaqal/product-reviews/`, compare against the most recent one.
+If previous product reviews exist in `docs/studious/product-reviews/`, compare against the most recent one.
 
-Save the report to `docs/jaqal/product-reviews/YYYY-MM-DD-product-review.md`.
+Save the report to `docs/studious/product-reviews/YYYY-MM-DD-product-review.md`.

--- a/agents/review-readme.md
+++ b/agents/review-readme.md
@@ -11,7 +11,7 @@ Check whether README.md still tells the truth about the product. A README goes s
 
 ## Workflow
 
-1. Read README.md. If none exists, report that and stop — creation belongs in `/jaqal-init`, not here.
+1. Read README.md. If none exists, report that and stop — creation belongs in `/studious-init`, not here.
 2. Read PRODUCT.md, DESIGN.md, and CLAUDE.md for ground truth and the project's writing style.
 3. Scan the codebase to verify what the README claims: package manifest (name, scripts, version), install/run commands, config files, `.env.example`, route/command/feature definitions, and the actual directory structure.
 4. Evaluate drift in five categories:
@@ -49,10 +49,10 @@ Check whether README.md still tells the truth about the product. A README goes s
 [N] findings: [breakdown by category]. Overall: README is [current / lightly stale / significantly out of date].
 ```
 
-Save the report to `docs/jaqal/readme-reviews/YYYY-MM-DD-readme-review.md` (create the directory if it doesn't exist). If previous README reviews exist there, compare against the most recent one.
+Save the report to `docs/studious/readme-reviews/YYYY-MM-DD-readme-review.md` (create the directory if it doesn't exist). If previous README reviews exist there, compare against the most recent one.
 
 ## What this agent does NOT do
 
 - Write, overwrite, or create README.md — it proposes a diff; the human applies it.
-- Generate a README from scratch — that's `/jaqal-init` when no README exists.
+- Generate a README from scratch — that's `/studious-init` when no README exists.
 - Review code quality, architecture, or product strategy — other reviews own those.

--- a/commands/backlog-hygiene.md
+++ b/commands/backlog-hygiene.md
@@ -16,7 +16,7 @@ Read PRODUCT.md and CLAUDE.md first for product context.
 Spawn @agent-backlog-hygiene to:
 
 1. Fetch all open issues via `gh issue list`.
-2. Read the most recent review reports in `docs/jaqal/health-reviews/`, `docs/jaqal/architecture-reviews/`, `docs/jaqal/product-reviews/`, `docs/jaqal/frontend-reviews/`, `docs/jaqal/readme-reviews/` for context on what's been addressed.
+2. Read the most recent review reports in `docs/studious/health-reviews/`, `docs/studious/architecture-reviews/`, `docs/studious/product-reviews/`, `docs/studious/frontend-reviews/`, `docs/studious/readme-reviews/` for context on what's been addressed.
 3. For each open issue, check:
    - **Resolved?** — Search git log for commits that reference the issue or fix the stated problem. Check if the code now reflects the desired state.
    - **Obsolete?** — Compare against PRODUCT.md "what we're NOT building." Check if the feature area has been replaced or redesigned.

--- a/commands/deep-review.md
+++ b/commands/deep-review.md
@@ -15,11 +15,11 @@ Read CLAUDE.md, PRODUCT.md, and DESIGN.md first.
 
 | Keyword | `subagent_type` | What it reviews | Report path |
 |---------|-----------------|-----------------|-------------|
-| `codebase` (or `health`) | `review-codebase-health` | Architecture coherence, tech debt, dependency health, test health, API consistency | `docs/jaqal/health-reviews/YYYY-MM-DD-health-review.md` |
-| `frontend` | `review-frontend-health` | Design system consistency, accessibility, frontend code quality, responsive spot-check | `docs/jaqal/frontend-reviews/YYYY-MM-DD-frontend-review.md` |
-| `architecture` (or `arch`) | `review-architecture` | Dependency map, boundaries, complexity, evolution readiness, data layer | `docs/jaqal/architecture-reviews/YYYY-MM-DD-architecture-review.md` |
-| `product` | `review-product-health` | PRODUCT.md accuracy, product coherence, onboarding path, proposed PRODUCT.md updates | `docs/jaqal/product-reviews/YYYY-MM-DD-product-review.md` |
-| `readme` | `review-readme` | README drift: stale claims, missing features, broken commands/paths/links, voice drift, proposed diff | `docs/jaqal/readme-reviews/YYYY-MM-DD-readme-review.md` |
+| `codebase` (or `health`) | `review-codebase-health` | Architecture coherence, tech debt, dependency health, test health, API consistency | `docs/studious/health-reviews/YYYY-MM-DD-health-review.md` |
+| `frontend` | `review-frontend-health` | Design system consistency, accessibility, frontend code quality, responsive spot-check | `docs/studious/frontend-reviews/YYYY-MM-DD-frontend-review.md` |
+| `architecture` (or `arch`) | `review-architecture` | Dependency map, boundaries, complexity, evolution readiness, data layer | `docs/studious/architecture-reviews/YYYY-MM-DD-architecture-review.md` |
+| `product` | `review-product-health` | PRODUCT.md accuracy, product coherence, onboarding path, proposed PRODUCT.md updates | `docs/studious/product-reviews/YYYY-MM-DD-product-review.md` |
+| `readme` | `review-readme` | README drift: stale claims, missing features, broken commands/paths/links, voice drift, proposed diff | `docs/studious/readme-reviews/YYYY-MM-DD-readme-review.md` |
 
 If `$ARGUMENTS` is non-empty but matches no keyword, list the valid keywords and stop.
 
@@ -88,6 +88,6 @@ Pull the metrics snapshots from the codebase health and frontend health reports 
 
 Every row maps to a metric one of the two health reports actually emits — don't add rows no agent produces.
 
-If previous review reports exist in the `docs/jaqal/` subdirectories, compare against the most recent one and fill in the trend column. Otherwise mark as "baseline".
+If previous review reports exist in the `docs/studious/` subdirectories, compare against the most recent one and fill in the trend column. Otherwise mark as "baseline".
 
-Save the master summary to `docs/jaqal/health-reviews/YYYY-MM-DD-deep-review-summary.md`.
+Save the master summary to `docs/studious/health-reviews/YYYY-MM-DD-deep-review-summary.md`.

--- a/commands/gate-audit.md
+++ b/commands/gate-audit.md
@@ -31,7 +31,7 @@ Spawn auditors 1–6 as subagents simultaneously — do not run them sequentiall
 
 6. **@agent-frontend-reviewer** — Review frontend code changes for component architecture, state management patterns, data fetching, render performance, and bundle impact.
 
-7. **Web Interface Guidelines (external, optional)** — This check depends on the `web-design-guidelines` skill, which ships separately, not with Jaqal. If it's installed, invoke the `web-design-guidelines` skill against all modified frontend files (components, pages, layouts) to check accessibility, keyboard support, form behavior, focus management, semantic HTML, and animation. Unlike auditors 1–6, this runs inline rather than as a parallel subagent. If the skill isn't available, note "accessibility check skipped — web-design-guidelines not installed" and move on.
+7. **Web Interface Guidelines (external, optional)** — This check depends on the `web-design-guidelines` skill, which ships separately, not with Studious. If it's installed, invoke the `web-design-guidelines` skill against all modified frontend files (components, pages, layouts) to check accessibility, keyboard support, form behavior, focus management, semantic HTML, and animation. Unlike auditors 1–6, this runs inline rather than as a parallel subagent. If the skill isn't available, note "accessibility check skipped — web-design-guidelines not installed" and move on.
 
 ## After all auditors return
 

--- a/commands/studious-init.md
+++ b/commands/studious-init.md
@@ -1,5 +1,5 @@
 ---
-description: Initialize Jaqal in the current project — creates PRODUCT.md, DESIGN.md, scaffolds review directories, and configures CLAUDE.md
+description: Initialize Studious in the current project — creates PRODUCT.md, DESIGN.md, scaffolds review directories, and configures CLAUDE.md
 allowed-tools: Read, Glob, Grep, Bash, Task, Write, Edit, WebFetch
 ---
 
@@ -147,11 +147,11 @@ Cover, at minimum: what it is, install, a runnable usage example, and license. W
 ## Step 5 — Scaffold review directories
 
 Create these directories if they don't exist:
-- `docs/jaqal/health-reviews/`
-- `docs/jaqal/frontend-reviews/`
-- `docs/jaqal/architecture-reviews/`
-- `docs/jaqal/product-reviews/`
-- `docs/jaqal/readme-reviews/`
+- `docs/studious/health-reviews/`
+- `docs/studious/frontend-reviews/`
+- `docs/studious/architecture-reviews/`
+- `docs/studious/product-reviews/`
+- `docs/studious/readme-reviews/`
 
 Add a `.gitkeep` to each empty directory so they're tracked in git.
 
@@ -171,7 +171,7 @@ Add this section:
 
 ### Code conventions
 
-Language conventions `code-auditor` enforces at `/gate-audit`. Document the rules and any deliberate deviations here — they override Jaqal's built-in idiom rubric.
+Language conventions `code-auditor` enforces at `/gate-audit`. Document the rules and any deliberate deviations here — they override Studious's built-in idiom rubric.
 
 - **<language>** — <conventions, e.g. "Python 3.11+. Prefer comprehensions, generator expressions, and stdlib (functools, itertools, collections) over explicit loops. Type hints required.">
 - **Linter** — <the idiom linter and its rule selection, e.g. "Ruff with C4,SIM,PERF,B,RUF,PIE; run `ruff check` before pushing.">
@@ -220,6 +220,6 @@ Report what was created, what was populated, and what the user should review:
 - CLAUDE.md — sections added
 - Review directories created
 
-Note that the plugin's PR-time gate reminder is already active (it ships with Jaqal as a `PreToolUse` hook — no per-project wiring needed) and fires a non-blocking confirmation when you run `gh pr create`.
+Note that the plugin's PR-time gate reminder is already active (it ships with Studious as a `PreToolUse` hook — no per-project wiring needed) and fires a non-blocking confirmation when you run `gh pr create`.
 
 Suggest the user review PRODUCT.md first (product principles and "not building" sections need human judgment), then DESIGN.md (anti-patterns section needs human input), then README.md if one was generated.

--- a/hooks/gate-reminder.sh
+++ b/hooks/gate-reminder.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Jaqal gate reminder — a PreToolUse hook that fires before `gh pr create`.
+# Studious gate reminder — a PreToolUse hook that fires before `gh pr create`.
 #
 # It surfaces a non-blocking confirmation at PR-create time so you don't merge
 # work that skipped the gates. It is unconditional by design: it always asks,
 # it does not try to detect whether a gate actually ran. Answer "yes" if the
 # gates passed or don't apply to this change.
 #
-# Wired into a project's .claude/settings.json by `/jaqal-init`, scoped to
+# Wired into a project's .claude/settings.json by `/studious-init`, scoped to
 # `gh pr create` via the hook's `if` rule. The grep below is defense in depth
 # in case the hook is ever invoked on a broader matcher.
 
@@ -18,7 +18,7 @@ if printf '%s' "$input" | grep -q 'gh pr create'; then
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "ask",
-    "permissionDecisionReason": "Jaqal: opening a PR. Did /gate-audit and /gate-acceptance run on this branch? Proceed if the gates passed or don't apply to this change."
+    "permissionDecisionReason": "Studious: opening a PR. Did /gate-audit and /gate-acceptance run on this branch? Proceed if the gates passed or don't apply to this change."
   }
 }
 JSON

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Jaqal PR-time gate reminder — non-blocking 'ask' before `gh pr create`",
+  "description": "Studious PR-time gate reminder — non-blocking 'ask' before `gh pr create`",
   "hooks": {
     "PreToolUse": [
       {

--- a/skills/acceptance-check-before-merge/SKILL.md
+++ b/skills/acceptance-check-before-merge/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: acceptance-check-before-merge
-description: Use when an implementation is complete and the user is checking whether it actually delivers the intended experience before merge — "did we ship the right thing", "does this deliver", "acceptance check", "is this ready to merge". This routes to Jaqal's acceptance gate. Do NOT use for code review, security or quality audits (that's /gate-audit), or for work still in progress.
+description: Use when an implementation is complete and the user is checking whether it actually delivers the intended experience before merge — "did we ship the right thing", "does this deliver", "acceptance check", "is this ready to merge". This routes to Studious's acceptance gate. Do NOT use for code review, security or quality audits (that's /gate-audit), or for work still in progress.
 ---
 
 # Does the result deliver?
 
-This is the natural-language entry to Jaqal's acceptance gate. The build is done and the user wants to know whether it delivers — route that to the gate.
+This is the natural-language entry to Studious's acceptance gate. The build is done and the user wants to know whether it delivers — route that to the gate.
 
 Invoke the `/gate-acceptance` command. Do not reimplement its logic here — the command owns it. This is a product acceptance review, not code review: it walks every user-facing change, checks error states for human-friendly messaging, regression-tests the critical journeys in PRODUCT.md, and returns **SHIP / FIX AND RE-CHECK / HOLD**.
 

--- a/skills/evaluate-feature-idea/SKILL.md
+++ b/skills/evaluate-feature-idea/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: evaluate-feature-idea
-description: Use when the user is explicitly deciding whether to build a specific feature — asking "should we build X", "is this worth building", "is this a good idea", or weighing a feature idea against what else matters. This routes the decision to Jaqal's should-we-build gate. Do NOT use for general feature brainstorming, for shaping a design once the decision to build is already made, or for prioritizing existing issues (that's /backlog-priorities).
+description: Use when the user is explicitly deciding whether to build a specific feature — asking "should we build X", "is this worth building", "is this a good idea", or weighing a feature idea against what else matters. This routes the decision to Studious's should-we-build gate. Do NOT use for general feature brainstorming, for shaping a design once the decision to build is already made, or for prioritizing existing issues (that's /backlog-priorities).
 ---
 
 # Should we build this?
 
-This is the natural-language entry to Jaqal's first quality gate. The user is questioning whether a feature is worth building — route that to the gate instead of answering from the hip.
+This is the natural-language entry to Studious's first quality gate. The user is questioning whether a feature is worth building — route that to the gate instead of answering from the hip.
 
 Invoke the `/gate-should-we-build` command, passing the feature idea the user described as its argument. Do not reimplement the gate's logic here — the command owns it. It scores the idea against PRODUCT.md (persona fit, priority vs. known problems, scope conflicts, the simplest viable version) and returns **BUILD / BUILD SMALLER / DEFER / DON'T BUILD**.
 

--- a/skills/review-design-before-build/SKILL.md
+++ b/skills/review-design-before-build/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: review-design-before-build
-description: Use when a design doc or spec for a feature is ready and the user is about to start implementing — they want the design checked before build effort goes in. Triggers on "review this design", "is this design sound", "any problems with this design before I build it". This routes to Jaqal's design-review gate. Do NOT use for code review, after implementation has already started, or for evaluating whether to build at all (that's the should-we-build gate).
+description: Use when a design doc or spec for a feature is ready and the user is about to start implementing — they want the design checked before build effort goes in. Triggers on "review this design", "is this design sound", "any problems with this design before I build it". This routes to Studious's design-review gate. Do NOT use for code review, after implementation has already started, or for evaluating whether to build at all (that's the should-we-build gate).
 ---
 
 # Does this design serve users?
 
-This is the natural-language entry to Jaqal's design-review gate. A design is on the table and the user wants it vetted before spending build effort — route that to the gate.
+This is the natural-language entry to Studious's design-review gate. A design is on the table and the user wants it vetted before spending build effort — route that to the gate.
 
 Invoke the `/gate-design-review` command. Do not reimplement its logic here — the command owns it. It product-reviews the most recent design doc against PRODUCT.md and walks the design as the primary persona would experience it, returning **PROCEED TO PLAN / REVISE / RETHINK**.
 


### PR DESCRIPTION
`jaqal` was a throwaway name. **Studious** reflects what the plugin actually is — it reads each piece of work attentively and examines *whether to build it, whether the design serves users, and whether the result holds up*. It sits naturally beside the org's other tools (`dustjacket`, `viva`).

## What changed
- **Plugin name** `jaqal` → `studious` (`plugin.json`) + a rewritten description (the dead "jackal / quality loom" pun is gone).
- **Init command** `/jaqal-init` → `/studious-init` (file renamed).
- **All `docs/jaqal/` paths** → `docs/studious/` (36 refs across the review agents, `deep-review`, `backlog-hygiene`, `studious-init`, `code-auditor`).
- **Install strings, branding, hook message, CONTRIBUTING, PR template, skills** — all `Jaqal`/`jaqal` → `Studious`/`studious`.
- **GitHub repo** `jacquardlabs/jaqal` → `jacquardlabs/studious` (done; GitHub auto-redirects old URLs) + description updated.
- `CHANGELOG` history left under the old name as a record.

## Companion
The `jacquardlabs/marketplace` listing is updated in a separate PR so `/plugin install studious@…` resolves.

## Verification
Zero `jaqal`/`Jaqal` in tracked files except `CHANGELOG`; `plugin.json` + `hooks.json` valid JSON; command file renamed (tracked as a rename).

BREAKING CHANGE: the plugin installs as `studious@…` and the init command is `/studious-init`. Existing installs and `/jaqal-init` muscle memory break; reinstall under the new name.