### PR TITLE
fix: resolve gate-ledger via ${CLAUDE_PLUGIN_ROOT} in gate commands

### DIFF
--- a/commands/gate-acceptance.md
+++ b/commands/gate-acceptance.md
@@ -44,9 +44,9 @@ can be specific. Run (substituting the verdict token you just assigned — `SHIP
 `FIX AND RE-CHECK`, or `HOLD`):
 
 ```bash
-gate-ledger record --gate acceptance --verdict "SHIP"
+"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" record --gate acceptance --verdict "SHIP"
 ```
 
-The ledger is local and gitignored — it never enters the repo. If the `gate-ledger`
-command is not found (the plugin's `bin/` may not be on your PATH), tell the user the
-verdict could not be recorded to the gate ledger — do not skip silently.
+The ledger is local and gitignored — it never enters the repo. If `${CLAUDE_PLUGIN_ROOT}`
+did not resolve or the script is not found, tell the user the verdict could not be
+recorded to the gate ledger — do not skip silently.

--- a/commands/gate-audit.md
+++ b/commands/gate-audit.md
@@ -78,9 +78,9 @@ can be specific. Run (substituting the verdict token you just assigned — `PASS
 `FIX AND RE-AUDIT`, or `NEEDS DISCUSSION`):
 
 ```bash
-gate-ledger record --gate audit --verdict "PASS"
+"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" record --gate audit --verdict "PASS"
 ```
 
-The ledger is local and gitignored — it never enters the repo. If the `gate-ledger`
-command is not found (the plugin's `bin/` may not be on your PATH), tell the user the
-verdict could not be recorded to the gate ledger — do not skip silently.
+The ledger is local and gitignored — it never enters the repo. If `${CLAUDE_PLUGIN_ROOT}`
+did not resolve or the script is not found, tell the user the verdict could not be
+recorded to the gate ledger — do not skip silently.

--- a/tests/test_gate_ledger.sh
+++ b/tests/test_gate_ledger.sh
@@ -92,5 +92,11 @@ hook_noop=$(cd "$d6" && CLAUDE_PLUGIN_ROOT="$ROOT" \
   bash "$HOOK" <<<'{"tool_input":{"command":"ls -la"}}')
 check "hook ignores non-PR commands" "" "$hook_noop"
 
+# --- command prompts invoke the ledger via ${CLAUDE_PLUGIN_ROOT}, not a bare name ---
+# Plugins don't add bin/ to PATH, so a bare `gate-ledger ...` in a command prompt
+# is "command not found" at runtime. Every invocation must resolve the script path.
+bare=$(grep -rnE '^[[:space:]]*gate-ledger ' "$ROOT/commands" 2>/dev/null || true)
+check "no command invokes gate-ledger without \${CLAUDE_PLUGIN_ROOT}" "" "$bare"
+
 echo "----"
 if [ "$fails" -eq 0 ]; then echo "all gate-ledger tests passed"; exit 0; else echo "$fails failure(s)"; exit 1; fi


### PR DESCRIPTION
## Problem

`/gate-audit` and `/gate-acceptance` invoked a bare `gate-ledger` to record verdicts, assuming the plugin's `bin/` was on `PATH`. Claude Code does not add a plugin's `bin/` to `PATH`, so the call failed with "command not found" and gate verdicts were never recorded to the ledger — silently, since the failure happens after the verdict is stated.

Every other shipped-file reference in the plugin already resolves through `${CLAUDE_PLUGIN_ROOT}` — the hook (`hooks/gate-reminder.sh:17`) and `commands/studious-init.md`. The two `record` call sites were the only ones assuming `PATH`.

## Fix

- `commands/gate-audit.md`, `commands/gate-acceptance.md` — record via `"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger"`, matching the hook and `studious-init`; updated the fallback note to reference `${CLAUDE_PLUGIN_ROOT}` resolution instead of `PATH`.
- `tests/test_gate_ledger.sh` — added a regression test that fails if any `commands/*.md` invokes `gate-ledger` without the `${CLAUDE_PLUGIN_ROOT}` prefix.

## Verification

- `bash tests/test_gate_ledger.sh` — passes; new assertion both passes with the fix and flags a simulated bare invocation.
- `uv run --no-project python scripts/check_references.py` — passes.
- `shellcheck tests/test_gate_ledger.sh` — clean.