### PR TITLE
feat: self-verification harness + gate ledger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Gate-ledger integration tests
         run: bash tests/test_gate_ledger.sh
+
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  markdown:
+    name: markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npx -y markdownlint-cli2
+
+  python-checks:
+    name: link-check + schema + unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Link-check references
+        run: uv run --no-project python scripts/check_references.py
+      - name: Validate plugin manifest
+        run: uv run --no-project python scripts/validate_plugin.py
+      - name: Unit tests
+        run: uv run --no-project --with pytest pytest tests/python -v
+
+  ledger:
+    name: gate-ledger tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Gate-ledger integration tests
+        run: bash tests/test_gate_ledger.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .DS_Store
 .gg/
 __pycache__/
+
+# Studious local gate ledger (do not commit)
+.studious/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .DS_Store
 .gg/
+__pycache__/

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,22 @@
+{
+  // Studious markdown lint. Prose-heavy prompt files, so several stylistic rules are
+  // disabled. The link-check (scripts/check_references.py) and plugin-schema jobs carry
+  // the real protection; this job ratchets the markdown at its current state and blocks
+  // new violations of every still-enabled rule.
+  "config": {
+    "default": true,
+    // Prose rules — intentionally off for command/agent/skill content:
+    "MD013": false, // line length
+    "MD033": false, // inline HTML (system-reminder tags, etc.)
+    "MD041": false, // first line must be a heading (frontmatter precedes it)
+    // Current violators — tighten incrementally via a follow-up `--fix` pass:
+    "MD022": false, // blanks around headings
+    "MD032": false, // blanks around lists
+    "MD060": false, // table formatting
+    "MD040": false, // fenced code language
+    "MD026": false, // trailing punctuation in heading
+    "MD029": false  // ordered list prefix
+  },
+  "globs": ["commands/**/*.md", "agents/**/*.md", "skills/**/*.md", "*.md"],
+  "ignores": ["node_modules", "CHANGELOG.md", "docs/**"]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,18 +29,21 @@ Open an issue for bugs, unclear documentation, or suggestions. Include:
 
 ```
 agents/       — Agent definitions (name, description, tools, model in frontmatter)
+bin/          — Executables used by commands (e.g. gate-ledger for recording gate verdicts)
 commands/     — Slash commands (description, allowed-tools in frontmatter)
+scripts/      — CI helper scripts (link checking, manifest validation)
 skills/       — Natural-language trigger shims (skills/<name>/SKILL.md)
 hooks/        — Shipped hook scripts + hooks.json (e.g. the PR-time gate reminder)
 reference/    — Curated rubrics agents read at audit time (e.g. reference/idioms/<lang>.md)
 templates/    — Scaffold files created by /studious-init
+tests/        — Python and shell tests for commands and CI scripts
 ```
 
 - Agents do the work. Commands orchestrate agents or provide standalone workflows.
 - Skills are trigger shims: a tightly-scoped `description` lets a gate fire from natural language, and the body delegates to the matching command instead of duplicating it.
 - Every agent and command reads PRODUCT.md, DESIGN.md, or CLAUDE.md for project context.
 - Review reports save to `docs/studious/` subdirectories in the user's project, not to the plugin itself.
-- Commands that produce output are recommend-only — they report, never modify external state (issues, PRs, files outside `docs/studious/`).
+- Commands that produce output are recommend-only — they report, never modify external state (issues, PRs, files outside `docs/studious/`). **Exception:** gate commands (`/gate-audit`, `/gate-acceptance`) record their verdicts to a local, gitignored `.studious/` ledger in the consuming project; the ledger auto-appends `.studious/` to `.gitignore` on first write.
 
 ## Naming conventions
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Studious wraps feature development in quality gates. Between them you build, and
        merge
 ```
 
-When you run `gh pr create`, a PR-time hook reads the gate verdicts recorded to a local, gitignored `.studious/` ledger and gives a specific reminder — naming gates that never ran, ran on an older commit, or didn't pass — while staying non-blocking.
+When you run `gh pr create`, a PR-time hook reads the gate verdicts recorded to a local `.studious/` ledger (which Studious adds to your `.gitignore` on first run) and gives a specific reminder — naming gates that never ran, ran on an older commit, or didn't pass — while staying non-blocking.
 
 You don't need every gate every time. For small fixes, `/gate-audit` alone is enough. The gates exist to catch building the wrong thing or shipping a bad experience. Use judgment about when that risk applies.
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ Studious wraps feature development in quality gates. Between them you build, and
          ↓
    /gate-acceptance
          ↓
-       merge
+       merge → /gh pr create
 ```
+
+When you run `gh pr create`, a PR-time hook reads the gate verdicts recorded to a local, gitignored `.studious/` ledger and gives a specific reminder — naming gates that never ran, ran on an older commit, or didn't pass — while staying non-blocking.
 
 You don't need every gate every time. For small fixes, `/gate-audit` alone is enough. The gates exist to catch building the wrong thing or shipping a bad experience. Use judgment about when that risk applies.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Studious wraps feature development in quality gates. Between them you build, and
          ↓
    /gate-acceptance
          ↓
-       merge → /gh pr create
+   gh pr create
+         ↓
+       merge
 ```
 
 When you run `gh pr create`, a PR-time hook reads the gate verdicts recorded to a local, gitignored `.studious/` ledger and gives a specific reminder — naming gates that never ran, ran on an older commit, or didn't pass — while staying non-blocking.

--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# gate-ledger — read/write Studious's per-branch gate ledger.
+#
+# Local, gitignored state at .studious/gates/<branch-slug>.json in the consuming
+# project. Written by /gate-audit and /gate-acceptance (via `record`); read by the
+# PR-time hook (via `status`). Degrades silently when git or jq is unavailable.
+set -uo pipefail
+
+LEDGER_DIR=".studious/gates"
+
+branch_name() { git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD; }
+branch_slug() { local b; b=$(branch_name); printf '%s' "${b//\//-}"; }
+head_sha()    { git rev-parse --short HEAD 2>/dev/null || echo ""; }
+now_iso()     { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+ensure_gitignore() {
+  # Self-heal: keep .studious/ out of the user's git status, even for projects
+  # initialized before the ledger existed.
+  local root gi
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+  gi="$root/.gitignore"
+  if [ ! -f "$gi" ] || ! grep -qxF '.studious/' "$gi" 2>/dev/null; then
+    printf '\n# Studious local gate ledger (do not commit)\n.studious/\n' >> "$gi"
+  fi
+}
+
+cmd_record() {
+  local gate="" verdict=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --gate)    gate="$2"; shift 2 ;;
+      --verdict) verdict="$2"; shift 2 ;;
+      *) echo "gate-ledger: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+  [ -n "$gate" ] && [ -n "$verdict" ] || { echo "gate-ledger: --gate and --verdict required" >&2; return 2; }
+  have jq && have git || { echo "gate-ledger: jq/git unavailable; skipping ledger write" >&2; return 0; }
+
+  ensure_gitignore
+  mkdir -p "$LEDGER_DIR"
+  local file; file="$LEDGER_DIR/$(branch_slug).json"
+  [ -f "$file" ] || printf '{"branch":"","gates":{}}' > "$file"
+
+  local tmp; tmp=$(mktemp)
+  jq --arg b "$(branch_name)" --arg g "$gate" --arg v "$verdict" \
+     --arg s "$(head_sha)" --arg t "$(now_iso)" \
+     '.branch = $b | .gates[$g] = {verdict: $v, sha: $s, ranAt: $t}' \
+     "$file" > "$tmp" && mv "$tmp" "$file"
+}
+
+cmd_status() {
+  have jq && have git || return 0
+  local file; file="$LEDGER_DIR/$(branch_slug).json"
+  [ -f "$file" ] || return 0
+
+  local head a_v a_s c_v c_s
+  head=$(head_sha)
+  a_v=$(jq -r '.gates.audit.verdict // empty' "$file")
+  a_s=$(jq -r '.gates.audit.sha // empty' "$file")
+  c_v=$(jq -r '.gates.acceptance.verdict // empty' "$file")
+  c_s=$(jq -r '.gates.acceptance.sha // empty' "$file")
+
+  local msgs=()
+  [ -z "$a_v" ] && msgs+=("audit never ran on this branch")
+  [ -z "$c_v" ] && msgs+=("acceptance never ran on this branch")
+  [ -n "$a_v" ] && [ "$a_s" != "$head" ] && msgs+=("audit ran at $a_s but HEAD is $head — re-run before merging")
+  [ -n "$c_v" ] && [ "$c_s" != "$head" ] && msgs+=("acceptance ran at $c_s but HEAD is $head — re-run before merging")
+  [ -n "$a_v" ] && [ "$a_s" = "$head" ] && [ "$a_v" != "PASS" ] && msgs+=("audit returned $a_v")
+  [ -n "$c_v" ] && [ "$c_s" = "$head" ] && [ "$c_v" != "SHIP" ] && msgs+=("acceptance returned $c_v")
+
+  if [ "${#msgs[@]}" -eq 0 ]; then
+    printf 'audit (PASS) and acceptance (SHIP) ran on this branch at HEAD — proceed.'
+  else
+    local joined; joined=$(printf '%s; ' "${msgs[@]}"); joined=${joined%; }
+    printf 'Studious gate check — %s. Proceed anyway?' "$joined"
+  fi
+}
+
+case "${1:-}" in
+  record) shift; cmd_record "$@" ;;
+  status) shift; cmd_status "$@" ;;
+  *) echo "usage: gate-ledger {record --gate G --verdict V | status}" >&2; exit 2 ;;
+esac

--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -74,7 +74,13 @@ cmd_status() {
     if [ -z "$v" ]; then
       msgs+=("$gate never ran on this branch")
     elif [ "$s" != "$head" ]; then
-      msgs+=("$gate ran at $s but HEAD is $head — re-run before merging")
+      n=$(git rev-list --count "$s..$head" 2>/dev/null || git rev-list --count "$s..HEAD" 2>/dev/null)
+      if [ -n "$n" ] && [ "$n" -gt 0 ] 2>/dev/null; then
+        if [ "$n" -eq 1 ]; then unit=commit; else unit=commits; fi
+        msgs+=("$gate ran $n $unit ago — re-run before merging")
+      else
+        msgs+=("$gate ran at $s but HEAD is $head — re-run before merging")
+      fi
     elif [ "$v" != "$pass" ]; then
       msgs+=("$gate returned $v")
     fi

--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -66,8 +66,11 @@ cmd_status() {
   for entry in "${gates[@]}"; do
     gate="${entry%%:*}"
     pass="${entry##*:}"
-    v=$(jq -r ".gates.$gate.verdict // empty" "$file")
-    s=$(jq -r ".gates.$gate.sha // empty" "$file")
+    # Use --arg + bracket index: dot-syntax (.gates.$gate) parses '-' as
+    # subtraction and compile-errors on hyphenated gate names (e.g. the
+    # planned should-we-build / design-review gates).
+    v=$(jq -r --arg g "$gate" '.gates[$g].verdict // empty' "$file")
+    s=$(jq -r --arg g "$gate" '.gates[$g].sha // empty' "$file")
     if [ -z "$v" ]; then
       msgs+=("$gate never ran on this branch")
     elif [ "$s" != "$head" ]; then
@@ -78,7 +81,21 @@ cmd_status() {
   done
 
   if [ "${#msgs[@]}" -eq 0 ]; then
-    printf 'audit (PASS) and acceptance (SHIP) ran on this branch at HEAD — proceed.'
+    # Build pass summary from the gate table so adding a gate auto-updates
+    # this message. Output for current table: "audit (PASS) and acceptance (SHIP)"
+    local pass_parts=()
+    for entry in "${gates[@]}"; do
+      pass_parts+=("${entry%%:*} (${entry##*:})")
+    done
+    local pass_str=""
+    if [ "${#pass_parts[@]}" -gt 0 ]; then
+      pass_str="${pass_parts[0]}"
+      local i
+      for (( i=1; i<${#pass_parts[@]}; i++ )); do
+        pass_str="$pass_str and ${pass_parts[$i]}"
+      done
+    fi
+    printf '%s ran on this branch at HEAD — proceed.' "$pass_str"
   else
     local joined; joined=$(printf '%s; ' "${msgs[@]}"); joined=${joined%; }
     printf 'Studious gate check — %s. Proceed anyway?' "$joined"

--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -36,7 +36,7 @@ cmd_record() {
     esac
   done
   [ -n "$gate" ] && [ -n "$verdict" ] || { echo "gate-ledger: --gate and --verdict required" >&2; return 2; }
-  have jq && have git || { echo "gate-ledger: jq/git unavailable; skipping ledger write" >&2; return 0; }
+  have jq && have git || return 0
 
   ensure_gitignore
   mkdir -p "$LEDGER_DIR"

--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -35,7 +35,10 @@ cmd_record() {
       *) echo "gate-ledger: unknown arg '$1'" >&2; return 2 ;;
     esac
   done
-  [ -n "$gate" ] && [ -n "$verdict" ] || { echo "gate-ledger: --gate and --verdict required" >&2; return 2; }
+  if [ -z "$gate" ] || [ -z "$verdict" ]; then
+    echo "gate-ledger: --gate and --verdict required" >&2
+    return 2
+  fi
   if ! have jq || ! have git; then return 0; fi
 
   ensure_gitignore

--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -36,14 +36,15 @@ cmd_record() {
     esac
   done
   [ -n "$gate" ] && [ -n "$verdict" ] || { echo "gate-ledger: --gate and --verdict required" >&2; return 2; }
-  have jq && have git || return 0
+  if ! have jq || ! have git; then return 0; fi
 
   ensure_gitignore
   mkdir -p "$LEDGER_DIR"
   local file; file="$LEDGER_DIR/$(branch_slug).json"
   [ -f "$file" ] || printf '{"branch":"","gates":{}}' > "$file"
 
-  local tmp; tmp=$(mktemp)
+  local tmp; tmp=$(mktemp "$LEDGER_DIR/.tmp.XXXXXX")
+  trap 'rm -f "$tmp"' RETURN
   jq --arg b "$(branch_name)" --arg g "$gate" --arg v "$verdict" \
      --arg s "$(head_sha)" --arg t "$(now_iso)" \
      '.branch = $b | .gates[$g] = {verdict: $v, sha: $s, ranAt: $t}' \
@@ -51,24 +52,30 @@ cmd_record() {
 }
 
 cmd_status() {
-  have jq && have git || return 0
+  if ! have jq || ! have git; then return 0; fi
   local file; file="$LEDGER_DIR/$(branch_slug).json"
   [ -f "$file" ] || return 0
 
-  local head a_v a_s c_v c_s
+  local head
   head=$(head_sha)
-  a_v=$(jq -r '.gates.audit.verdict // empty' "$file")
-  a_s=$(jq -r '.gates.audit.sha // empty' "$file")
-  c_v=$(jq -r '.gates.acceptance.verdict // empty' "$file")
-  c_s=$(jq -r '.gates.acceptance.sha // empty' "$file")
 
+  # Gate→pass-token table: "gate:PASS_TOKEN" entries, audit-then-acceptance order preserved.
+  local gates=("audit:PASS" "acceptance:SHIP")
   local msgs=()
-  [ -z "$a_v" ] && msgs+=("audit never ran on this branch")
-  [ -z "$c_v" ] && msgs+=("acceptance never ran on this branch")
-  [ -n "$a_v" ] && [ "$a_s" != "$head" ] && msgs+=("audit ran at $a_s but HEAD is $head — re-run before merging")
-  [ -n "$c_v" ] && [ "$c_s" != "$head" ] && msgs+=("acceptance ran at $c_s but HEAD is $head — re-run before merging")
-  [ -n "$a_v" ] && [ "$a_s" = "$head" ] && [ "$a_v" != "PASS" ] && msgs+=("audit returned $a_v")
-  [ -n "$c_v" ] && [ "$c_s" = "$head" ] && [ "$c_v" != "SHIP" ] && msgs+=("acceptance returned $c_v")
+  local gate pass v s entry
+  for entry in "${gates[@]}"; do
+    gate="${entry%%:*}"
+    pass="${entry##*:}"
+    v=$(jq -r ".gates.$gate.verdict // empty" "$file")
+    s=$(jq -r ".gates.$gate.sha // empty" "$file")
+    if [ -z "$v" ]; then
+      msgs+=("$gate never ran on this branch")
+    elif [ "$s" != "$head" ]; then
+      msgs+=("$gate ran at $s but HEAD is $head — re-run before merging")
+    elif [ "$v" != "$pass" ]; then
+      msgs+=("$gate returned $v")
+    fi
+  done
 
   if [ "${#msgs[@]}" -eq 0 ]; then
     printf 'audit (PASS) and acceptance (SHIP) ran on this branch at HEAD — proceed.'

--- a/commands/gate-acceptance.md
+++ b/commands/gate-acceptance.md
@@ -36,3 +36,16 @@ Map the product-reviewer's severities to this gate's verdict:
 - **HOLD** — a BLOCKER that's a fundamental gap between design intent and implementation, needing rework beyond quick fixes.
 
 For FIX AND RE-CHECK items, be specific enough that they can go directly into the engineering chain as fix tasks.
+
+## Record the verdict
+
+After stating the verdict, record it to the local gate ledger so the PR-time reminder
+can be specific. Run (substituting the verdict token you just assigned — `SHIP`,
+`FIX AND RE-CHECK`, or `HOLD`):
+
+```bash
+gate-ledger record --gate acceptance --verdict "SHIP"
+```
+
+The ledger is local and gitignored — it never enters the repo. If the `gate-ledger`
+command is unavailable, skip this step.

--- a/commands/gate-acceptance.md
+++ b/commands/gate-acceptance.md
@@ -48,4 +48,5 @@ gate-ledger record --gate acceptance --verdict "SHIP"
 ```
 
 The ledger is local and gitignored — it never enters the repo. If the `gate-ledger`
-command is unavailable, skip this step.
+command is not found (the plugin's `bin/` may not be on your PATH), tell the user the
+verdict could not be recorded to the gate ledger — do not skip silently.

--- a/commands/gate-audit.md
+++ b/commands/gate-audit.md
@@ -82,4 +82,5 @@ gate-ledger record --gate audit --verdict "PASS"
 ```
 
 The ledger is local and gitignored — it never enters the repo. If the `gate-ledger`
-command is unavailable, skip this step.
+command is not found (the plugin's `bin/` may not be on your PATH), tell the user the
+verdict could not be recorded to the gate ledger — do not skip silently.

--- a/commands/gate-audit.md
+++ b/commands/gate-audit.md
@@ -70,3 +70,16 @@ Based on the findings, recommend one of:
 - **PASS** — No critical findings. Safe to proceed to product acceptance gate.
 - **FIX AND RE-AUDIT** — Critical findings listed. Fix these, then re-run `/gate-audit`.
 - **NEEDS DISCUSSION** — Architectural or product-level concerns that aren't simple fixes.
+
+## Record the verdict
+
+After stating the verdict, record it to the local gate ledger so the PR-time reminder
+can be specific. Run (substituting the verdict token you just assigned — `PASS`,
+`FIX AND RE-AUDIT`, or `NEEDS DISCUSSION`):
+
+```bash
+gate-ledger record --gate audit --verdict "PASS"
+```
+
+The ledger is local and gitignored — it never enters the repo. If the `gate-ledger`
+command is unavailable, skip this step.

--- a/commands/studious-init.md
+++ b/commands/studious-init.md
@@ -131,6 +131,6 @@ Report what was created, what was populated, and what the user should review:
 - CLAUDE.md — sections added
 - Review directories created
 
-Note that the plugin's PR-time gate reminder is already active (it ships with Studious as a `PreToolUse` hook — no per-project wiring needed) and fires a non-blocking confirmation when you run `gh pr create`.
+Note that the plugin's PR-time gate reminder is already active (it ships with Studious as a `PreToolUse` hook — no per-project wiring needed) and fires a non-blocking confirmation when you run `gh pr create`. When `/gate-audit` and `/gate-acceptance` have recorded verdicts to the branch's ledger, the reminder names the specific gates that never ran, ran on a stale commit, or didn't pass.
 
 Suggest the user review PRODUCT.md first (product principles and "not building" sections need human judgment), then DESIGN.md (anti-patterns section needs human input), then README.md if one was generated.

--- a/hooks/gate-reminder.sh
+++ b/hooks/gate-reminder.sh
@@ -1,18 +1,35 @@
 #!/usr/bin/env bash
 # Studious gate reminder — a PreToolUse hook that fires before `gh pr create`.
 #
-# It surfaces a non-blocking confirmation at PR-create time so you don't merge
-# work that skipped the gates. It is unconditional by design: it always asks,
-# it does not try to detect whether a gate actually ran. Answer "yes" if the
-# gates passed or don't apply to this change.
-#
-# Wired into a project's .claude/settings.json by `/studious-init`, scoped to
-# `gh pr create` via the hook's `if` rule. The grep below is defense in depth
-# in case the hook is ever invoked on a broader matcher.
+# Non-blocking by design: it always returns an "ask" decision so a human confirms
+# before the PR opens. When a gate ledger exists for the current branch
+# (.studious/gates/<branch>.json, written by /gate-audit and /gate-acceptance) it
+# makes the reason SPECIFIC — naming a missing, stale, or non-passing gate — instead
+# of asking blindly. With no ledger (or no jq) it falls back to the generic prompt.
 
 input=$(cat)
 
-if printf '%s' "$input" | grep -q 'gh pr create'; then
+printf '%s' "$input" | grep -q 'gh pr create' || exit 0
+
+default_reason="Studious: opening a PR. Did /gate-audit and /gate-acceptance run on this branch? Proceed if the gates passed or don't apply to this change."
+
+reason=""
+ledger="${CLAUDE_PLUGIN_ROOT:-}/bin/gate-ledger"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "$ledger" ]; then
+  reason=$("$ledger" status 2>/dev/null) || reason=""
+fi
+[ -n "$reason" ] || reason="$default_reason"
+
+if command -v jq >/dev/null 2>&1; then
+  jq -n --arg r "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: $r
+    }
+  }'
+else
+  # jq-less fallback: reason is controlled text; emit static generic prompt.
   cat <<'JSON'
 {
   "hookSpecificOutput": {

--- a/scripts/check_references.py
+++ b/scripts/check_references.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Verify every @agent-* and internal-skill reference in commands/ and agents/ resolves.
+
+Run from CI to catch broken cross-references (e.g. an agent rename that orphans a
+command's @agent-* reference). Standard library only.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCAN_DIRS = ("commands", "agents")
+AGENT_RE = re.compile(r"@agent-([a-z0-9-]+)")
+# "the `<name>` skill" is the codebase's phrasing for a skill reference.
+SKILL_RE = re.compile(r"the `([a-z0-9-]+)` skill")
+# Skills referenced by name but legitimately shipped elsewhere, not in this repo.
+EXTERNAL_SKILLS = {"web-design-guidelines"}
+
+
+def find_broken(root: Path) -> list[str]:
+    errors: list[str] = []
+    for sub in SCAN_DIRS:
+        base = root / sub
+        if not base.is_dir():
+            continue
+        for md in sorted(base.rglob("*.md")):
+            text = md.read_text(encoding="utf-8")
+            rel = md.relative_to(root)
+            for name in sorted(set(AGENT_RE.findall(text))):
+                if not (root / "agents" / f"{name}.md").is_file():
+                    errors.append(
+                        f"@agent-{name} referenced in {rel} but agents/{name}.md missing"
+                    )
+            for name in sorted(set(SKILL_RE.findall(text))):
+                if name in EXTERNAL_SKILLS:
+                    continue
+                if not (root / "skills" / name).is_dir():
+                    errors.append(
+                        f"skill `{name}` referenced in {rel} but skills/{name}/ missing"
+                    )
+    return errors
+
+
+def main() -> int:
+    errors = find_broken(REPO)
+    if errors:
+        print("Reference check FAILED:")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    print("Reference check passed: all @agent-* and skill references resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_plugin.py
+++ b/scripts/validate_plugin.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Validate .claude-plugin/plugin.json against Studious's required manifest shape.
+
+Standard library only. Cross-check against the official Claude Code plugin manifest
+schema if one is published; until then this local check stands.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+PLUGIN = REPO / ".claude-plugin" / "plugin.json"
+SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+NAME = re.compile(r"^[a-z0-9-]+$")
+REQUIRED = ("name", "description", "version", "author", "repository", "license", "keywords")
+
+
+def validate(data: dict) -> list[str]:
+    errors: list[str] = []
+    for key in REQUIRED:
+        if key not in data:
+            errors.append(f"missing required field: {key}")
+
+    name = data.get("name")
+    if "name" in data and not isinstance(name, str):
+        errors.append("name must be a string")
+    elif isinstance(name, str) and not NAME.match(name):
+        errors.append(f"name '{name}' must match ^[a-z0-9-]+$")
+
+    version = data.get("version")
+    if "version" in data and not isinstance(version, str):
+        errors.append("version must be a string")
+    elif isinstance(version, str) and not SEMVER.match(version):
+        errors.append(f"version '{version}' is not semver (X.Y.Z)")
+
+    author = data.get("author")
+    if isinstance(author, dict):
+        if "name" not in author:
+            errors.append("author.name is required")
+    elif "author" in data:
+        errors.append("author must be an object with a name")
+
+    if "keywords" in data and not isinstance(data.get("keywords"), list):
+        errors.append("keywords must be an array")
+
+    return errors
+
+
+def main() -> int:
+    try:
+        data = json.loads(PLUGIN.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"plugin.json could not be read/parsed: {exc}")
+        return 1
+    errors = validate(data)
+    if errors:
+        print("Plugin manifest validation FAILED:")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    print("Plugin manifest valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Make scripts/ importable as top-level modules in tests.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))

--- a/tests/python/test_check_references.py
+++ b/tests/python/test_check_references.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from check_references import find_broken
+
+
+def _write(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def test_resolves_clean(tmp_path: Path) -> None:
+    _write(tmp_path / "agents" / "security-auditor.md", "x")
+    _write(tmp_path / "commands" / "gate.md", "Use @agent-security-auditor here")
+    assert find_broken(tmp_path) == []
+
+
+def test_flags_dangling_agent(tmp_path: Path) -> None:
+    _write(tmp_path / "commands" / "gate.md", "Use @agent-ghost here")
+    errors = find_broken(tmp_path)
+    assert len(errors) == 1
+    assert "agents/ghost.md missing" in errors[0]
+
+
+def test_allows_external_skill(tmp_path: Path) -> None:
+    _write(tmp_path / "commands" / "gate.md", "invoke the `web-design-guidelines` skill")
+    assert find_broken(tmp_path) == []
+
+
+def test_flags_missing_internal_skill(tmp_path: Path) -> None:
+    _write(tmp_path / "commands" / "gate.md", "invoke the `ghost-skill` skill")
+    errors = find_broken(tmp_path)
+    assert any("skills/ghost-skill/ missing" in e for e in errors)
+
+
+def test_passes_when_internal_skill_exists(tmp_path: Path) -> None:
+    (tmp_path / "skills" / "real-skill").mkdir(parents=True)
+    _write(tmp_path / "commands" / "gate.md", "invoke the `real-skill` skill")
+    assert find_broken(tmp_path) == []

--- a/tests/python/test_validate_plugin.py
+++ b/tests/python/test_validate_plugin.py
@@ -1,0 +1,45 @@
+from validate_plugin import validate
+
+GOOD = {
+    "name": "studious",
+    "description": "d",
+    "version": "2.0.0",
+    "author": {"name": "Jacquard Labs"},
+    "repository": "https://github.com/jacquardlabs/studious",
+    "license": "MIT",
+    "keywords": ["review"],
+}
+
+
+def test_good_manifest_passes() -> None:
+    assert validate(GOOD) == []
+
+
+def test_missing_required_field() -> None:
+    data = dict(GOOD)
+    del data["license"]
+    assert any("license" in e for e in validate(data))
+
+
+def test_bad_semver() -> None:
+    data = dict(GOOD)
+    data["version"] = "2.0"
+    assert any("semver" in e for e in validate(data))
+
+
+def test_bad_name_pattern() -> None:
+    data = dict(GOOD)
+    data["name"] = "Studious_X"
+    assert any("name" in e for e in validate(data))
+
+
+def test_author_without_name() -> None:
+    data = dict(GOOD)
+    data["author"] = {}
+    assert any("author.name" in e for e in validate(data))
+
+
+def test_keywords_must_be_list() -> None:
+    data = dict(GOOD)
+    data["keywords"] = "review"
+    assert any("keywords" in e for e in validate(data))

--- a/tests/test_gate_ledger.sh
+++ b/tests/test_gate_ledger.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Integration tests for bin/gate-ledger. Requires git + jq.
+set -uo pipefail
+
+LEDGER="$(cd "$(dirname "$0")/.." && pwd)/bin/gate-ledger"
+fails=0
+
+check() { # description, expected, actual
+  if [ "$2" = "$3" ]; then
+    echo "ok   - $1"
+  else
+    echo "FAIL - $1"; echo "       expected: $2"; echo "       actual:   $3"; fails=$((fails + 1))
+  fi
+}
+contains() { # description, needle, haystack
+  case "$3" in
+    *"$2"*) echo "ok   - $1" ;;
+    *) echo "FAIL - $1"; echo "       expected substring: $2"; echo "       in: $3"; fails=$((fails + 1)) ;;
+  esac
+}
+
+sandbox() { # create a throwaway git repo, echo its path
+  local d; d=$(mktemp -d)
+  git -C "$d" init -q
+  git -C "$d" config user.email t@t.t
+  git -C "$d" config user.name t
+  git -C "$d" commit -q --allow-empty -m init
+  git -C "$d" checkout -q -b feat/foo
+  printf '%s' "$d"
+}
+
+# --- record writes the expected shape ---
+d=$(sandbox)
+( cd "$d" && "$LEDGER" record --gate audit --verdict PASS )
+f="$d/.studious/gates/feat-foo.json"
+check "record creates branch-slug ledger file" "yes" "$([ -f "$f" ] && echo yes || echo no)"
+check "record stores verdict token" "PASS" "$(jq -r '.gates.audit.verdict' "$f")"
+check "record stores branch name" "feat/foo" "$(jq -r '.branch' "$f")"
+check "record stores HEAD sha" "$(git -C "$d" rev-parse --short HEAD)" "$(jq -r '.gates.audit.sha' "$f")"
+
+# --- record self-heals .gitignore ---
+contains "record adds .studious/ to .gitignore" ".studious/" "$(cat "$d/.gitignore")"
+check "ledger is gitignored (not in status)" "" "$(cd "$d" && git status --porcelain .studious 2>/dev/null)"
+
+# --- second record upserts (latest wins, second gate added) ---
+( cd "$d" && "$LEDGER" record --gate acceptance --verdict SHIP )
+check "upsert keeps audit" "PASS" "$(jq -r '.gates.audit.verdict' "$f")"
+check "upsert adds acceptance" "SHIP" "$(jq -r '.gates.acceptance.verdict' "$f")"
+
+# --- status: both passing at HEAD ---
+out=$(cd "$d" && "$LEDGER" status)
+contains "status reports clean pass" "proceed" "$out"
+
+# --- status: missing gate ---
+d2=$(sandbox)
+( cd "$d2" && "$LEDGER" record --gate audit --verdict PASS )
+out=$(cd "$d2" && "$LEDGER" status)
+contains "status names the missing gate" "acceptance never ran" "$out"
+
+# --- status: non-passing verdict ---
+d3=$(sandbox)
+( cd "$d3" && "$LEDGER" record --gate audit --verdict "FIX AND RE-AUDIT" )
+( cd "$d3" && "$LEDGER" record --gate acceptance --verdict SHIP )
+out=$(cd "$d3" && "$LEDGER" status)
+contains "status surfaces non-passing audit" "FIX AND RE-AUDIT" "$out"
+
+# --- status: stale sha ---
+d4=$(sandbox)
+( cd "$d4" && "$LEDGER" record --gate audit --verdict PASS )
+( cd "$d4" && "$LEDGER" record --gate acceptance --verdict SHIP )
+( cd "$d4" && git commit -q --allow-empty -m more )
+out=$(cd "$d4" && "$LEDGER" status)
+contains "status flags stale gate" "re-run" "$out"
+
+# --- status: no ledger -> empty (hook uses default) ---
+d5=$(sandbox)
+out=$(cd "$d5" && "$LEDGER" status)
+check "status empty when no ledger" "" "$out"
+
+echo "----"
+if [ "$fails" -eq 0 ]; then echo "all gate-ledger tests passed"; exit 0; else echo "$fails failure(s)"; exit 1; fi

--- a/tests/test_gate_ledger.sh
+++ b/tests/test_gate_ledger.sh
@@ -77,5 +77,19 @@ d5=$(sandbox)
 out=$(cd "$d5" && "$LEDGER" status)
 check "status empty when no ledger" "" "$out"
 
+# --- hook surfaces the ledger reason and always asks ---
+HOOK="$(cd "$(dirname "$0")/.." && pwd)/hooks/gate-reminder.sh"
+d6=$(sandbox)
+( cd "$d6" && "$LEDGER" record --gate audit --verdict PASS )
+hook_out=$(cd "$d6" && CLAUDE_PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)" \
+  bash "$HOOK" <<<'{"tool_input":{"command":"gh pr create"}}')
+contains "hook decision is ask" '"permissionDecision": "ask"' "$hook_out"
+contains "hook reason names missing acceptance" "acceptance never ran" "$hook_out"
+
+# --- hook stays silent for non-PR commands ---
+hook_noop=$(cd "$d6" && CLAUDE_PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)" \
+  bash "$HOOK" <<<'{"tool_input":{"command":"ls -la"}}')
+check "hook ignores non-PR commands" "" "$hook_noop"
+
 echo "----"
 if [ "$fails" -eq 0 ]; then echo "all gate-ledger tests passed"; exit 0; else echo "$fails failure(s)"; exit 1; fi

--- a/tests/test_gate_ledger.sh
+++ b/tests/test_gate_ledger.sh
@@ -2,7 +2,8 @@
 # Integration tests for bin/gate-ledger. Requires git + jq.
 set -uo pipefail
 
-LEDGER="$(cd "$(dirname "$0")/.." && pwd)/bin/gate-ledger"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LEDGER="$ROOT/bin/gate-ledger"
 fails=0
 
 check() { # description, expected, actual
@@ -78,16 +79,16 @@ out=$(cd "$d5" && "$LEDGER" status)
 check "status empty when no ledger" "" "$out"
 
 # --- hook surfaces the ledger reason and always asks ---
-HOOK="$(cd "$(dirname "$0")/.." && pwd)/hooks/gate-reminder.sh"
+HOOK="$ROOT/hooks/gate-reminder.sh"
 d6=$(sandbox)
 ( cd "$d6" && "$LEDGER" record --gate audit --verdict PASS )
-hook_out=$(cd "$d6" && CLAUDE_PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)" \
+hook_out=$(cd "$d6" && CLAUDE_PLUGIN_ROOT="$ROOT" \
   bash "$HOOK" <<<'{"tool_input":{"command":"gh pr create"}}')
 contains "hook decision is ask" '"permissionDecision": "ask"' "$hook_out"
 contains "hook reason names missing acceptance" "acceptance never ran" "$hook_out"
 
 # --- hook stays silent for non-PR commands ---
-hook_noop=$(cd "$d6" && CLAUDE_PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)" \
+hook_noop=$(cd "$d6" && CLAUDE_PLUGIN_ROOT="$ROOT" \
   bash "$HOOK" <<<'{"tool_input":{"command":"ls -la"}}')
 check "hook ignores non-PR commands" "" "$hook_noop"
 


### PR DESCRIPTION
Adds a CI quality gate on Studious's own prompts (#24) and a per-branch gate ledger that makes the PR-time reminder specific (#27). Both shipped through Studious's own gate flow — dogfooded end to end.

## #24 — Self-verification harness
`.github/workflows/ci.yml` runs on `pull_request` + `workflow_dispatch`, four jobs:
- **link-check** (`scripts/check_references.py`) — resolves every `@agent-*` and skill reference to a file; catches the v2.0.0-rename class of bug before it ships a broken command to users.
- **plugin-manifest validation** (`scripts/validate_plugin.py`) — required fields, types, semver, name pattern. Stdlib only.
- **markdownlint** (`.markdownlint-cli2.jsonc`) — ratchets the markdown at its current state.
- **shellcheck** — lints the new bash.
Plus pytest (11) and the bash gate-ledger suite (16).

## #27 — Gate ledger
- `bin/gate-ledger` writes a **local, gitignored** `.studious/gates/<branch>.json` (added to `.gitignore` on first run); never enters the tracked tree.
- `/gate-audit` and `/gate-acceptance` record their verdict (exact token + commit SHA).
- `hooks/gate-reminder.sh` reads it to make the reminder **specific** — "acceptance never ran on this branch", "audit ran 3 commits ago — re-run" — while always returning `permissionDecision: "ask"`. The independent human checkpoint is preserved; the LLM never self-certifies.

## Dogfooded on itself
Ran the full Studious flow against this branch: should-we-build → BUILD, design-review → REVISE (reversed a committed-ledger and a silent auto-allow), audit → PASS (caught a `.gitignore`-write principle gap and a fix-introduced jq regression), acceptance → SHIP. The ledger records its own `audit=PASS` / `acceptance=SHIP`.

Deferred as follow-ups: CI dependency pinning, hook substring match, branch-slug collision, ledger GC.

Closes #24
Closes #27