### PR TITLE
docs: ship reference/idioms go/rust/ruby files to match code-auditor's claimed language coverage

### DIFF
--- a/agents/code-auditor.md
+++ b/agents/code-auditor.md
@@ -68,6 +68,7 @@ Escalate an egregious cross-lane issue you stumble on — e.g. an obvious inject
 - Code that contradicts a documented CLAUDE.md convention is a Consistency finding
 
 ### Idiomatic style
+**Invariant: the `reference/idioms/` file set must track the linter list below** — adding a language's linter here without shipping its `reference/idioms/<language>.md` reopens the same coverage gap.
 CLAUDE.md's documented conventions are authoritative and override everything below. Then:
 - Detect the changed files' language(s) by extension.
 - **Run the language's idiom linter read-only** if one is configured or available, and fold its findings in. Never pass a fix/`--fix` flag — this audit reports, it doesn't modify. Examples: Python — `ruff check --select C4,SIM,PERF,B,RUF,PIE`; JS/TS — `eslint` or `biome check`; Go — `golangci-lint run`; Rust — `cargo clippy`; Ruby — `rubocop`. If no linter is available, say so and recommend adding one.

--- a/reference/idioms/go.md
+++ b/reference/idioms/go.md
@@ -1,0 +1,40 @@
+# Go idioms — judgment layer
+
+The linter (`golangci-lint run`) catches the mechanical cases. This rubric is for the structural recognitions a linter misses — where the code works but a Go developer would write it differently. CLAUDE.md conventions override anything here.
+
+## Errors
+
+- Returning an error without context → wrap it: `fmt.Errorf("doing x: %w", err)`.
+- Comparing errors with `==` or string matching → `errors.Is`/`errors.As` against a sentinel or typed error.
+- `_ = err` discarding an error with no comment explaining why it's safe to ignore.
+- Ad-hoc error strings scattered across call sites → a package-level sentinel (`var ErrNotFound = errors.New(...)`) or typed error the caller can match on.
+
+## Interfaces & structs
+
+- A struct returned where only behavior is needed → accept interfaces, return concrete structs.
+- Interfaces defined by the producer package "just in case" → define them at the point of use, kept to 1-2 methods.
+- Getter/setter methods for exported fields with no invariant to protect — just export the field.
+
+## Control flow
+
+- Nested `if` pyramids → early `return`/`continue` guard clauses.
+- `if/else if/else` chains keying off the same value → `switch`.
+- Naked returns in a function longer than a few lines — name the outputs or return explicitly.
+
+## Concurrency
+
+- A goroutine started with no way to wait for it or cancel it (no `WaitGroup`, no `context`) — leak risk.
+- Shared state mutated from more than one goroutine without a mutex or channel.
+- `context.Context` stored in a struct field instead of threaded as the first parameter.
+
+## Data & slices
+
+- Repeated `append` growing a slice whose final size is known upfront → `make([]T, 0, n)`.
+- A constructor required to produce a usable value when the zero value could do the job.
+- `nil` vs empty slice used inconsistently for the same meaning — pick one and document it if it affects JSON output.
+
+## Traps
+
+- `defer` inside a loop — the deferred calls pile up until the function returns, not the loop iteration.
+- Shadowing `err` in a nested scope (`if err := ...; err != nil`) that silently drops the outer error.
+- `panic` for an error the caller could reasonably recover from — return an `error` instead.

