### PR TITLE
fix: validate reference/ paths in check_references.py (#46)

### DIFF
--- a/scripts/check_references.py
+++ b/scripts/check_references.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify every @agent-* and internal-skill reference in commands/ and agents/ resolves.
+"""Verify every @agent-*, internal-skill, and reference/ path in commands/ and agents/ resolves.
 
 Run from CI to catch broken cross-references (e.g. an agent rename that orphans a
 command's @agent-* reference). Standard library only.
@@ -15,6 +15,9 @@ SCAN_DIRS = ("commands", "agents")
 AGENT_RE = re.compile(r"@agent-([a-z0-9-]+)")
 # "the `<name>` skill" is the codebase's phrasing for a skill reference.
 SKILL_RE = re.compile(r"the `([a-z0-9-]+)` skill")
+# Curated rubric paths agents cite, e.g. `reference/security-checklist.md` or the
+# template `reference/idioms/<language>.md`. Angle-bracket placeholders are allowed.
+REFERENCE_RE = re.compile(r"reference/[A-Za-z0-9_./<>-]+\.md")
 # Skills referenced by name but legitimately shipped elsewhere, not in this repo.
 EXTERNAL_SKILLS = {"web-design-guidelines"}
 
@@ -40,6 +43,21 @@ def find_broken(root: Path) -> list[str]:
                     errors.append(
                         f"skill `{name}` referenced in {rel} but skills/{name}/ missing"
                     )
+            for ref in sorted(set(REFERENCE_RE.findall(text))):
+                if "<" in ref:
+                    # Template path (e.g. reference/idioms/<language>.md): the literal
+                    # file can't exist, so validate the deepest placeholder-free dir.
+                    parts: list[str] = []
+                    for part in ref.split("/"):
+                        if "<" in part:
+                            break
+                        parts.append(part)
+                    if not root.joinpath(*parts).is_dir():
+                        errors.append(
+                            f"{ref} referenced in {rel} but {'/'.join(parts)}/ missing"
+                        )
+                elif not (root / ref).is_file():
+                    errors.append(f"{ref} referenced in {rel} but {ref} missing")
     return errors
 
 
@@ -50,7 +68,7 @@ def main() -> int:
         for e in errors:
             print(f"  - {e}")
         return 1
-    print("Reference check passed: all @agent-* and skill references resolve.")
+    print("Reference check passed: all @agent-*, skill, and reference/ paths resolve.")
     return 0
 
 

--- a/tests/python/test_check_references.py
+++ b/tests/python/test_check_references.py
@@ -36,3 +36,38 @@ def test_passes_when_internal_skill_exists(tmp_path: Path) -> None:
     (tmp_path / "skills" / "real-skill").mkdir(parents=True)
     _write(tmp_path / "commands" / "gate.md", "invoke the `real-skill` skill")
     assert find_broken(tmp_path) == []
+
+
+def test_resolves_existing_reference_file(tmp_path: Path) -> None:
+    _write(tmp_path / "reference" / "security-checklist.md", "x")
+    _write(
+        tmp_path / "agents" / "security-auditor.md",
+        "consult `reference/security-checklist.md`",
+    )
+    assert find_broken(tmp_path) == []
+
+
+def test_flags_missing_reference_file(tmp_path: Path) -> None:
+    _write(tmp_path / "agents" / "security-auditor.md", "see `reference/ghost.md`")
+    errors = find_broken(tmp_path)
+    assert any("reference/ghost.md" in e for e in errors)
+
+
+def test_resolves_reference_placeholder_path_via_directory(tmp_path: Path) -> None:
+    # code-auditor cites a template path with a <language> placeholder; the literal
+    # file can't exist, so the containing directory is what gets validated.
+    _write(tmp_path / "reference" / "idioms" / "python.md", "x")
+    _write(
+        tmp_path / "agents" / "code-auditor.md",
+        "apply `reference/idioms/<language>.md`",
+    )
+    assert find_broken(tmp_path) == []
+
+
+def test_flags_reference_placeholder_with_missing_directory(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "agents" / "code-auditor.md",
+        "apply `reference/ghosts/<language>.md`",
+    )
+    errors = find_broken(tmp_path)
+    assert any("reference/ghosts" in e for e in errors)


### PR DESCRIPTION
Closes #46.

`scripts/check_references.py` resolved `@agent-*` and ``the `name` skill`` references but never validated `reference/*.md` paths. After the self-verification harness shipped (#24), agents cite `reference/idioms/<language>.md` (code-auditor) and `reference/security-checklist.md` (security-auditor) — a typo'd or orphaned path passed CI silently, the exact failure mode the checker exists to prevent. Ties to PRODUCT.md known-problem #1 ("the quality tool has no quality gate on itself").

## Change

- Add `REFERENCE_RE` and a resolution loop over `agents/` and `commands/`.
  - **Concrete paths** (`reference/security-checklist.md`) are checked as files.
  - **Template paths** with `<placeholder>` segments (`reference/idioms/<language>.md`) validate the deepest placeholder-free directory — the literal file can't exist.
- Update the module docstring and success message to reflect the added coverage.

## Tests

4 new cases in `tests/python/test_check_references.py`: existing file resolves, missing file flagged, placeholder resolves via directory, placeholder with missing directory flagged. 15/15 pass; the regex matches both live references in the repo and both resolve.

## Out of scope

CI can confirm a reference file exists, not that the subagent actually Reads it at runtime — noted in the issue, not addressed here.