### PR TITLE
feat: CI-mode gate-audit (dormant — manual trigger, docs in README)

### DIFF
--- a/.github/workflows/gate-audit-pr.yml
+++ b/.github/workflows/gate-audit-pr.yml
@@ -1,0 +1,85 @@
+name: Gate audit (CI)
+
+# Runs /gate-audit non-interactively against each PR's diff and posts the
+# report as a PR comment. Skips PRs above CHANGED_FILES_LIMIT: the fan-out
+# spawns 6-7 parallel auditors, each reviewing the full changeset, so cost
+# scales with changed-file count x auditor count. Studious's own merged PR
+# history tops out at 21 changed files (#35, the Jaqal->Studious rename);
+# 40 leaves headroom above every real PR to date while still capping a
+# pathological diff (e.g. a vendored dependency bump or generated-file dump).
+#
+# Restricted to same-repo PRs. GitHub withholds repository secrets (other than
+# GITHUB_TOKEN) from `pull_request` runs triggered by a fork, so ANTHROPIC_API_KEY
+# would be absent and the job would just fail; skip forks rather than run a
+# guaranteed-broken check. This also keeps the non-interactive agent loop, which
+# reads the PR diff as untrusted content via Bash/Grep, scoped to contributors
+# who already have write access rather than to arbitrary external PR content.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  CHANGED_FILES_LIMIT: 40
+
+jobs:
+  gate-audit:
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Count changed files
+        id: scope
+        run: |
+          changed=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | wc -l | tr -d ' ')
+          echo "changed_files=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Skip — diff too large to sample affordably
+        if: fromJSON(steps.scope.outputs.changed_files) > fromJSON(env.CHANGED_FILES_LIMIT)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "**Gate audit (CI) skipped.** This PR changes ${{ steps.scope.outputs.changed_files }} files, over the ${{ env.CHANGED_FILES_LIMIT }}-file sampling limit set to keep the 6-7-agent audit fan-out affordable on large diffs. Run \`/gate-audit\` locally instead."
+
+      - name: Set up Node
+        if: fromJSON(steps.scope.outputs.changed_files) <= fromJSON(env.CHANGED_FILES_LIMIT)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Claude Code
+        if: fromJSON(steps.scope.outputs.changed_files) <= fromJSON(env.CHANGED_FILES_LIMIT)
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run gate-audit headlessly
+        if: fromJSON(steps.scope.outputs.changed_files) <= fromJSON(env.CHANGED_FILES_LIMIT)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          claude -p "/gate-audit" \
+            --plugin-dir "$GITHUB_WORKSPACE" \
+            --allowedTools "Read Glob Grep Bash Task Write" \
+            --output-format text \
+            --no-session-persistence \
+            > audit-report.md
+
+      - name: Post report as PR comment
+        if: fromJSON(steps.scope.outputs.changed_files) <= fromJSON(env.CHANGED_FILES_LIMIT)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body-file audit-report.md

--- a/.github/workflows/gate-audit-pr.yml
+++ b/.github/workflows/gate-audit-pr.yml
@@ -1,22 +1,33 @@
 name: Gate audit (CI)
 
-# Runs /gate-audit non-interactively against each PR's diff and posts the
-# report as a PR comment. Skips PRs above CHANGED_FILES_LIMIT: the fan-out
-# spawns 6-7 parallel auditors, each reviewing the full changeset, so cost
-# scales with changed-file count x auditor count. Studious's own merged PR
-# history tops out at 21 changed files (#35, the Jaqal->Studious rename);
-# 40 leaves headroom above every real PR to date while still capping a
-# pathological diff (e.g. a vendored dependency bump or generated-file dump).
+# Runs /gate-audit non-interactively against a PR's diff and posts the report as a
+# PR comment. Deliberately workflow_dispatch only for now — not wired to fire
+# automatically on every PR yet. See README.md "CI mode (optional)" for what
+# adding the `pull_request` trigger back gets you, the ANTHROPIC_API_KEY secret
+# it needs, and why this shipped dormant first (untested in a real Actions run
+# at the time it was written).
 #
