### PR TITLE
[Proposed - needs design review] feat: define the design-doc contract gate-design-review expects

### DIFF
--- a/commands/gate-design-review.md
+++ b/commands/gate-design-review.md
@@ -11,8 +11,9 @@ Then find the design doc or spec under review:
 - Check the branch's added/changed docs: `git diff --name-only $(git merge-base HEAD origin/main)...HEAD` and look for design/spec Markdown (e.g. under `docs/`, `specs/`, `design/`).
 - If nothing turns up there, take the most recently modified Markdown under those locations.
 - If still ambiguous or there are several candidates, ask the user which doc to review rather than guessing.
+- If no candidate doc exists at all, say so and point at `templates/design-doc.md` as a starting scaffold rather than guessing at content that isn't there.
 
-Pass the resolved doc path explicitly into the product review below.
+Pass the resolved doc path explicitly into the product review below. The doc is expected to satisfy the contract in `reference/design-doc-contract.md` — a section the contract requires but the doc omits is itself a finding, not something to infer.
 
 ## Part 1 — Product review
 

--- a/reference/design-doc-contract.md
+++ b/reference/design-doc-contract.md
@@ -1,0 +1,22 @@
+# Design-doc contract — lookup data
+
+`/gate-design-review` reviews a design doc that nothing in Studious produces — authoring stays in Superpowers (per [#29](https://github.com/jacquardlabs/studious/issues/29)). This file names the interface between the two: a Superpowers plan/design-doc output, or any hand-written spec, satisfies this contract if @agent-product-reviewer's design-mode review (`agents/product-reviewer.md`) can answer its six questions from the doc's text alone. It is the Studious↔Superpowers handshake, not a new authoring tool.
+
+A doc missing a required section isn't a style nit — it's a finding. The gate cannot evaluate a question it has no evidence for, so an empty or missing section maps to a **REVISE** (fixable gap) or, if the missing evidence is problem validity or scope, a **RETHINK** (see `commands/gate-design-review.md` Part 3).
+
+## Required sections
+
+| Section | Answers | What "good" looks like |
+|---------|---------|------------------------|
+| Problem & persona | Problem validity (Q1) | Names a persona and job-to-be-done from PRODUCT.md verbatim, not a paraphrase invented for this doc. States the problem the persona has today without this feature. |
+| Proposed design | Principle alignment (Q2), user mental model (Q6) | Describes the design at the level a user would experience it — what changes, what stays the same — not an implementation plan. Explicit about which PRODUCT.md principles it leans on. |
+| User journey | Journey impact (Q3) | Walks the primary persona through the feature end to end, referencing the specific critical user journey in PRODUCT.md it touches. Calls out any step that changes an existing journey. |
+| Out of scope | Scope creep (Q4) | Lists what this design deliberately excludes, especially anything adjacent that a reader might assume is included. Cross-checks PRODUCT.md's "What we're NOT building." |
+| Alternatives considered | Simplicity (Q5) | At least one simpler alternative and why it was rejected. A doc with no alternatives reads as the first idea, not the best one — the reviewer cannot judge "50% simpler" against nothing. |
+| Open questions | (informs calibration, not a numbered check) | Unresolved decisions flagged explicitly rather than papered over. An empty section is fine; a missing one hides risk. |
+
+Sections may carry any heading text as long as the content answers the mapped question — the gate reads for substance, not exact titles. `templates/design-doc.md` uses the exact section names above as the default scaffold.
+
+## Non-requirements
+
+Keep implementation detail out of the doc this contract governs — code structure, file layout, and task breakdown belong to Superpowers' planning step, not the design doc `/gate-design-review` reads. A design doc that reads like an implementation plan makes Q6 (user mental model) and Q2 (principle alignment) harder to answer, not easier.

--- a/templates/design-doc.md
+++ b/templates/design-doc.md
@@ -1,0 +1,36 @@
+# Design: <!-- feature name -->
+
+<!-- Stub scaffold for a design doc — the artifact /gate-design-review reviews before
+     implementation begins. The required sections and what "good" looks like for each
+     are defined in reference/design-doc-contract.md; this file is just the shape.
+     Actual authoring (fleshing this out, turning it into an implementation plan) happens
+     in Superpowers — this is a starting point, not a tool. Delete this comment block
+     once filled in. -->
+
+## Problem & persona
+
+<!-- Which named persona from PRODUCT.md has this problem, and what job are they trying
+     to get done? Quote PRODUCT.md rather than paraphrasing. -->
+
+## Proposed design
+
+<!-- Describe the design at the level a user would experience it — what changes, what
+     stays the same. Note which PRODUCT.md principles it leans on. -->
+
+## User journey
+
+<!-- Walk the persona through the feature end to end. Which critical user journey from
+     PRODUCT.md does this touch, and does any step change? -->
+
+## Out of scope
+
+<!-- What this design deliberately excludes, especially anything adjacent a reader might
+     assume is included. Cross-check PRODUCT.md's "What we're NOT building." -->
+
+## Alternatives considered
+
+<!-- At least one simpler alternative and why it was rejected. -->
+
+## Open questions
+
+<!-- Unresolved decisions. Leave empty if there are none — don't omit the section. -->


### PR DESCRIPTION
Proposed approach — needs design review.

Closes the hole named in #29: `/gate-design-review` reviews a design doc that nothing in Studious produces, and the handoff to/from Superpowers was implicit. This defines the contract without building any authoring tooling — authoring stays in Superpowers per the issue.

## What this adds

- `reference/design-doc-contract.md` — the required sections for a design doc and what "good" looks like for each, mapped directly onto `agents/product-reviewer.md`'s six design-mode review questions. States explicitly that a missing required section is a finding (REVISE/RETHINK), not a style nit.
- `templates/design-doc.md` — a stub scaffold (same style as `templates/DESIGN.md` / `templates/PRODUCT.md`) using the contract's section names, for Superpowers or a human author to start from.
- `commands/gate-design-review.md` — cites the contract when resolving the doc under review, and points at the template when no doc exists yet.

Fixes #29

## Test plan

- [x] `uv run --no-project python scripts/check_references.py` — passed
- [x] `npx -y markdownlint-cli2` — passed (0 errors, 32 files linted; `reference/` and `templates/` are outside the configured lint globs)