### PR TITLE
ci: pin dependencies, add push trigger, add macOS ledger runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -9,18 +11,18 @@ jobs:
     name: markdownlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
-      - run: npx -y markdownlint-cli2
+      - run: npx -y markdownlint-cli2@0.23.0
 
   python-checks:
     name: link-check + schema + unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
       - name: Link-check references
         run: uv run --no-project python scripts/check_references.py
       - name: Validate plugin manifest
@@ -30,9 +32,22 @@ jobs:
 
   ledger:
     name: gate-ledger tests
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Ensure git and jq are available
+        run: |
+          command -v git >/dev/null || { echo "git is required but not found" >&2; exit 1; }
+          if ! command -v jq >/dev/null; then
+            if [ "$RUNNER_OS" = "macOS" ]; then
+              brew install jq
+            else
+              sudo apt-get update && sudo apt-get install -y jq
+            fi
+          fi
       - name: Gate-ledger integration tests
         run: bash tests/test_gate_ledger.sh
 
@@ -40,5 +55,11 @@ jobs:
     name: shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Install shellcheck 0.11.0
+        run: |
+          curl -fsSL -o /tmp/shellcheck.tar.xz \
+            https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+          sudo install /tmp/shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
       - run: shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh


### PR DESCRIPTION
Fixes #39, Fixes #56, Fixes #57

## Changes

- Pin `actions/checkout`, `actions/setup-node`, `astral-sh/setup-uv` to commit SHAs (looked up via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`), keeping the same major/minor versions already in use.
- Pin `markdownlint-cli2` to `0.23.0` and `shellcheck` to `0.11.0` (both matching the versions installed locally) to close the local/CI drift that broke PR #38.
- Add `push: branches: [main]` to the `on:` trigger block so a direct push to `main` runs CI before `semantic-release` ships it.
- Add a `macos-latest` leg to the `ledger` job's matrix (alongside `ubuntu-latest`), with an explicit step that checks for `git`/`jq` and installs `jq` if missing, instead of assuming the runner image ships it.

## Test plan

- [x] `bash tests/test_gate_ledger.sh` — all 17 tests pass (run locally on macOS/Darwin, which is the same BSD/bash-3.2 surface the new `macos-latest` matrix leg exercises)
- [x] `shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh` — clean, exit 0
- [x] `uv run --no-project python scripts/check_references.py` — passed, all references resolve
- [x] `uv run --no-project --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses without error
- [x] Manually verified the `shellcheck-v0.11.0.linux.x86_64.tar.xz` release asset extracts to `shellcheck-v0.11.0/shellcheck`, matching the install path used in the new shellcheck job step