-# Restricted to same-repo PRs. GitHub withholds repository secrets (other than
-# GITHUB_TOKEN) from `pull_request` runs triggered by a fork, so ANTHROPIC_API_KEY
-# would be absent and the job would just fail; skip forks rather than run a
-# guaranteed-broken check. This also keeps the non-interactive agent loop, which
-# reads the PR diff as untrusted content via Bash/Grep, scoped to contributors
-# who already have write access rather than to arbitrary external PR content.
+# Skips PRs above CHANGED_FILES_LIMIT: the fan-out spawns 6-7 parallel auditors,
+# each reviewing the full changeset, so cost scales with changed-file count x
+# auditor count. Studious's own merged PR history tops out at 21 changed files
+# (#35, the Jaqal->Studious rename); 40 leaves headroom above every real PR to
+# date while still capping a pathological diff (e.g. a vendored dependency bump
+# or generated-file dump).
+#
+# Refuses fork-originated and draft PRs. GitHub withholds repository secrets
+# (other than GITHUB_TOKEN) from `pull_request` runs triggered by a fork, so
+# ANTHROPIC_API_KEY would be absent and the job would just fail; refusing avoids
+# running a guaranteed-broken check. This also keeps the non-interactive agent
+# loop, which reads the PR diff as untrusted content via Bash/Grep, scoped to
+# contributors who already have write access rather than to arbitrary external
+# PR content.
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to audit"
+        required: true
+        type: number
 
 permissions:
   contents: read
@@ -27,21 +38,41 @@ env:
 
 jobs:
   gate-audit:
-    if: >-
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve PR info
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pr_json=$(gh pr view "${{ inputs.pr_number }}" --repo "${{ github.repository }}" \
+            --json headRefOid,baseRefOid,isDraft,headRepositoryOwner,number)
+          echo "head_sha=$(echo "$pr_json" | jq -r .headRefOid)" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$(echo "$pr_json" | jq -r .baseRefOid)" >> "$GITHUB_OUTPUT"
+
+          is_draft=$(echo "$pr_json" | jq -r .isDraft)
+          if [ "$is_draft" = "true" ]; then
+            echo "PR #${{ inputs.pr_number }} is a draft — refusing to audit it." >&2
+            exit 1
+          fi
+
+          head_owner=$(echo "$pr_json" | jq -r .headRepositoryOwner.login)
+          base_owner="${{ github.repository_owner }}"
+          if [ "$head_owner" != "$base_owner" ]; then
+            echo "PR #${{ inputs.pr_number }} is from a fork ($head_owner) — refusing to audit it (no repo secrets available on fork PRs, and this keeps agent Bash access scoped to write-access contributors)." >&2
+            exit 1
+          fi
+
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ steps.pr.outputs.head_sha }}
           fetch-depth: 0
 
       - name: Count changed files
         id: scope
         run: |
-          changed=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | wc -l | tr -d ' ')
+          changed=$(git diff --name-only "${{ steps.pr.outputs.base_sha }}" "${{ steps.pr.outputs.head_sha }}" | wc -l | tr -d ' ')
           echo "changed_files=$changed" >> "$GITHUB_OUTPUT"
 
       - name: Skip — diff too large to sample affordably
@@ -49,13 +80,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr comment "${{ github.event.pull_request.number }}" \
+          gh pr comment "${{ inputs.pr_number }}" \
             --repo "${{ github.repository }}" \
             --body "**Gate audit (CI) skipped.** This PR changes ${{ steps.scope.outputs.changed_files }} files, over the ${{ env.CHANGED_FILES_LIMIT }}-file sampling limit set to keep the 6-7-agent audit fan-out affordable on large diffs. Run \`/gate-audit\` locally instead."
 
       - name: Set up Node
         if: fromJSON(steps.scope.outputs.changed_files) <= fromJSON(env.CHANGED_FILES_LIMIT)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
 
