### PR TITLE
[Proposed - needs design review] feat: persist deep-review metrics for trend tracking

### DIFF
--- a/agents/review-codebase-health.md
+++ b/agents/review-codebase-health.md
@@ -80,13 +80,11 @@ Structure the report:
 **Critical**, **Important**, **Track** — findings grouped by tier.
 **Metrics snapshot** — the numbers below. These key names are a **contract with `/deep-review`'s dashboard** (`commands/deep-review.md`) — do not rename them:
 
-- Lines of code
 - Test coverage
 - TODO/FIXME count
 - Outdated deps
 - Known vulnerabilities
 - Largest file (lines)
-- Deepest dependency chain
 - Coupling / circular-dependency count
 - Dead-code symbol count
 - Endpoint-convention-violation count

--- a/commands/deep-review.md
+++ b/commands/deep-review.md
@@ -79,13 +79,11 @@ Pull the metrics snapshots from the codebase health and interface health reports
 
 | Metric | Value | Trend vs last review | Source |
 |--------|-------|---------------------|--------|
-| Lines of code | — | — | codebase health |
 | Test coverage | — | — | codebase health |
 | TODO/FIXME count | — | — | codebase health |
 | Outdated deps | — | — | codebase health |
 | Known vulnerabilities | — | — | codebase health |
 | Largest file (lines) | — | — | codebase health |
-| Deepest dependency chain | — | — | codebase health |
 | Coupling / circular-dependency count | — | — | codebase health |
 | Dead-code symbol count | — | — | codebase health |
 | Endpoint-convention-violation count | — | — | codebase health |
@@ -97,6 +95,12 @@ Pull the metrics snapshots from the codebase health and interface health reports
 
 Every row maps to a metric one of the two health reports actually emits — don't add rows no agent produces.
 
-If previous review reports exist in the `docs/studious/` subdirectories, compare against the most recent one and fill in the trend column. Otherwise mark as "baseline".
+#### Metrics history
+
+Read `docs/studious/reviews/metrics.jsonl` (in the consuming project). Each line is one prior run: `{"date": "YYYY-MM-DD", "metrics": {"<row's Metric column text>": "<value>", ...}}`.
+
+- If the file exists, take its **last line** as the previous run and diff each dashboard row's value against that row's key in `metrics.metrics` to fill the Trend column (up/down/flat, or "new" for a row that key wasn't present for). If the file doesn't exist, mark every row "baseline".
+- After the table above is finalized, **append** one new line to `docs/studious/reviews/metrics.jsonl` (create the file and the `docs/studious/reviews/` directory if they don't exist) with today's date and this run's dashboard values, keyed by the exact Metric column text — same key used for the read, so the next run's diff lines up. Never rewrite or reorder existing lines; append-only.
+- This history file replaces re-reading prior prose reports for the trend column; the prose reports still exist for narrative context but are no longer the diff source.
 
 Save the master summary to `docs/studious/health-reviews/YYYY-MM-DD-deep-review-summary.md`.


### PR DESCRIPTION
Proposed approach — needs design review.

Implements the smallest version of #28: after each full-sweep `/deep-review` run, append one JSON Lines row to `docs/studious/reviews/metrics.jsonl` in the *consuming* project (matching CLAUDE.md's "reviews write to the consuming project, not here" invariant). The master-summary step diffs the new dashboard values against the previous row instead of re-reading the previous prose report.

Row shape: `{"date": "YYYY-MM-DD", "metrics": {"<Metric column text>": "<value>", ...}}` — keyed by the dashboard table's own `Metric` column text, so there's no separate naming scheme to drift out of sync with the table.

Also fixes the pre-existing contract bug flagged in the issue comment before freezing the schema: `agents/review-codebase-health.md` declared **Lines of code** and **Deepest dependency chain** as contract keys ("do not rename them"), but no check in that agent computes either, so those two dashboard rows were permanently blank. Dropped both keys and their dashboard rows rather than adding new checks (BUILD SMALLER, per the issue's gate verdict) — every remaining row now maps to a metric one of the two health reports actually emits.

Scoped to full-sweep only: single-area runs skip Phase 2 (no master summary), so they don't touch `metrics.jsonl` — a partial row would poison the trend diff.

Note for reviewers: `review-interface-health.md` has no equivalent explicit "contract, do not rename" language, but its five dashboard rows (Surfaces reviewed, Cross-surface inconsistencies, Design system deviations, Web component/CSS, Web accessibility) do line up with what its Metrics snapshot section actually emits — checked, not changed.

Fixes #28

## Test plan
- [x] `uv run --no-project python scripts/check_references.py`
- [x] `npx -y markdownlint-cli2`