### PR TITLE
fix: register all 5 deep-review agents (over-long descriptions) (#48)

### DIFF
--- a/agents/review-interface-health.md
+++ b/agents/review-interface-health.md
@@ -1,6 +1,6 @@
 ---
 name: review-interface-health
-description: Periodic interface health review — cross-surface consistency, design-system adherence, accessibility, and interface code quality across whatever surfaces the product has (web, CLI, TUI, API, plugin, report)
+description: Periodic interface review — cross-surface consistency, design-system, accessibility.
 tools: Read, Glob, Grep, Bash, Write
 model: inherit
 ---

--- a/agents/review-readme.md
+++ b/agents/review-readme.md
@@ -1,6 +1,6 @@
 ---
 name: review-readme
-description: README drift review — compare README against PRODUCT.md and the codebase, flag stale claims, broken commands, and voice drift, propose a diff. Recommend-only, never writes README.
+description: README drift review — flag stale claims, broken commands, and voice drift, propose a fix.
 tools: Read, Glob, Grep, Bash, Write
 model: inherit
 ---


### PR DESCRIPTION
Closes #48.

## Problem

`review-interface-health` (206 chars) and `review-readme` (179 chars) had `description:` frontmatter exceeding the agent-loader cap and silently failed to register as subagent types. The three working review agents sit at 84–89 chars. Result: `/deep-review` (critical journey #3) dispatched only 3 of 5 lanes, with no warning — `Agent type 'review-interface-health' not found`.

## Fix

Shorten both descriptions into the proven-working band:

| Agent | Before | After |
|-------|--------|-------|
| `review-readme` | 179 | 89 |
| `review-interface-health` | 206 | 84 |

The detail trimmed from the frontmatter already lives in each agent's body and in the `deep-review.md` routing table, which is what actually documents each lane. Routing is by `subagent_type` (the `name:` field), not description — so no lane shifted.

## Scope

Minimal by design — gated through `/gate-should-we-build` (verdict: **BUILD**, fix the two descriptions only). The proposed CI guard (assert description length + that every command-referenced agent resolves) is deferred to the **#24** self-quality keystone, where it composes with the rest of that work rather than landing as a one-off.

## Verification

- Both descriptions now in the 84–89 char band, matching the three always-registering agents.
- `/gate-acceptance` → **SHIP** (product-reviewer CLEAN: 3 OBSERVATIONs, 0 BLOCKER/SHOULD FIX).
- Not empirically loaded — the real proof is a fresh `/deep-review` spawning all five lanes. The root-cause length cap is inferred (clean split at 89 vs. 179 chars), not confirmed against Claude Code docs; the fix is safe regardless since it matches the known-good band.