@@ -80,6 +111,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr comment "${{ github.event.pull_request.number }}" \
+          gh pr comment "${{ inputs.pr_number }}" \
             --repo "${{ github.repository }}" \
             --body-file audit-report.md

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ You don't need every gate every time. For small fixes, `/gate-audit` alone is en
 
 The three product gates also fire from natural language, not just the slash command — asking "should we build this?", "review this design before I build it", or "does this actually deliver?" routes to the matching gate. Triggers are deliberately conservative, so you'll still reach for the commands directly most of the time.
 
+## CI mode (optional)
+
+`.github/workflows/gate-audit-pr.yml` runs `/gate-audit` non-interactively against a PR and posts the report as a PR comment — the same 6-7 auditor fan-out you'd get locally, without anyone having to remember to run it. It ships **dormant** (manual `workflow_dispatch` trigger only): pick a PR, run the workflow from the Actions tab with that PR's number as input, and it audits that PR and comments on it. It does not fire automatically on every PR yet.
+
+To set it up:
+
+1. Add `ANTHROPIC_API_KEY` as a repository secret (Settings → Secrets and variables → Actions). Without it, the job fails at the "Run gate-audit headlessly" step.
+2. Test it manually first: `workflow_dispatch` it against a real, non-draft, same-repo PR and read the comment it posts before trusting it further.
+3. To make it run automatically on every PR instead of by hand, change the workflow's `on:` block from `workflow_dispatch` (with the `pr_number` input) to `pull_request: types: [opened, synchronize, reopened, ready_for_review]`, and swap every `inputs.pr_number` reference for `github.event.pull_request.number` (and the head/base SHA resolution step can be dropped in favor of `github.event.pull_request.head.sha` / `.base.sha` directly).
+
+It refuses draft PRs and fork PRs (no repository secrets are available to fork-triggered runs, and this keeps the agent's Bash access scoped to contributors who already have write access), and skips diffs over 40 changed files to keep the fan-out's cost bounded — see the workflow file's own comments for the full reasoning.
+
 ## Keeping the project healthy
 
 Separate from the feature flow: periodic reviews that assess overall project health. These run against main, not feature branches.


### PR DESCRIPTION
Adds `.github/workflows/gate-audit-pr.yml`, which runs `/gate-audit` non-interactively against a PR and posts the report as a PR comment — the 6-7 auditor fan-out, without anyone having to remember to run it locally.

**Revised from the original version** (see PR history): reviewer decision was to document setup rather than wire this to fire automatically on this repo's own PRs yet, given two open items the original version flagged — `ANTHROPIC_API_KEY` not yet confirmed as a repo secret, and no real GitHub Actions run to validate against. So this version ships **dormant**:

- Trigger changed from `pull_request` to manual `workflow_dispatch` with a `pr_number` input. PR head/base SHA, fork-origin, and draft status are resolved via `gh pr view` instead of the `pull_request` event context (which doesn't exist for a `workflow_dispatch` run).
- Same safeguards as before: refuses draft PRs, refuses fork-originated PRs (no repo secrets on fork-triggered runs; also keeps the agent's Bash access scoped to write-access contributors), skips diffs over 40 changed files (this repo's largest merged PR to date was 21).
- New README.md section ("CI mode (optional)") documents the `ANTHROPIC_API_KEY` secret requirement, how to test it manually against a real PR first, and the exact `on:` block change to flip it to automatic later.

Fixes #30

## Test plan
- [x] `uv run --no-project --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/gate-audit-pr.yml'))"` — parses cleanly
- [x] `uv run --no-project python scripts/check_references.py` — passes
- [x] `npx -y markdownlint-cli2` — 0 errors
- [ ] Not yet run in a real Actions runner — first manual `workflow_dispatch` run against a real PR should be watched closely, per the original PR's own caveat