### PR TITLE
fix: scan skills/ and recognize more skill-reference phrasings in check_references.py

### DIFF
--- a/scripts/check_references.py
+++ b/scripts/check_references.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify every @agent-*, internal-skill, and reference/ path in commands/ and agents/ resolves.
+"""Verify every @agent-*, internal-skill, and reference/ path in commands/, agents/, and skills/ resolves.
 
 Run from CI to catch broken cross-references (e.g. an agent rename that orphans a
 command's @agent-* reference). Standard library only.
@@ -11,10 +11,18 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
-SCAN_DIRS = ("commands", "agents")
+SCAN_DIRS = ("commands", "agents", "skills")
 AGENT_RE = re.compile(r"@agent-([a-z0-9-]+)")
-# "the `<name>` skill" is the codebase's phrasing for a skill reference.
-SKILL_RE = re.compile(r"the `([a-z0-9-]+)` skill")
+# Recognized phrasings for a skill reference, e.g. "the `<name>` skill" (also
+# matches the possessive "the `<name>` skill's ..."), "invoke `<name>`"/"invoke
+# the `<name>`", and "skill `<name>`". Commands (`` `/gate-x` ``) and agents
+# (`@agent-x`) use their own distinct prefixes, so a bare backtick-wrapped
+# lowercase-dash token after "invoke" or "skill" is unambiguously a skill name.
+SKILL_RES = (
+    re.compile(r"the `([a-z0-9-]+)` skill"),
+    re.compile(r"invoke (?:the )?`([a-z0-9-]+)`"),
+    re.compile(r"skill `([a-z0-9-]+)`"),
+)
 # Curated rubric paths agents cite, e.g. `reference/security-checklist.md` or the
 # template `reference/idioms/<language>.md`. Angle-bracket placeholders are allowed.
 REFERENCE_RE = re.compile(r"reference/[A-Za-z0-9_./<>-]+\.md")
@@ -36,7 +44,8 @@ def find_broken(root: Path) -> list[str]:
                     errors.append(
                         f"@agent-{name} referenced in {rel} but agents/{name}.md missing"
                     )
-            for name in sorted(set(SKILL_RE.findall(text))):
+            skill_names = {name for regex in SKILL_RES for name in regex.findall(text)}
+            for name in sorted(skill_names):
                 if name in EXTERNAL_SKILLS:
                     continue
                 if not (root / "skills" / name).is_dir():

--- a/tests/python/test_check_references.py
+++ b/tests/python/test_check_references.py
@@ -71,3 +71,33 @@ def test_flags_reference_placeholder_with_missing_directory(tmp_path: Path) -> N
     )
     errors = find_broken(tmp_path)
     assert any("reference/ghosts" in e for e in errors)
+
+
+def test_resolves_skill_reference_inside_skill_md(tmp_path: Path) -> None:
+    (tmp_path / "skills" / "real-skill").mkdir(parents=True)
+    _write(
+        tmp_path / "skills" / "shim" / "SKILL.md",
+        "Invoke the `/gate-x` command, which delegates to the `real-skill` skill.",
+    )
+    assert find_broken(tmp_path) == []
+
+
+def test_flags_broken_skill_reference_inside_skill_md(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "skills" / "shim" / "SKILL.md",
+        "This routes to the `ghost-skill` skill.",
+    )
+    errors = find_broken(tmp_path)
+    assert any("skills/ghost-skill/ missing" in e for e in errors)
+
+
+def test_recognizes_invoke_backtick_phrasing(tmp_path: Path) -> None:
+    _write(tmp_path / "commands" / "gate.md", "invoke `ghost-skill` before continuing")
+    errors = find_broken(tmp_path)
+    assert any("skills/ghost-skill/ missing" in e for e in errors)
+
+
+def test_recognizes_skill_name_backtick_phrasing(tmp_path: Path) -> None:
+    _write(tmp_path / "commands" / "gate.md", "delegates to skill `ghost-skill`")
+    errors = find_broken(tmp_path)
+    assert any("skills/ghost-skill/ missing" in e for e in errors)


### PR DESCRIPTION
Fixes #58

`SCAN_DIRS` skipped `skills/`, so a broken `@agent-*` or skill reference inside a `skills/*/SKILL.md` delegation shim passed silently. `SKILL_RE` also only recognized the literal "the `X` skill" phrasing, missing other forms actually used in the repo's prose (e.g. `skill \`X\`` in DESIGN.md, `invoke \`X\`` as called out in the issue).

- Add `skills` to `SCAN_DIRS`.
- Broaden skill-reference matching to a tuple of regexes: `the \`X\` skill` (unchanged; already covers the possessive "skill's" form via substring match), `invoke \`X\``/`invoke the \`X\``, and `skill \`X\``.
- Add tests for a clean and a broken skill reference inside a `SKILL.md` file, plus coverage of the two newly-recognized phrasings.

## Test plan
- [x] `uv run --no-project --with pytest pytest tests/python -v` (19 passed)
- [x] `uv run --no-project python scripts/check_references.py` (passes against the real repo, including the newly-scanned `skills/` dir)