### PR TITLE
fix: gate-reminder hook no longer matches 'gh pr create' as a bare substring

### DIFF
--- a/hooks/gate-reminder.sh
+++ b/hooks/gate-reminder.sh
@@ -9,7 +9,7 @@
 
 input=$(cat)
 
-printf '%s' "$input" | grep -q 'gh pr create' || exit 0
+printf '%s' "$input" | grep -Eq 'gh[[:space:]]+pr[[:space:]]+create' || exit 0
 
 default_reason="Studious: opening a PR. Did /gate-audit and /gate-acceptance run on this branch? Proceed if the gates passed or don't apply to this change."
 

--- a/tests/test_gate_ledger.sh
+++ b/tests/test_gate_ledger.sh
@@ -92,6 +92,16 @@ hook_noop=$(cd "$d6" && CLAUDE_PLUGIN_ROOT="$ROOT" \
   bash "$HOOK" <<<'{"tool_input":{"command":"ls -la"}}')
 check "hook ignores non-PR commands" "" "$hook_noop"
 
+# --- hook matches spacing variants that would evade a literal-string grep ---
+hook_spacing=$(cd "$d6" && CLAUDE_PLUGIN_ROOT="$ROOT" \
+  bash "$HOOK" <<<'{"tool_input":{"command":"gh  pr   create"}}')
+contains "hook matches gh pr create with irregular spacing" '"permissionDecision": "ask"' "$hook_spacing"
+
+# --- hook still matches when the phrase is embedded in a longer command ---
+hook_embedded=$(cd "$d6" && CLAUDE_PLUGIN_ROOT="$ROOT" \
+  bash "$HOOK" <<<'{"tool_input":{"command":"git log --grep=\"gh pr create\""}}')
+contains "hook matches gh pr create embedded in a longer command" '"permissionDecision": "ask"' "$hook_embedded"
+
 # --- command prompts invoke the ledger via ${CLAUDE_PLUGIN_ROOT}, not a bare name ---
 # Plugins don't add bin/ to PATH, so a bare `gate-ledger ...` in a command prompt
 # is "command not found" at runtime. Every invocation must resolve the script path.


### PR DESCRIPTION
Fixes #40

## Approach

The issue offered two options: parse `tool_input.command` via `jq -r`, or normalize whitespace with a regex like `gh[[:space:]]+pr[[:space:]]+create`. I picked the **regex** approach:

- The issue explicitly notes the detection line is deliberately jq-free.
- The file's existing `jq` usage (building the JSON response) is conditional — guarded by `command -v jq` with a jq-less fallback — so the file does not assume jq is present anywhere. That rules out the "match existing jq assumption" exception, so the no-new-dependency option applies.
- The jq option wouldn't fully solve the substring problem either (see below), so there's no completeness argument for switching.

## Scope — what this does and doesn't fix

- **Fixes**: the false-negative evasion. `gh  pr create` (double space) or tab-separated variants previously slipped past the literal-string `grep -q 'gh pr create'` and silently suppressed the reminder. The new `grep -Eq 'gh[[:space:]]+pr[[:space:]]+create'` catches these.
- **Deliberately unchanged**: a command where the phrase is merely embedded in something else (e.g. `git log --grep="gh pr create"`) still triggers the non-blocking `ask`. Eliminating that fully would require extracting and anchoring on the actual `tool_input.command` field (via jq), which is more invasive for a Low-severity precision nit. Since the hook only ever returns a non-blocking `ask`, over-triggering here is harmless — under-triggering (the evasion case) was the actual risk.

## Test plan

- [x] `shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh` — clean
- [x] `bash tests/test_gate_ledger.sh` — all 18 checks pass, including 2 new cases:
  - `gh  pr   create` (irregular spacing) → `ask`
  - `git log --grep="gh pr create"` (phrase embedded in unrelated command) → `ask` (unchanged behavior, documented above)