### PR TITLE
fix: harden gate-ledger (CWD resolution, collision detection, GC, write-side signal)

### DIFF
--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -6,14 +6,24 @@
 # PR-time hook (via `status`). Degrades silently when git or jq is unavailable.
 set -uo pipefail
 
-LEDGER_DIR=".studious/gates"
-
 branch_name() { git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD; }
 branch_slug() { local b; b=$(branch_name); printf '%s' "${b//\//-}"; }
 head_sha()    { git rev-parse --short HEAD 2>/dev/null || echo ""; }
 now_iso()     { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
 have() { command -v "$1" >/dev/null 2>&1; }
+
+ledger_dir() {
+  # Anchor to the repo root (same resolution ensure_gitignore uses) so the
+  # ledger location doesn't depend on the caller's CWD. Degrade to a
+  # CWD-relative path if we're not in a git repo at all.
+  local root
+  if root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    printf '%s/.studious/gates' "$root"
+  else
+    printf '.studious/gates'
+  fi
+}
 
 ensure_gitignore() {
   # Self-heal: keep .studious/ out of the user's git status, even for projects
@@ -39,28 +49,41 @@ cmd_record() {
     echo "gate-ledger: --gate and --verdict required" >&2
     return 2
   fi
-  if ! have jq || ! have git; then return 0; fi
+  if ! have jq || ! have git; then
+    echo "gate-ledger: record skipped (jq and git required)" >&2
+    return 0
+  fi
 
   ensure_gitignore
-  mkdir -p "$LEDGER_DIR"
-  local file; file="$LEDGER_DIR/$(branch_slug).json"
-  [ -f "$file" ] || printf '{"branch":"","gates":{}}' > "$file"
+  local dir; dir=$(ledger_dir)
+  mkdir -p "$dir"
+  local file; file="$dir/$(branch_slug).json"
+  [ -f "$file" ] || printf '{"schemaVersion":1,"branch":"","gates":{}}' > "$file"
 
-  local tmp; tmp=$(mktemp "$LEDGER_DIR/.tmp.XXXXXX")
+  local tmp; tmp=$(mktemp "$dir/.tmp.XXXXXX")
   trap 'rm -f "$tmp"' RETURN
   jq --arg b "$(branch_name)" --arg g "$gate" --arg v "$verdict" \
      --arg s "$(head_sha)" --arg t "$(now_iso)" \
-     '.branch = $b | .gates[$g] = {verdict: $v, sha: $s, ranAt: $t}' \
+     '.schemaVersion = (.schemaVersion // 1) | .branch = $b | .gates[$g] = {verdict: $v, sha: $s, ranAt: $t}' \
      "$file" > "$tmp" && mv "$tmp" "$file"
 }
 
 cmd_status() {
   if ! have jq || ! have git; then return 0; fi
-  local file; file="$LEDGER_DIR/$(branch_slug).json"
+  local dir; dir=$(ledger_dir)
+  local file; file="$dir/$(branch_slug).json"
   [ -f "$file" ] || return 0
 
-  local head
+  local head cur_branch stored_branch branch_mismatch
   head=$(head_sha)
+  cur_branch=$(branch_name)
+  stored_branch=$(jq -r '.branch // empty' "$file")
+  branch_mismatch=0
+  # branch_slug() collapses '/' to '-', so e.g. feat/foo and feat-foo share a
+  # ledger file. If the branch recorded in the file isn't the branch we're
+  # actually on, the file was written by the other branch — don't trust its
+  # verdicts, report as if nothing was ever recorded for this branch.
+  [ "$stored_branch" = "$cur_branch" ] || branch_mismatch=1
 
   # Gate→pass-token table: "gate:PASS_TOKEN" entries, audit-then-acceptance order preserved.
   local gates=("audit:PASS" "acceptance:SHIP")
@@ -69,11 +92,16 @@ cmd_status() {
   for entry in "${gates[@]}"; do
     gate="${entry%%:*}"
     pass="${entry##*:}"
-    # Use --arg + bracket index: dot-syntax (.gates.$gate) parses '-' as
-    # subtraction and compile-errors on hyphenated gate names (e.g. the
-    # planned should-we-build / design-review gates).
-    v=$(jq -r --arg g "$gate" '.gates[$g].verdict // empty' "$file")
-    s=$(jq -r --arg g "$gate" '.gates[$g].sha // empty' "$file")
+    if [ "$branch_mismatch" -eq 1 ]; then
+      v=""
+      s=""
+    else
+      # Use --arg + bracket index: dot-syntax (.gates.$gate) parses '-' as
+      # subtraction and compile-errors on hyphenated gate names (e.g. the
+      # planned should-we-build / design-review gates).
+      v=$(jq -r --arg g "$gate" '.gates[$g].verdict // empty' "$file")
+      s=$(jq -r --arg g "$gate" '.gates[$g].sha // empty' "$file")
+    fi
     if [ -z "$v" ]; then
       msgs+=("$gate never ran on this branch")
     elif [ "$s" != "$head" ]; then
@@ -111,8 +139,24 @@ cmd_status() {
   fi
 }
 
+cmd_gc() {
+  if ! have jq || ! have git; then return 0; fi
+  local dir; dir=$(ledger_dir)
+  local f branch
+  for f in "$dir"/*.json; do
+    [ -e "$f" ] || continue
+    branch=$(jq -r '.branch // empty' "$f" 2>/dev/null)
+    [ -n "$branch" ] || continue
+    if ! git rev-parse --verify --quiet "refs/heads/$branch" >/dev/null 2>&1; then
+      rm -f "$f"
+      printf 'removed stale ledger: %s (branch %s no longer exists)\n' "$(basename "$f")" "$branch"
+    fi
+  done
+}
+
 case "${1:-}" in
   record) shift; cmd_record "$@" ;;
   status) shift; cmd_status "$@" ;;
-  *) echo "usage: gate-ledger {record --gate G --verdict V | status}" >&2; exit 2 ;;
+  gc)     shift; cmd_gc "$@" ;;
+  *) echo "usage: gate-ledger {record --gate G --verdict V | status | gc}" >&2; exit 2 ;;
 esac

--- a/tests/test_gate_ledger.sh
+++ b/tests/test_gate_ledger.sh
@@ -98,5 +98,58 @@ check "hook ignores non-PR commands" "" "$hook_noop"
 bare=$(grep -rnE '^[[:space:]]*gate-ledger ' "$ROOT/commands" 2>/dev/null || true)
 check "no command invokes gate-ledger without \${CLAUDE_PLUGIN_ROOT}" "" "$bare"
 
+# --- record from a subdirectory still anchors the ledger at the repo root (#55) ---
+d7=$(sandbox)
+mkdir -p "$d7/sub/dir"
+( cd "$d7/sub/dir" && "$LEDGER" record --gate audit --verdict PASS )
+check "record from a subdirectory writes the ledger at the repo root" "yes" \
+  "$([ -f "$d7/.studious/gates/feat-foo.json" ] && echo yes || echo no)"
+check "record from a subdirectory does not write under the subdirectory" "no" \
+  "$([ -f "$d7/sub/dir/.studious/gates/feat-foo.json" ] && echo yes || echo no)"
+out=$(cd "$d7" && "$LEDGER" status)
+contains "status run from repo root sees a ledger written from a subdirectory" "acceptance never ran" "$out"
+
+# --- record stamps schemaVersion, and preserves it on upsert (#55) ---
+f7="$d7/.studious/gates/feat-foo.json"
+check "record sets schemaVersion on the new file" "1" "$(jq -r '.schemaVersion' "$f7")"
+( cd "$d7/sub/dir" && "$LEDGER" record --gate acceptance --verdict SHIP )
+check "record preserves schemaVersion on upsert" "1" "$(jq -r '.schemaVersion' "$f7")"
+
+# --- status treats a branch-slug collision as no record, not a stale/wrong verdict (#41) ---
+d9=$(sandbox)
+( cd "$d9" && "$LEDGER" record --gate audit --verdict PASS )
+( cd "$d9" && "$LEDGER" record --gate acceptance --verdict SHIP )
+f9="$d9/.studious/gates/feat-foo.json"
+# Simulate the collision: feat/foo and feat-foo both slug to feat-foo.json. Rewrite
+# the stored .branch to a different branch than the one we're actually on.
+tmp9=$(mktemp)
+jq '.branch = "feat-foo"' "$f9" > "$tmp9" && mv "$tmp9" "$f9"
+out=$(cd "$d9" && "$LEDGER" status)
+contains "branch-slug collision reports audit as never ran" "audit never ran on this branch" "$out"
+contains "branch-slug collision reports acceptance as never ran" "acceptance never ran on this branch" "$out"
+
+# --- gc prunes ledgers for branches that no longer exist, keeps live ones (#42) ---
+d10=$(sandbox)
+( cd "$d10" && "$LEDGER" record --gate audit --verdict PASS )
+stale10="$d10/.studious/gates/ghost-branch.json"
+printf '{"schemaVersion":1,"branch":"ghost/branch","gates":{}}' > "$stale10"
+out=$(cd "$d10" && "$LEDGER" gc)
+contains "gc reports the removed stale ledger" "removed stale ledger: ghost-branch.json (branch ghost/branch no longer exists)" "$out"
+check "gc deletes the stale ledger file" "no" "$([ -f "$stale10" ] && echo yes || echo no)"
+check "gc keeps the ledger for a live branch" "yes" \
+  "$([ -f "$d10/.studious/gates/feat-foo.json" ] && echo yes || echo no)"
+
+# --- record signals on stderr (but still returns 0) when jq is unavailable (#43) ---
+d11=$(sandbox)
+fakebin=$(mktemp -d)
+for tool in bash git date mktemp grep mv mkdir rm cat; do
+  src=$(command -v "$tool" 2>/dev/null) || continue
+  ln -sf "$src" "$fakebin/$tool"
+done
+stderr11=$(cd "$d11" && PATH="$fakebin" "$LEDGER" record --gate audit --verdict PASS 2>&1 1>/dev/null)
+contains "record signals on stderr when jq is unavailable" "gate-ledger: record skipped (jq and git required)" "$stderr11"
+check "record does not create a ledger file when jq is unavailable" "no" \
+  "$([ -f "$d11/.studious/gates/feat-foo.json" ] && echo yes || echo no)"
+
 echo "----"
 if [ "$fails" -eq 0 ]; then echo "all gate-ledger tests passed"; exit 0; else echo "$fails failure(s)"; exit 1; fi


### PR DESCRIPTION
Bundles 4 related gate-ledger hardening issues surfaced by the 2026-07-01 deep review / #24-#27 dogfood, per the issue author's own suggestion to land them together since the fixes overlap in the same functions.

- Fixes #55 — anchor LEDGER_DIR to the git repo root instead of CWD; add schemaVersion to the record JSON
- Fixes #41 — detect branch-slug collisions on read by validating the stored `.branch` field
- Fixes #42 — add a `gc` subcommand to prune ledger files for deleted branches
- Fixes #43 — signal on stderr when a record write is skipped due to missing jq/git

## Test plan
- [x] `bash tests/test_gate_ledger.sh`
- [x] `shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh`