### PR TITLE
feat: backlog-priorities overview mode (no-arg → top-1 per area)

### DIFF
--- a/agents/backlog-priorities.md
+++ b/agents/backlog-priorities.md
@@ -19,7 +19,11 @@ Help the user decide what to work on next by curating a ranked shortlist from op
 1. Read PRODUCT.md and CLAUDE.md for product context. If PRODUCT.md is absent, fall back to README.md as the product proxy and note it.
 2. Fetch all open issues via `gh issue list --json number,title,body,labels,createdAt`.
 3. Read the most recent deep review summary (`docs/studious/health-reviews/*-deep-review-summary.md`) and any individual review reports for cross-referencing severity and findings.
-4. **Determine the intent.** If an intent argument was supplied (tech debt / maintenance / polish / new initiative), proceed with it and skip the prompt. Ask only when it is absent:
+4. **Determine the mode.**
+   - **Deep-dive mode** — intent argument supplied (tech-debt / maintenance / polish / new-initiative): proceed through steps 5–8 for that intent and present the full ranked list. Do not ask the user to pick.
+   - **Overview mode** — no argument: run steps 5–8 for **all 4 intents** using the same issue data fetched in step 2. Pick the top-1 ranked item per intent. Do not ask the user to pick an intent. Present the overview output.
+
+   Intent definitions for filtering (used in steps 6–8 regardless of mode):
    - **Tech debt** — code quality, refactoring, dependency upgrades, test coverage gaps, architectural cleanup
    - **Maintenance** — bug fixes, security patches, performance improvements, accessibility fixes
    - **Polish existing feature** — finish, adjust, or improve something already shipped
@@ -36,7 +40,7 @@ Help the user decide what to work on next by curating a ranked shortlist from op
 
 ## Output
 
-For each ranked item: **rank** · **issue #** + title · **intent-fit** (high/med/low) · **effort** (S/M/L) · **impact** (H/M/L) · **rationale** (1 line naming the dominant factor + the PRODUCT.md principle or review finding it ties to) · **confidence** (Confirmed | Potential).
+**Deep-dive mode** — for each ranked item: **rank** · **issue #** + title · **intent-fit** (high/med/low) · **effort** (S/M/L) · **impact** (H/M/L) · **rationale** (1 line naming the dominant factor + the PRODUCT.md principle or review finding it ties to) · **confidence** (Confirmed | Potential).
 
 ```markdown
 ## Intent: [tech debt | maintenance | polish | new initiative]
@@ -49,6 +53,29 @@ For each ranked item: **rank** · **issue #** + title · **intent-fit** (high/me
 ```
 
 Close with a **What I couldn't assess** line — effort estimates are rough (blast radius is inferred, not measured), and any flagged steering text or close-candidates deferred to hygiene. **Calibrate, don't suppress:** a strong-fit issue ranks even on thin evidence — mark it Potential rather than dropping it. If the backlog is empty or low-signal (no open issues, or none matching the intent), say so plainly and suggest the nearest adjacent intent rather than manufacturing a ranking.
+
+**Overview mode** — one entry per intent area:
+
+```markdown
+## Backlog overview
+
+**Tech debt** — #N [title] · effort: X · impact: Y
+  [1 line: dominant factor]
+
+**Maintenance** — #N [title] · effort: X · impact: Y
+  [1 line: dominant factor]
+
+**Polish** — #N [title] · effort: X · impact: Y
+  [1 line: dominant factor]
+
+**New initiative** — #N [title] · effort: X · impact: Y
+  [1 line: dominant factor]
+
+---
+Run `/backlog-priorities [area]` for a full ranked list.
+```
+
+If a category has no matching issues, write "No matching issues" for that row rather than omitting it or fabricating a pick. Close with the same **What I couldn't assess** note.
 
 ## What this agent does NOT do
 

--- a/commands/backlog-priorities.md
+++ b/commands/backlog-priorities.md
@@ -1,6 +1,6 @@
 ---
 description: Curate a ranked shortlist from open GitHub issues based on your current intent — tech debt, maintenance, polish, or new initiative
-argument-hint: "[tech-debt | maintenance | polish | new-initiative]"
+argument-hint: "[tech-debt | maintenance | polish | new-initiative] (omit for overview)"
 allowed-tools: Read, Glob, Grep, Bash, Task
 ---
 
@@ -14,27 +14,27 @@ Read PRODUCT.md and CLAUDE.md first for product context.
 
 ## Run the analysis
 
-Pass `$ARGUMENTS` to @agent-backlog-priorities as the work-mode intent. If it's empty, the agent asks; if it names an intent, the agent proceeds with it and skips the prompt. Spawn @agent-backlog-priorities to:
+Pass `$ARGUMENTS` to @agent-backlog-priorities as the work-mode intent. If it's empty, the agent runs overview mode (top-1 per area); if it names an intent, the agent runs deep-dive mode for that intent. Spawn @agent-backlog-priorities to:
 
 1. Fetch all open issues via `gh issue list`.
 2. Read the most recent deep review summary and individual review reports.
-3. Resolve the work mode — use the intent from `$ARGUMENTS` if supplied, otherwise ask the user to pick:
-   - **Tech debt** — code quality, refactoring, dependency upgrades, test coverage gaps
-   - **Maintenance** — bug fixes, security patches, performance, accessibility
-   - **Polish existing feature** — finish, adjust, or improve something already shipped
-   - **New initiative** — start something from the roadmap, known problems, or backlog
+3. Resolve the work mode:
+   - **Intent supplied** (`$ARGUMENTS` names one of tech-debt / maintenance / polish / new-initiative) — **deep-dive mode**: filter, score, and present the full ranked list (3-5 items) for that intent.
+   - **No argument** — **overview mode**: pick the top priority from each of the 4 intent areas and present them together in a compact format.
 4. Filter and rank issues by:
    - Severity from review reports (Critical/Important findings rank higher)
    - Product alignment (addresses PRODUCT.md known problems or principles)
    - Unblocking potential (enables other issues or features)
    - Context freshness (code areas with recent commits are cheaper to tackle)
