### PR TITLE
fix: commit install-dev.sh, cover skills/hooks/bin, fix empty-glob bug, add --remove

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
             https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz
           tar -xJf /tmp/shellcheck.tar.xz -C /tmp
           sudo install /tmp/shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
-      - run: shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh
+      - run: shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh scripts/install-dev.sh

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Install Studious for local development by symlinking commands, agents,
+# skills, hooks, and bin into ~/.claude/. Safe to re-run — removes stale
+# copies and refreshes symlinks. Pass --remove to uninstall the symlinks.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+COMMANDS_SRC="$REPO_DIR/commands"
+AGENTS_SRC="$REPO_DIR/agents"
+SKILLS_SRC="$REPO_DIR/skills"
+HOOKS_SRC="$REPO_DIR/hooks"
+BIN_SRC="$REPO_DIR/bin"
+COMMANDS_DST="$HOME/.claude/commands"
+AGENTS_DST="$HOME/.claude/agents"
+SKILLS_DST="$HOME/.claude/skills"
+HOOKS_DST="$HOME/.claude/hooks"
+BIN_DST="$HOME/.claude/bin"
+
+ACTION="install"
+case "${1:-}" in
+  "") ;;
+  --remove) ACTION="remove" ;;
+  *) echo "usage: $(basename "$0") [--remove]" >&2; exit 2 ;;
+esac
+
+link_files() {
+  local src="$1"
+  local dst="$2"
+  local label="$3"
+  local pattern="${4:-*.md}"
+
+  mkdir -p "$dst"
+
+  # Remove any plain files (non-symlinks) that exist in dst and match src
+  for f in "$src"/$pattern; do
+    [ -e "$f" ] || continue
+    name="$(basename "$f")"
+    target="$dst/$name"
+    if [[ -f "$target" && ! -L "$target" ]]; then
+      echo "  removing stale copy: $label/$name"
+      rm "$target"
+    fi
+  done
+
+  # Create or refresh symlinks
+  for f in "$src"/$pattern; do
+    [ -e "$f" ] || continue
+    name="$(basename "$f")"
+    target="$dst/$name"
+    if [[ -L "$target" && "$(readlink "$target")" == "$f" ]]; then
+      echo "  ok (already linked): $label/$name"
+    else
+      [[ -L "$target" ]] && rm "$target"
+      ln -s "$f" "$target"
+      echo "  linked: $label/$name"
+    fi
+  done
+}
+
+link_dirs() {
+  local src="$1"
+  local dst="$2"
+  local label="$3"
+
+  mkdir -p "$dst"
+
+  for d in "$src"/*/; do
+    [ -e "$d" ] || continue
+    d="${d%/}"
+    name="$(basename "$d")"
+    target="$dst/$name"
+    if [[ -d "$target" && ! -L "$target" ]]; then
+      echo "  removing stale copy: $label/$name"
+      rm -rf "$target"
+    fi
+    if [[ -L "$target" && "$(readlink "$target")" == "$d" ]]; then
+      echo "  ok (already linked): $label/$name"
+    else
+      [[ -L "$target" ]] && rm "$target"
+      ln -s "$d" "$target"
+      echo "  linked: $label/$name"
+    fi
+  done
+}
+
+remove_files() {
+  local src="$1"
+  local dst="$2"
+  local label="$3"
+  local pattern="${4:-*.md}"
+
+  [ -d "$dst" ] || return 0
+  for f in "$src"/$pattern; do
+    [ -e "$f" ] || continue
+    name="$(basename "$f")"
+    target="$dst/$name"
+    if [[ -L "$target" && "$(readlink "$target")" == "$f" ]]; then
+      rm "$target"
+      echo "  removed: $label/$name"
+    fi
+  done
+}
+
+remove_dirs() {
+  local src="$1"
+  local dst="$2"
+  local label="$3"
+
+  [ -d "$dst" ] || return 0
+  for d in "$src"/*/; do
+    [ -e "$d" ] || continue
+    d="${d%/}"
+    name="$(basename "$d")"
+    target="$dst/$name"
+    if [[ -L "$target" && "$(readlink "$target")" == "$d" ]]; then
+      rm "$target"
+      echo "  removed: $label/$name"
+    fi
+  done
+}
+
+if [[ "$ACTION" == "remove" ]]; then
+  echo "Removing Studious dev symlinks for $REPO_DIR"
+  echo ""
+  echo "Commands:"
+  remove_files "$COMMANDS_SRC" "$COMMANDS_DST" "commands"
+  echo ""
+  echo "Agents:"
+  remove_files "$AGENTS_SRC" "$AGENTS_DST" "agents"
+  echo ""
+  echo "Skills:"
+  remove_dirs "$SKILLS_SRC" "$SKILLS_DST" "skills"
+  echo ""
+  echo "Hooks:"
+  remove_files "$HOOKS_SRC" "$HOOKS_DST" "hooks" "*"
+  echo ""
+  echo "Bin:"
+  remove_files "$BIN_SRC" "$BIN_DST" "bin" "*"
+  echo ""
+  echo "Done."
+  exit 0
+fi
+
+echo "Installing Studious from $REPO_DIR"
+echo ""
+echo "Commands:"
+link_files "$COMMANDS_SRC" "$COMMANDS_DST" "commands"
+echo ""
+echo "Agents:"
+link_files "$AGENTS_SRC" "$AGENTS_DST" "agents"
+echo ""
+echo "Skills:"
+link_dirs "$SKILLS_SRC" "$SKILLS_DST" "skills"
+echo ""
+echo "Hooks:"
+link_files "$HOOKS_SRC" "$HOOKS_DST" "hooks" "*"
+echo ""
+echo "Bin:"
+link_files "$BIN_SRC" "$BIN_DST" "bin" "*"
+echo ""
+echo "Done. Restart Claude Code to pick up any new commands."


### PR DESCRIPTION
Fixes #59

`scripts/install-dev.sh` previously lived untracked in the working tree, only
symlinked `commands/` and `agents/` into `~/.claude/`, and iterated
`"$src"/*.md` without a glob guard — an empty source directory created a
broken symlink literally named `*.md`.

- Commit the script (it was never gitignored; nothing to remove there).
- Extend it to symlink `skills/` (3 dirs, linked as directories), `hooks/`,
  and `bin/`, not just `commands/` and `agents/`.
- Guard every glob loop with `[ -e "$f" ] || continue` (bash-3.2-safe,
  matches `bin/gate-ledger`'s plain-`[ ]`/no-`shopt` style) so an empty
  source directory is a no-op.
- Add `scripts/install-dev.sh` to the shellcheck job's file list in
  `.github/workflows/ci.yml`.
- Add an uninstall path: `install-dev.sh --remove` removes the symlinks it
  created (files and skill directories alike).

## Test plan
- [x] `shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh scripts/install-dev.sh` — clean, local shellcheck matches CI's pinned 0.11.0
- [x] Manual run against a sandboxed `$HOME`: `install-dev.sh` links commands, agents, skills (as dirs), hooks, and bin
- [x] Re-run is idempotent (`ok (already linked)` for every entry, no changes)
- [x] `install-dev.sh --remove` removes every symlink it created
- [x] Empty-source-dir case: pointed the script at empty `commands/agents/skills/hooks/bin` dirs — no `*.md`/`*` literal symlinks created, clean no-op