### PR TITLE
fix: align init's CLAUDE.md tier vocabulary with review output

### DIFF
--- a/commands/studious-init.md
+++ b/commands/studious-init.md
@@ -110,9 +110,9 @@ Language conventions `code-auditor` enforces at `/gate-audit`. Document the rule
 
 ### After each review
 
-1. Fix any **critical** findings before the next feature
-2. File **important** findings as tasks to address this cycle
-3. Track **minor** findings — they compound if ignored
+1. Fix any **Critical** findings before the next feature
+2. File **Important** findings as tasks to address this cycle
+3. Log **Track** findings (lowest tier — revisit next cycle); they compound if ignored
 4. Update context docs if the review surfaced changes:
    - `/deep-review product` updates PRODUCT.md
    - `/deep-review interface` updates DESIGN.md


### PR DESCRIPTION
## What

The CLAUDE.md template that `/studious-init` generates had a tier-vocabulary mismatch in its "After each review" list:

```diff
-1. Fix any **critical** findings before the next feature
-2. File **important** findings as tasks to address this cycle
-3. Track **minor** findings — they compound if ignored
+1. Fix any **Critical** findings before the next feature
+2. File **Important** findings as tasks to address this cycle
+3. Log **Track** findings (lowest tier — revisit next cycle); they compound if ignored
```

## Why

`/deep-review` emits its lowest tier as **Track** (`commands/deep-review.md:63`, `Track (next review cycle)`). No review agent emits "minor" — so a developer following the generated CLAUDE.md was told to track a label that never appears in the output. The list now speaks the same vocabulary as the report it mirrors (the **Grounded in shared context** principle), with an inline gloss so the tier name is self-explanatory to a first-time reader.

Scope is the review path only; item 4's sub-bullets are all `/deep-review` commands. The separate `gate-audit` "Minor" vs review "Track" split (DESIGN.md inconsistency #1) is intentionally left out of this one-line fix.

## How it was found

Dogfooding the gate flow on this repo: `/gate-audit` flagged `minor` not matching the agents' `Track`; the naive fix to `Track-tier` was accurate but opaque, which `/gate-acceptance`'s first-time-user test caught — landing on wording that is both correct and readable.