-5. Present top 3-5 with rationale.
+5. Present results in the format for the active mode (see Output).
 
 ## Output
 
-The report presents:
+**Deep-dive mode** — full ranked list with:
 - **Recommended (top pick)** — with 2-3 sentence rationale referencing PRODUCT.md or review findings
 - **Also strong candidates** — 2-3 alternatives with one-line rationale each
 - **Honorable mentions** — additional options worth considering
+
+**Overview mode** — top-1 pick per intent area in compact format, closing with a hint to run `/backlog-priorities [area]` for the full list.
 
 This command is recommend-only. It never starts work, creates branches, or modifies issues.

--- a/docs/superpowers/specs/2026-06-27-backlog-priorities-overview-design.md
+++ b/docs/superpowers/specs/2026-06-27-backlog-priorities-overview-design.md
@@ -1,0 +1,66 @@
+# Design: backlog-priorities overview mode
+
+**Date:** 2026-06-27
+**Status:** Approved
+
+## Problem
+
+`/backlog-priorities` with no argument asks the user to pick a work-mode intent before doing any analysis. This creates a decision bottleneck: the user has to commit to a category before seeing what's in each one. The command is meant to help decide what to work on — making the user decide first defeats the purpose.
+
+## Goal
+
+When invoked with no argument, show the top priority for each of the 4 intent areas in a single compact output. The user reads it, picks one, and starts. If they want the full ranked list for a specific area, they pass the intent as an argument (existing behavior, unchanged).
+
+## Two modes
+
+| Invocation | Mode | Output |
+|---|---|---|
+| `/backlog-priorities` | Overview | Top-1 pick per area (4 items total) |
+| `/backlog-priorities tech-debt` | Deep-dive | Full ranked list (3-5 items) for that area |
+
+## What changes
+
+**`commands/backlog-priorities.md`**
+
+- Update `argument-hint` to make no-arg → overview implicit
+- Step 3 replaces the "ask the user to pick" branch: if intent absent, run overview mode; if present, run deep-dive
+
+**`agents/backlog-priorities.md`**
+
+Step 4 becomes a branch:
+- Intent supplied → existing deep-dive flow, unchanged
+- No intent → **overview mode**: fetch all issues once, apply all 4 intent filters in turn using the same scoring logic (effort S/M/L × impact H/M/L), pick the top-1 item per intent, present in compact format
+
+## Overview output format
+
+```
+## Backlog overview
+
+**Tech debt** — #42 Fix legacy auth middleware · effort: S · impact: H
+  Dominant factor: flagged in last security audit
+
+**Maintenance** — #15 Rate-limit errors on upload · effort: M · impact: H
+  Dominant factor: user-facing bug, hits free tier disproportionately
+
+**Polish** — #38 Search result ranking · effort: M · impact: M
+  Dominant factor: PRODUCT.md polish goal; recent activity in search module
+
+**New initiative** — #7 CSV export · effort: L · impact: H
+  Dominant factor: top roadmap item; unblocks 2 other issues
+
+---
+Run `/backlog-priorities [area]` for a full ranked list.
+```
+
+## What does not change
+
+- Scoring logic (effort, impact, dominant factor, confidence) — identical in both modes; overview just caps at 1 item per intent
+- Deep-dive output format (3-5 ranked items with rationale)
+- Security posture (issue text treated as untrusted data)
+- Read-only constraint (no issue mutation)
+- Fallback behavior (if a category has no matching issues, say so rather than manufacturing a pick)
+
+## Files touched
+
+- `commands/backlog-priorities.md`
+- `agents/backlog-priorities.md`


### PR DESCRIPTION
## Summary

- Adds **overview mode** to `/backlog-priorities`: invoked with no argument, the command now surfaces the top-1 priority for each of the 4 intent areas (tech-debt, maintenance, polish, new-initiative) in a compact format — pick one and start, no prompt required
- Preserves existing **deep-dive mode** unchanged: passing an intent argument (e.g. `/backlog-priorities tech-debt`) still returns the full ranked list for that area
- Scoring logic (effort S/M/L, impact H/M/L, dominant factor, confidence) is identical in both modes — overview just caps output at 1 item per intent
- No-match edge case handled: "No matching issues" rendered rather than fabricating a pick

## Files changed

- `commands/backlog-priorities.md` — argument-hint updated, step 3 rewritten as two-mode branch, output section split into Deep-dive / Overview descriptions
- `agents/backlog-priorities.md` — step 4 rewritten as mode branch with shared intent definitions, Output section gains Overview format with compact per-area template
- `docs/superpowers/specs/2026-06-27-backlog-priorities-overview-design.md` — design spec

## Test plan

- [ ] Full CI suite: markdownlint 0 errors, reference check pass, plugin validator pass, pytest 11/11, gate-ledger tests pass, shellcheck clean
- [ ] Verify no-arg invocation produces 4-item overview (one per area) without asking the user to pick an intent
- [ ] Verify intent-arg invocation (e.g. `tech-debt`) still produces full ranked deep-dive list
- [ ] Verify "No matching issues" renders for a category with no open issues matching that intent