--- a/reference/idioms/ruby.md
+++ b/reference/idioms/ruby.md
@@ -1,0 +1,38 @@
+# Ruby idioms — judgment layer
+
+The linter (`rubocop`) catches the mechanical cases. This rubric is for the structural recognitions a linter misses — where the code works but a Ruby developer would write it differently. CLAUDE.md conventions override anything here.
+
+## Loops that aren't loops
+
+- `for`/`each` building up an accumulator → `map`/`select`/`reject`/`reduce`.
+- `n.times` building an array by pushing → `Array.new(n) { ... }` or `map`.
+- Nested `each` flattening results by hand → `flat_map`.
+
+## Blocks & symbols
+
+- A `{ |x| x.method }` block that only calls one method on the element → `&:method` shorthand.
+- `do...end` used for a value-returning one-liner, or `{}` used for a multi-line side-effecting block — swap to match the convention (`{}` for values, `do...end` for effects).
+
+## Control flow
+
+- `if/else` whose branches are only `true`/`false` → return the boolean expression itself.
+- `unless` with an `else` branch → invert the condition and use `if`.
+- Nested `if` pyramids → guard clauses with `return`/`next`.
+
+## Structured data
+
+- Hash access guarded by manual `nil` checks → `dig` or `fetch` with a default.
+- Parallel arrays or hashes passed around together → a `Struct.new` or small class.
+- More than three positional arguments → keyword arguments.
+
+## Objects & methods
+
+- Hand-written getter/setter methods with no extra logic → `attr_accessor`/`attr_reader`/`attr_writer`.
+- Explicit `x == nil` / `nil == x` → `x.nil?`.
+- `respond_to?` guarding a call that could just be made and rescued — prefer duck typing over pre-checking.
+
+## Traps
+
+- `rescue => e` (or a bare `rescue`) swallowing `StandardError` broadly enough to hide real bugs.
+- Mutating a method argument in place (`arr.push!`-style side effects on a passed-in object) where a pure transform is expected.
+- `define_method`/`method_missing` reached for where a handful of explicit methods would be clearer.

--- a/reference/idioms/rust.md
+++ b/reference/idioms/rust.md
@@ -1,0 +1,38 @@
+# Rust idioms — judgment layer
+
+The linter (`cargo clippy`) catches the mechanical cases. This rubric is for the structural recognitions a linter misses — where the code works but a Rust developer would write it differently. CLAUDE.md conventions override anything here.
+
+## Ownership & borrowing
+
+- `.clone()` reached for to dodge a borrow-checker error, rather than restructuring or borrowing.
+- `&String`/`&Vec<T>` parameters where `&str`/`&[T]` would accept both owned and borrowed callers.
+- Explicit lifetime annotations where lifetime elision would already compile.
+
+## Iterators
+
+- A `for` loop pushing into a `Vec` → `.collect()` over `map`/`filter`/`fold`.
+- Manual index loops (`for i in 0..v.len()`) → `.iter().enumerate()` or `.zip()`.
+- A chain of `.unwrap()` after `.find()`/`.filter()` where `.and_then()`/`.ok_or()` reads cleaner and stays lazy.
+
+## Error handling
+
+- `.unwrap()`/`.expect()` on a path that can fail at runtime, outside tests/prototypes → propagate with `?`.
+- Stringly-typed errors (`Err("something failed".to_string())`) → `thiserror` for libraries, `anyhow` for applications, or a custom enum.
+- `panic!` used for a condition the caller could recover from.
+
+## Types & structure
+
+- Boolean flags standing in for mutually exclusive states → an `enum` with the states as variants.
+- `Option<Option<T>>` or deeply nested `Option`/`Result` → flatten with `?`, `.flatten()`, or `.and_then()`.
+- A raw `String`/`u64` used as an ID or unit-bearing value across the codebase → a newtype wrapper.
+
+## Traits & generics
+
+- A generic bound (`fn f<T: Trait>(x: T)`) where the caller never needs to name `T` → `impl Trait` in argument position.
+- Hand-written `Clone`/`Debug`/`PartialEq` where `#[derive(...)]` would produce the same semantics.
+
+## Traps
+
+- Repeated `.clone()` calls are a signal to reconsider ownership, not a fix to apply and move on.
+- `match` arms that discard bound data with `_` where the caller likely needed it.
+- A `Mutex`/`RwLock` guard held across an `.await` point — blocks the executor instead of just the critical section.


### PR DESCRIPTION
Fixes #60

code-auditor.md names linters for Python, JS/TS, Go, Rust, and Ruby, but `reference/idioms/` only shipped `python.md` and `typescript.md`. Ships the three missing rubrics and adds a one-line invariant note to code-auditor.md so the idiom-file set and linter list stay in sync.

- `reference/idioms/go.md` — judgment layer for `golangci-lint run`
- `reference/idioms/rust.md` — judgment layer for `cargo clippy`
- `reference/idioms/ruby.md` — judgment layer for `rubocop`
- `agents/code-auditor.md` — invariant note above the linter/idiom-file list

## Test plan

- [x] `uv run --no-project python scripts/check_references.py`
- [x] `npx -y markdownlint-cli2`