### PR TITLE
fix: commit install-dev.sh, cover skills/hooks/bin, fix empty-glob bug, add --remove

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
             https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz
           tar -xJf /tmp/shellcheck.tar.xz -C /tmp
           sudo install /tmp/shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
-      - run: shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh
+      - run: shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh scripts/install-dev.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -9,18 +11,18 @@ jobs:
     name: markdownlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
-      - run: npx -y markdownlint-cli2
+      - run: npx -y markdownlint-cli2@0.23.0
 
   python-checks:
     name: link-check + schema + unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
       - name: Link-check references
         run: uv run --no-project python scripts/check_references.py
       - name: Validate plugin manifest
@@ -30,9 +32,22 @@ jobs:
 
   ledger:
     name: gate-ledger tests
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Ensure git and jq are available
+        run: |
+          command -v git >/dev/null || { echo "git is required but not found" >&2; exit 1; }
+          if ! command -v jq >/dev/null; then
+            if [ "$RUNNER_OS" = "macOS" ]; then
+              brew install jq
+            else
+              sudo apt-get update && sudo apt-get install -y jq
+            fi
+          fi
       - name: Gate-ledger integration tests
         run: bash tests/test_gate_ledger.sh
 
@@ -40,5 +55,11 @@ jobs:
     name: shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Install shellcheck 0.11.0
+        run: |
+          curl -fsSL -o /tmp/shellcheck.tar.xz \
+            https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+          sudo install /tmp/shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
       - run: shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Install Studious for local development by symlinking commands, agents,
+# skills, hooks, and bin into ~/.claude/. Safe to re-run — removes stale
+# copies and refreshes symlinks. Pass --remove to uninstall the symlinks.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+COMMANDS_SRC="$REPO_DIR/commands"
+AGENTS_SRC="$REPO_DIR/agents"
+SKILLS_SRC="$REPO_DIR/skills"
+HOOKS_SRC="$REPO_DIR/hooks"
+BIN_SRC="$REPO_DIR/bin"
+COMMANDS_DST="$HOME/.claude/commands"
+AGENTS_DST="$HOME/.claude/agents"
+SKILLS_DST="$HOME/.claude/skills"
+HOOKS_DST="$HOME/.claude/hooks"
+BIN_DST="$HOME/.claude/bin"
+
+ACTION="install"
+case "${1:-}" in
+  "") ;;
+  --remove) ACTION="remove" ;;
+  *) echo "usage: $(basename "$0") [--remove]" >&2; exit 2 ;;
+esac
+
+link_files() {
+  local src="$1"
+  local dst="$2"
+  local label="$3"
+  local pattern="${4:-*.md}"
+
+  mkdir -p "$dst"
+
+  # Remove any plain files (non-symlinks) that exist in dst and match src
+  for f in "$src"/$pattern; do
+    [ -e "$f" ] || continue
+    name="$(basename "$f")"
+    target="$dst/$name"
+    if [[ -f "$target" && ! -L "$target" ]]; then
+      echo "  removing stale copy: $label/$name"
+      rm "$target"
+    fi
+  done
+
+  # Create or refresh symlinks
+  for f in "$src"/$pattern; do
+    [ -e "$f" ] || continue
+    name="$(basename "$f")"
+    target="$dst/$name"
+    if [[ -L "$target" && "$(readlink "$target")" == "$f" ]]; then
+      echo "  ok (already linked): $label/$name"
+    else
+      [[ -L "$target" ]] && rm "$target"
+      ln -s "$f" "$target"
+      echo "  linked: $label/$name"
+    fi
+  done
+}
+
+link_dirs() {
+  local src="$1"
+  local dst="$2"
+  local label="$3"
+
+  mkdir -p "$dst"
+
+  for d in "$src"/*/; do
+    [ -e "$d" ] || continue
+    d="${d%/}"
+    name="$(basename "$d")"
+    target="$dst/$name"
+    if [[ -d "$target" && ! -L "$target" ]]; then
+      echo "  removing stale copy: $label/$name"
+      rm -rf "$target"
+    fi
+    if [[ -L "$target" && "$(readlink "$target")" == "$d" ]]; then
+      echo "  ok (already linked): $label/$name"
+    else
+      [[ -L "$target" ]] && rm "$target"
+      ln -s "$d" "$target"
+      echo "  linked: $label/$name"
+    fi
+  done
+}
+
+remove_files() {
+  local src="$1"
+  local dst="$2"
+  local label="$3"
+  local pattern="${4:-*.md}"
+
+  [ -d "$dst" ] || return 0
+  for f in "$src"/$pattern; do
+    [ -e "$f" ] || continue
+    name="$(basename "$f")"
+    target="$dst/$name"
+    if [[ -L "$target" && "$(readlink "$target")" == "$f" ]]; then
+      rm "$target"
+      echo "  removed: $label/$name"
+    fi
+  done
+}
+
+remove_dirs() {
+  local src="$1"
+  local dst="$2"
+  local label="$3"
+
+  [ -d "$dst" ] || return 0
+  for d in "$src"/*/; do
+    [ -e "$d" ] || continue
+    d="${d%/}"
+    name="$(basename "$d")"
+    target="$dst/$name"
+    if [[ -L "$target" && "$(readlink "$target")" == "$d" ]]; then
+      rm "$target"
+      echo "  removed: $label/$name"
+    fi
+  done
+}
+
+if [[ "$ACTION" == "remove" ]]; then
+  echo "Removing Studious dev symlinks for $REPO_DIR"
+  echo ""
+  echo "Commands:"
+  remove_files "$COMMANDS_SRC" "$COMMANDS_DST" "commands"
+  echo ""
+  echo "Agents:"
+  remove_files "$AGENTS_SRC" "$AGENTS_DST" "agents"
+  echo ""
+  echo "Skills:"
+  remove_dirs "$SKILLS_SRC" "$SKILLS_DST" "skills"
+  echo ""
+  echo "Hooks:"
+  remove_files "$HOOKS_SRC" "$HOOKS_DST" "hooks" "*"
+  echo ""
+  echo "Bin:"
+  remove_files "$BIN_SRC" "$BIN_DST" "bin" "*"
+  echo ""
+  echo "Done."
+  exit 0
+fi
+
+echo "Installing Studious from $REPO_DIR"
+echo ""
+echo "Commands:"
+link_files "$COMMANDS_SRC" "$COMMANDS_DST" "commands"
+echo ""
+echo "Agents:"
+link_files "$AGENTS_SRC" "$AGENTS_DST" "agents"
+echo ""
+echo "Skills:"
+link_dirs "$SKILLS_SRC" "$SKILLS_DST" "skills"
+echo ""
+echo "Hooks:"
+link_files "$HOOKS_SRC" "$HOOKS_DST" "hooks" "*"
+echo ""
+echo "Bin:"
+link_files "$BIN_SRC" "$BIN_DST" "bin" "*"
+echo ""
+echo "Done. Restart Claude Code to pick up any new commands."


### PR DESCRIPTION
Recreates #77, which was auto-closed when its original base branch (fix/ci-trust) was deleted after merge. Same branch, same content, retargeted to main.

Fixes #59

## Test plan
- [x] shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh scripts/install-dev.sh