### PR TITLE
feat: add /work-on — navigate the feature flow one piece at a time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,14 +44,14 @@ The directory layout encodes a role split (full version in `CONTRIBUTING.md`):
 - `skills/<name>/SKILL.md` — natural-language **trigger shims**. A tightly-scoped `description` lets a gate fire from plain language; the body delegates to the matching command and must not duplicate its logic.
 - `reference/` — curated rubrics agents read at audit time (`reference/security-checklist.md`, `reference/idioms/<lang>.md`). Agents consult these instead of restating them inline — keep depth in `reference/`, keep agents pointing at it.
 - `hooks/` — shipped hook scripts + `hooks.json`. The one live hook is a non-blocking PreToolUse reminder before `gh pr create`.
-- `bin/gate-ledger` — reads/writes the per-branch gate ledger.
+- `bin/gate-ledger` — reads/writes the per-branch gate ledger and the per-feature `/work-on` work files.
 - `templates/` — PRODUCT.md / DESIGN.md scaffolds created by `/studious-init` in the consuming project.
 
 Key invariants when adding or changing prompts:
 
 - **Stay in lane.** One agent = one concern. The security auditor owns the security rubric; other auditors escalate but don't hunt security issues. Don't bundle concerns into one agent.
 - **One fan-out command, many subagents.** Parallel checks live as subagents under a single entry point (`/gate-audit`, `/deep-review`) — never add a top-level command per check.
-- **Recommend-only.** Commands report; they never modify external state (issues, PRs, files outside `docs/studious/` in the consuming project). The sole exception: gate commands record verdicts to a local, gitignored `.studious/` ledger.
+- **Recommend-only.** Commands report; they never modify external state (issues, PRs, files outside `docs/studious/` in the consuming project). The sole exception: gate commands record verdicts, and `/work-on` records flow position, to local, gitignored `.studious/` state.
 - **Reviews write to the consuming project, not here.** Review reports land in the user's `docs/studious/` subdirectories. This plugin repo never accumulates them.
 - **Every agent/command reads PRODUCT.md, DESIGN.md, or CLAUDE.md** for project context. The 14 review/audit agents share a standardized prompt contract (posture, output format, calibration) — match it when adding an agent.
 
@@ -59,7 +59,7 @@ Key invariants when adding or changing prompts:
 
 These are enforced by convention, not tooling — follow the existing shape (details in `CONTRIBUTING.md`):
 
-- **Commands are actions:** an action prefix + target — `gate-`, `review-`/`deep-review`, `extract-`, `backlog-`.
+- **Commands are actions:** an action prefix + target — `gate-`, `review-`/`deep-review`, `extract-`, `backlog-`, `work-on`.
 - **Agents are a 1:1 reviewer or a role:** periodic project-scoped reviewers share their command's `review-*` name; changeset specialists are `<domain>-auditor` (rule/technical checks) or `<domain>-reviewer` (human-judgment checks).
 - **Skills are named for the intent they detect**, not the command they call. Keep `description` triggers conservative — list what they should NOT match so a gate never fires unwanted.
 - **Pin `model` by stakes:** `opus` for high-stakes reasoning/human judgment (security, architecture, product/UX). `inherit` for mechanical, rule-based, or inventory work. Never pin a bare tier like `sonnet` — use `inherit` so the agent tracks the session model.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Open an issue for bugs, unclear documentation, or suggestions. Include:
 
 ```
 agents/       — Agent definitions (name, description, tools, model in frontmatter)
-bin/          — Executables used by commands (e.g. gate-ledger for recording gate verdicts)
+bin/          — Executables used by commands (e.g. gate-ledger for gate verdicts and /work-on's per-feature state)
 commands/     — Slash commands (description, allowed-tools in frontmatter)
 scripts/      — CI helper scripts (link checking, manifest validation)
 skills/       — Natural-language trigger shims (skills/<name>/SKILL.md)
@@ -43,13 +43,13 @@ tests/        — Python and shell tests for commands and CI scripts
 - Skills are trigger shims: a tightly-scoped `description` lets a gate fire from natural language, and the body delegates to the matching command instead of duplicating it.
 - Every agent and command reads PRODUCT.md, DESIGN.md, or CLAUDE.md for project context.
 - Review reports save to `docs/studious/` subdirectories in the user's project, not to the plugin itself.
-- Commands that produce output are recommend-only — they report, never modify external state (issues, PRs, files outside `docs/studious/`). **Exception:** gate commands (`/gate-audit`, `/gate-acceptance`) record their verdicts to a local, gitignored `.studious/` ledger in the consuming project; the ledger auto-appends `.studious/` to `.gitignore` on first write.
+- Commands that produce output are recommend-only — they report, never modify external state (issues, PRs, files outside `docs/studious/`). **Exception:** the gate commands record their verdicts, and `/work-on` records per-feature flow position, to local, gitignored `.studious/` state in the consuming project; the ledger auto-appends `.studious/` to `.gitignore` on first write.
 
 ## Naming conventions
 
 Names encode two things — whether something is an action or a role, and what scope it works at. Follow the existing shape; the prefix/suffix split is deliberate, not drift.
 
-- **Commands are actions** — an action prefix plus its target: `gate-` (per-change checkpoints), `review-`/`deep-review` (periodic health), `extract-` (one-time scaffolding), `backlog-` (issue triage). The verb goes in front.
+- **Commands are actions** — an action prefix plus its target: `gate-` (per-change checkpoints), `review-`/`deep-review` (periodic health), `extract-` (one-time scaffolding), `backlog-` (issue triage), `work-on` (flow navigation, one piece at a time). The verb goes in front.
 - **Agents are either a 1:1 reviewer or a role.** Periodic, project-scoped reviewers share their command's `review-*` name (currently spawned by `/deep-review`). Changeset specialists spawned by a fan-out command (`/gate-audit`, the gates) are named by role: `<domain>-auditor` for technical/rule checks (security, code, doc, architecture), `<domain>-reviewer` for human-judgment checks (product, ux, frontend).
 - **One fan-out command, many subagents.** Parallel checks belong to subagents under a single entry point (`/gate-audit`, `/deep-review`), not to their own top-level commands. Don't add a command per check.
 - **Skills are named for the intent they detect** — `evaluate-feature-idea`, `review-design-before-build`, `acceptance-check-before-merge` — not for the command they call. The `description` carries the trigger; keep it conservative (fire on explicit intent, list what it should NOT match) so a gate never interrupts when it isn't wanted.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,15 +31,15 @@ the same tokens.
 
 | Command | Verdict tokens (canonical) | Source of truth | Consumers |
 |---------|----------------------------|-----------------|-----------|
-| `gate-should-we-build` | `BUILD` · `BUILD SMALLER` · `DEFER` · `DON'T BUILD` | `commands/gate-should-we-build.md` | skill `evaluate-feature-idea` |
-| `gate-design-review` | `PROCEED TO PLAN` · `REVISE` · `RETHINK` | `commands/gate-design-review.md` | skill `review-design-before-build` |
-| `gate-audit` | `PASS` · `FIX AND RE-AUDIT` · `NEEDS DISCUSSION` | `commands/gate-audit.md` | (no skill shim) |
-| `gate-acceptance` | `SHIP` · `FIX AND RE-CHECK` · `HOLD` | `commands/gate-acceptance.md` | skill `acceptance-check-before-merge` |
+| `gate-should-we-build` | `BUILD` · `BUILD SMALLER` · `DEFER` · `DON'T BUILD` | `commands/gate-should-we-build.md` | skill `evaluate-feature-idea` · `/work-on` |
+| `gate-design-review` | `PROCEED TO PLAN` · `REVISE` · `RETHINK` | `commands/gate-design-review.md` | skill `review-design-before-build` · `/work-on` |
+| `gate-audit` | `PASS` · `FIX AND RE-AUDIT` · `NEEDS DISCUSSION` | `commands/gate-audit.md` | `/work-on` (no skill shim) |
+| `gate-acceptance` | `SHIP` · `FIX AND RE-CHECK` · `HOLD` | `commands/gate-acceptance.md` | skill `acceptance-check-before-merge` · `/work-on` |
 
 Each vocabulary is three or four tokens: one "proceed," one "fix and retry," and (most)
-one "stop/rethink." There is **no shared source-of-truth file** — every command defines its
-own tokens inline, and the skill shims restate them. <!-- deviation: a single reference
-listing all gate vocabularies would prevent a command and its skill drifting apart. -->
+one "stop/rethink." The canonical listing and per-gate breakdown now live in
+`reference/gate-vocabulary.md`, cited by `commands/work-on.md` rather than restated there —
+this table should mirror that file, not diverge from it.
 
 ### Severity tiers
 
@@ -68,7 +68,7 @@ cited by the auditor/reviewer agents rather than restated per-agent.
 
 - **Command naming** — `verb`-prefixed families: `gate-*` (per-feature quality gates),
   `deep-review` (periodic reviews), `backlog-*` (issue triage), `extract-*` (context-doc
-  population), `studious-init` (setup). All lowercase, hyphenated.
+  population), `studious-init` (setup), `work-on` (feature-flow navigation). All lowercase, hyphenated.
 - **Frontmatter** — commands carry `description` + `allowed-tools`; agents carry `name` +
   `description` + `tools` + `model`. Descriptions are one line, imperative.
 - **Skills as trigger shims** — `skills/<name>/SKILL.md` holds a tightly-scoped `description`
@@ -103,8 +103,10 @@ documents the policy for the interface surface, it does not restate the per-agen
    `deep-review` and the review agents. Same concept, two labels.~~ Resolved: unified on
    `Track` everywhere; the canonical ladder and per-auditor mapping now live in
    `reference/severity-rubric.md`.
-2. **No shared source for gate verdict vocabularies** — each command and its skill shim
-   restate the tokens independently, so a command and its trigger can drift apart.
+2. **No shared source for gate verdict vocabularies** — partially addressed: the canonical
+   listing now lives in `reference/gate-vocabulary.md`, and `/work-on` cites it rather than
+   restating token definitions. The three skill shims still restate their gate's tokens
+   independently in a one-line summary and haven't been repointed at the reference file yet.
 3. **`gate-audit` has no skill shim** while the other three gates do (`evaluate-feature-idea`,
    `review-design-before-build`, `acceptance-check-before-merge`) — natural-language access
    is inconsistent across the gate family.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ When you run `gh pr create`, a PR-time hook reads the gate verdicts recorded to 
 
 You don't need every gate every time. For small fixes, `/gate-audit` alone is enough. The gates exist to catch building the wrong thing or shipping a bad experience. Use judgment about when that risk applies.
 
-The three product gates also fire from natural language, not just the slash command — asking "should we build this?", "review this design before I build it", or "does this actually deliver?" routes to the matching gate. Triggers are deliberately conservative, so you'll still reach for the commands directly most of the time.
+The three product gates also fire from natural language, not just the slash command — asking "should we build this?", "review this design before I build it", or "does this actually deliver?" routes to the matching gate. So does flow continuation — "do the next piece" resumes `/work-on` (below). Triggers are deliberately conservative, so you'll still reach for the commands directly most of the time.
+
+### Or have Studious navigate
+
+`/work-on [idea or issue]` walks a feature through that same sequence one piece at a time. Each invocation runs exactly one step — a gate, or a handoff at the two steps Studious doesn't own (design doc, build) — then stops and tells you what the next piece is. There is no auto-advance. When you're ready, `/work-on` with no argument (or just "next", or "do the next piece") runs it; you never have to remember which gate comes after which. Position is tracked per feature in the same local, gitignored `.studious/` state as the gate ledger, so the flow survives across sessions and picks up where the feature actually stands — including gates you ran by hand.
 
 ## CI mode (optional)
 

--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
-# gate-ledger — read/write Studious's per-branch gate ledger.
+# gate-ledger — read/write Studious's local, gitignored .studious/ state.
 #
-# Local, gitignored state at .studious/gates/<branch-slug>.json in the consuming
-# project. Written by /gate-audit and /gate-acceptance (via `record`); read by the
-# PR-time hook (via `status`). Degrades silently when git or jq is unavailable.
+# Two stores in the consuming project:
+#   .studious/gates/<branch-slug>.json  — per-branch gate verdicts. Written by the
+#     gate commands (via `record`); read by the PR-time hook (via `status`) and by
+#     /work-on's evidence check (via `gate-get`) — never read as a raw file by callers.
+#   .studious/work/<feature-slug>.json  — per-feature flow position for /work-on
+#     (written via `work-set` / `work-log`; read via `work-get` / `work-list`).
+# Degrades silently when git or jq is unavailable.
 set -uo pipefail
 
 branch_name() { git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD; }
-branch_slug() { local b; b=$(branch_name); printf '%s' "${b//\//-}"; }
+branch_slug() { local b; b="${1:-$(branch_name)}"; printf '%s' "${b//\//-}"; } # optional arg: slug for a given branch instead of the current one
 head_sha()    { git rev-parse --short HEAD 2>/dev/null || echo ""; }
 now_iso()     { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
@@ -23,6 +27,22 @@ ledger_dir() {
   else
     printf '.studious/gates'
   fi
+}
+
+work_dir() {
+  # Same root-anchoring as ledger_dir, different store.
+  local root
+  if root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    printf '%s/.studious/work' "$root"
+  else
+    printf '.studious/work'
+  fi
+}
+
+slugify() {
+  # Feature title/slug → filesystem- and JSON-safe key: lowercase, runs of
+  # anything outside [a-z0-9] collapse to '-', edges trimmed.
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-*//; s/-*$//'
 }
 
 ensure_gitignore() {
@@ -139,6 +159,142 @@ cmd_status() {
   fi
 }
 
+cmd_gate_get() {
+  local branch=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --branch) branch="$2"; shift 2 ;;
+      *) echo "gate-ledger: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+  local slug; slug=$(branch_slug "$branch")
+  local file; file="$(ledger_dir)/$slug.json"
+  [ -f "$file" ] || return 0
+  cat "$file"
+}
+
+work_file_init() { # slug → ensures the work file exists, echoes its path
+  local slug="$1"
+  local dir; dir=$(work_dir)
+  mkdir -p "$dir"
+  local file; file="$dir/$slug.json"
+  [ -f "$file" ] || printf '{"schemaVersion":1,"slug":"%s","history":[]}' "$slug" > "$file"
+  printf '%s' "$file"
+}
+
+cmd_work_set() {
+  local slug="" title="" src="" branch="" doc="" phase=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --slug)       slug="$2"; shift 2 ;;
+      --title)      title="$2"; shift 2 ;;
+      --source)     src="$2"; shift 2 ;;
+      --branch)     branch="$2"; shift 2 ;;
+      --design-doc) doc="$2"; shift 2 ;;
+      --phase)      phase="$2"; shift 2 ;;
+      *) echo "gate-ledger: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+  if [ -z "$slug" ]; then
+    echo "gate-ledger: --slug required" >&2
+    return 2
+  fi
+  if ! have jq || ! have git; then
+    echo "gate-ledger: work-set skipped (jq and git required)" >&2
+    return 0
+  fi
+
+  slug=$(slugify "$slug")
+  if [ -z "$slug" ]; then
+    echo "gate-ledger: --slug reduced to nothing after slugify" >&2
+    return 2
+  fi
+
+  ensure_gitignore
+  local file; file=$(work_file_init "$slug")
+  local dir; dir=$(work_dir)
+  local tmp; tmp=$(mktemp "$dir/.tmp.XXXXXX")
+  trap 'rm -f "$tmp"' RETURN
+  jq --arg title "$title" --arg src "$src" --arg branch "$branch" \
+     --arg doc "$doc" --arg phase "$phase" --arg t "$(now_iso)" \
+     '.schemaVersion = (.schemaVersion // 1)
+      | .createdAt = (.createdAt // $t)
+      | .updatedAt = $t
+      | (if $title  != "" then .title     = $title  else . end)
+      | (if $src    != "" then .source    = $src    else . end)
+      | (if $branch != "" then .branch    = $branch else . end)
+      | (if $doc    != "" then .designDoc = $doc    else . end)
+      | (if $phase  != "" then .phase     = $phase  else . end)' \
+     "$file" > "$tmp" && mv "$tmp" "$file"
+}
+
+cmd_work_log() {
+  local slug="" step="" outcome="" phase=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --slug)    slug="$2"; shift 2 ;;
+      --step)    step="$2"; shift 2 ;;
+      --outcome) outcome="$2"; shift 2 ;;
+      --phase)   phase="$2"; shift 2 ;;
+      *) echo "gate-ledger: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+  if [ -z "$slug" ] || [ -z "$step" ] || [ -z "$outcome" ]; then
+    echo "gate-ledger: --slug, --step, and --outcome required" >&2
+    return 2
+  fi
+  if ! have jq || ! have git; then
+    echo "gate-ledger: work-log skipped (jq and git required)" >&2
+    return 0
+  fi
+
+  slug=$(slugify "$slug")
+  if [ -z "$slug" ]; then
+    echo "gate-ledger: --slug reduced to nothing after slugify" >&2
+    return 2
+  fi
+
+  ensure_gitignore
+  local file; file=$(work_file_init "$slug")
+  local dir; dir=$(work_dir)
+  local tmp; tmp=$(mktemp "$dir/.tmp.XXXXXX")
+  trap 'rm -f "$tmp"' RETURN
+  jq --arg step "$step" --arg outcome "$outcome" --arg phase "$phase" \
+     --arg s "$(head_sha)" --arg t "$(now_iso)" \
+     '.history = ((.history // []) + [{step: $step, outcome: $outcome, sha: $s, at: $t}])
+      | .updatedAt = $t
+      | (if $phase != "" then .phase = $phase else . end)' \
+     "$file" > "$tmp" && mv "$tmp" "$file"
+}
+
+cmd_work_get() {
+  local slug=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --slug) slug="$2"; shift 2 ;;
+      *) echo "gate-ledger: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+  if [ -z "$slug" ]; then
+    echo "gate-ledger: --slug required" >&2
+    return 2
+  fi
+  slug=$(slugify "$slug")
+  local file; file="$(work_dir)/$slug.json"
+  [ -f "$file" ] || return 0
+  cat "$file"
+}
+
+cmd_work_list() {
+  if ! have jq; then return 0; fi
+  local dir; dir=$(work_dir)
+  local f
+  for f in "$dir"/*.json; do
+    [ -e "$f" ] || continue
+    jq -r '[(.slug // "?"), (.phase // "?"), (.branch // "-"), (.title // "-")] | @tsv' "$f" 2>/dev/null
+  done
+}
+
 cmd_gc() {
   if ! have jq || ! have git; then return 0; fi
   local dir; dir=$(ledger_dir)
@@ -152,11 +308,29 @@ cmd_gc() {
       printf 'removed stale ledger: %s (branch %s no longer exists)\n' "$(basename "$f")" "$branch"
     fi
   done
+
+  # Work files: prune only those tied to a branch that's gone. A work file with
+  # no branch yet (decide/design phases happen before one exists) is kept.
+  local wdir; wdir=$(work_dir)
+  for f in "$wdir"/*.json; do
+    [ -e "$f" ] || continue
+    branch=$(jq -r '.branch // empty' "$f" 2>/dev/null)
+    [ -n "$branch" ] || continue
+    if ! git rev-parse --verify --quiet "refs/heads/$branch" >/dev/null 2>&1; then
+      rm -f "$f"
+      printf 'removed stale work file: %s (branch %s no longer exists)\n' "$(basename "$f")" "$branch"
+    fi
+  done
 }
 
 case "${1:-}" in
-  record) shift; cmd_record "$@" ;;
-  status) shift; cmd_status "$@" ;;
-  gc)     shift; cmd_gc "$@" ;;
-  *) echo "usage: gate-ledger {record --gate G --verdict V | status | gc}" >&2; exit 2 ;;
+  record)    shift; cmd_record "$@" ;;
+  status)    shift; cmd_status "$@" ;;
+  gate-get)  shift; cmd_gate_get "$@" ;;
+  work-set)  shift; cmd_work_set "$@" ;;
+  work-log)  shift; cmd_work_log "$@" ;;
+  work-get)  shift; cmd_work_get "$@" ;;
+  work-list) shift; cmd_work_list "$@" ;;
+  gc)        shift; cmd_gc "$@" ;;
+  *) echo "usage: gate-ledger {record --gate G --verdict V | status | gate-get [--branch B] | work-set --slug S [--title T] [--source SRC] [--branch B] [--design-doc P] [--phase PH] | work-log --slug S --step ST --outcome O [--phase PH] | work-get --slug S | work-list | gc}" >&2; exit 2 ;;
 esac

--- a/commands/gate-design-review.md
+++ b/commands/gate-design-review.md
@@ -64,3 +64,17 @@ If and only if the verdict is PROCEED TO PLAN, write the pre-mortem to `docs/stu
 ```
 
 Tell the user the register was written and that `/gate-audit` (technical lane) and `/gate-acceptance` (product lane) will verify it at the end of the build; committing the file is their call. On REVISE or RETHINK, do not write the file — the re-run after revision regenerates the pre-mortem.
+
+## Record the verdict
+
+After stating the verdict, record it to the local gate ledger so `/work-on` and later
+gates can see where the feature stands. Run (substituting the verdict token you just
+assigned — `PROCEED TO PLAN`, `REVISE`, or `RETHINK`):
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" record --gate design-review --verdict "PROCEED TO PLAN"
+```
+
+The ledger is local and gitignored — it never enters the repo. If `${CLAUDE_PLUGIN_ROOT}`
+did not resolve or the script is not found, tell the user the verdict could not be
+recorded to the gate ledger — do not skip silently.

--- a/commands/gate-should-we-build.md
+++ b/commands/gate-should-we-build.md
@@ -1,6 +1,6 @@
 ---
 description: Evaluate whether a feature idea is worth building before any engineering begins
-allowed-tools: Read, Glob, Grep
+allowed-tools: Read, Glob, Grep, Bash
 ---
 
 # Should we build this?
@@ -26,3 +26,17 @@ Now evaluate honestly:
 Do not be a yes-man. If this is a bad idea, say so plainly and suggest what we should build instead based on the known problems list. If it's a good idea but scoped too big, say that and describe the smaller version.
 
 End with a clear recommendation: **BUILD**, **BUILD SMALLER** (with the scoped-down version), **DEFER** (with what to prioritize instead), or **DON'T BUILD** (with why).
+
+## Record the verdict
+
+After stating the recommendation, record it to the local gate ledger so `/work-on`
+and later gates can see where the feature stands. Run (substituting the verdict
+token you just assigned — `BUILD`, `BUILD SMALLER`, `DEFER`, or `DON'T BUILD`):
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" record --gate should-we-build --verdict "BUILD"
+```
+
+The ledger is local and gitignored — it never enters the repo. If `${CLAUDE_PLUGIN_ROOT}`
+did not resolve or the script is not found, tell the user the verdict could not be
+recorded to the gate ledger — do not skip silently.

--- a/commands/work-on.md
+++ b/commands/work-on.md
@@ -1,0 +1,143 @@
+---
+description: Navigate the feature flow one piece at a time — run the next step without needing to know the full workflow
+argument-hint: "[idea, issue number, or in-flight feature] (omit to do the next piece)"
+allowed-tools: Read, Glob, Grep, Bash, Task, Write
+---
+
+# Work on a feature
+
+Walk one feature through the per-feature gate flow, one piece per invocation. This command owns *which step comes next* — the what and the whether — never the how. It runs Studious's own gates directly and, at the two steps Studious doesn't own (writing the design doc, building), hands over context and steps back.
+
+**One invocation, one piece. Never auto-advance.** When the piece finishes — pass, fail, or handoff — stop and hand control back with the closing block below, even when the result is a clean pass and the next step is obvious. The user advances the flow; you never do.
+
+Read PRODUCT.md at the project root first.
+
+## The flow being navigated
+
+| # | Piece | Owner | The piece is done when |
+|---|-------|-------|------------------------|
+| 1 | decide | `/gate-should-we-build` | verdict recorded (**BUILD** / **BUILD SMALLER** continue the flow) |
+| 2 | design | handoff — Studious steps back | a design doc exists satisfying `reference/design-doc-contract.md` |
+| 3 | design-review | `/gate-design-review` | **PROCEED TO PLAN** |
+| 4 | build | handoff — Studious steps back | implementation commits exist on the feature branch |
+| 5 | audit | `/gate-audit` | **PASS** at HEAD |
+| 6 | acceptance | `/gate-acceptance` | **SHIP** at HEAD |
+
+After piece 6 the flow is `done`: recap the verdict trail and remind the user the PR is theirs to open (`gh pr create` — the PR-time hook reads the same ledger). Never create the PR yourself.
+
+For the gate pieces, run that slash command's workflow now, with the flow's context as its input — each gate owns its own logic and records its own verdict; don't restate or reimplement it here.
+
+## Resolve the feature
+
+Flow position lives in a per-feature work file, `.studious/work/<slug>.json`, read and written only through the ledger tool (see Record keeping). See what's in flight with:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" work-list
+```
+
+- **`$ARGUMENTS` is empty — "do the next piece."** If a work file's branch matches the current branch, that's the feature. Otherwise, if exactly one work file is active (phase not `done`/`stopped`), use it. If several are active, list them and ask which — don't guess. If none exist, say there's no feature in flight and invite `/work-on [idea or issue]`.
+- **`$ARGUMENTS` names in-flight work** (matches a slug, branch, or title) — resume that feature.
+- **Anything else starts a new feature** — a raw idea or an issue reference. For an issue, fetch its title and body with `gh issue view` and use them as the gate input. Derive a short slug from the title, then create the work file at phase `decide`:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" work-set --slug "<slug>" --title "<title>" --source "<issue #N or: idea>" --phase decide
+```
+
+## Find the next piece — evidence first
+
+The work file's `phase` names the next piece, but verify it against evidence before running anything, and correct the file when they disagree — evidence wins:
+
+- **Gate verdicts** — read via the ledger tool, never the raw file: `"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" gate-get` prints the current branch's recorded verdicts as JSON (`.gates.<gate>.verdict` / `.gates.<gate>.sha`); empty output means nothing recorded yet. For audit and acceptance a passing verdict counts only at the current HEAD sha; commits since mean that gate is due again.
+- **Design doc** — the `designDoc` path in the work file, else discover a candidate the way `/gate-design-review` does. When found, record it: `work-set --design-doc "<path>"`.
+- **Pre-mortem register** — `docs/studious/premortems/<doc-slug>.md`, where `<doc-slug>` is the recorded `designDoc`'s filename without its extension — `/gate-design-review` names the register after the design doc, not the feature slug, so don't reuse this flow's `<slug>` here. A register found at that path with a `Branch:` header matching the current branch is evidence design-review already returned **PROCEED TO PLAN**.
+- **Build progress** — implementation commits since the design-review sha. If the phase says `build` and there are none, the build piece isn't done: say so rather than advancing (re-offering the handoff is fine).
+
+## Run exactly one piece
+
+Verdict tokens named below are canonical in `reference/gate-vocabulary.md` — if a gate's
+actual output ever looks inconsistent with the mapping here, that file (and the gate command
+itself) wins.
+
+### 1 · decide
+
+Run `/gate-should-we-build` with the feature as its argument, then set the next phase by verdict:
+
+- **BUILD** → phase `design`
+- **BUILD SMALLER** → phase `design`, and update the work file title to the scoped-down version so every later piece inherits the smaller scope
+- **DEFER** / **DON'T BUILD** → phase `stopped`; surface the gate's reasoning and end the flow (the user can explicitly restart it later)
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" work-log --slug "<slug>" --step decide --outcome "<verdict>" --phase "<next phase>"
+```
+
+### 2 · design — handoff
+
+Studious doesn't author design docs (`reference/design-doc-contract.md` — authoring stays with the user's how-layer). Set the user up, then stop:
+
+- Hand over the decide verdict, the (possibly scoped-down) title, and the contract's six required sections; point at `templates/design-doc.md` as the scaffold.
+- If Superpowers is installed, note that its brainstorming and planning workflow produces a doc satisfying the contract; otherwise any hand-written spec does.
+- Do not draft the doc yourself. It may well get written right here in the session — that work belongs to the user and their workflow, not to this command.
+
+Log the handoff: `work-log --step design --outcome HANDED-OFF` (phase stays `design`; the evidence check advances the flow once the doc exists).
+
+### 3 · design-review
+
+Run `/gate-design-review` against the recorded doc, then:
+
+- **PROCEED TO PLAN** → phase `build`
+- **REVISE** → phase stays `design-review`; the next piece is addressing the listed changes, after which this gate re-runs
+- **RETHINK** → phase `design`; back to the doc with the gate's reasoning
+
+Log with `work-log --step design-review --outcome "<verdict>" --phase "<phase>"`.
+
+### 4 · build — handoff
+
+Studious steps back here (README: build with your own workflow). Hand over the working context, then stop:
+
+- The design doc path, the pre-mortem register path (its items are what `/gate-audit` and `/gate-acceptance` verify at the end), the scoped title, and the source issue if any.
+- Once a feature branch exists, record it — the gate ledger is per-branch, so later pieces need it: `work-set --branch "<branch>"`.
+- If Superpowers is installed, its plan/execute workflow picks up from the design doc; otherwise the user builds however they like.
+
+Log `work-log --step build --outcome HANDED-OFF`. Phase stays `build`; the evidence check advances it when implementation commits exist.
+
+### 5 · audit
+
+Run `/gate-audit`, then:
+
+- **PASS** → phase `acceptance`
+- **FIX AND RE-AUDIT** → phase stays `audit`; the next piece is fixing the critical findings, then re-audit
+- **NEEDS DISCUSSION** → phase stays `audit`; surface the concerns — the user decides how to resolve them
+
+Log with `work-log --step audit --outcome "<verdict>" --phase "<phase>"`.
+
+### 6 · acceptance
+
+Run `/gate-acceptance`, then:
+
+- **SHIP** → phase `done` — recap the trail and hand the PR to the user
+- **FIX AND RE-CHECK** → phase stays `acceptance`
+- **HOLD** → phase stays `acceptance`; surface the product concerns
+
+Log with `work-log --step acceptance --outcome "<verdict>" --phase "<phase>"`.
+
+## Skips
+
+Gates are optional by judgment — but that judgment is the user's. Skip a piece only when the user explicitly says to; log it (`work-log --step <piece> --outcome SKIPPED --phase <next>`) and move on. Never skip on your own initiative, and never treat a fix-and-retry verdict as skippable.
+
+## Close every invocation the same way
+
+After the piece finishes, end with exactly this shape and nothing after it:
+
+```text
+Flow: <slug> — piece <k>/6 (<name>): <outcome>.
+Next piece: <name> — <one clause on what it involves>.
+Run /work-on when you're ready, or just say "next".
+```
+
+When the flow reaches `done` or `stopped`, the last two lines become the wrap-up instead: `done` points at `gh pr create`; `stopped` states the verdict that ended it.
+
+Then stop. Do not start the next piece, do part of it "to save time," or ask whether to continue — the whole point is that the user advances the flow with one word, whenever they're ready.
+
+## Record keeping
+
+All flow state goes through `"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger"` — `work-set`, `work-log`, `work-get`, `work-list` for this flow's own state, and `gate-get` to read gate verdicts — never hand-edit the JSON or read either store's files directly. The files are local and gitignored; they never enter the repo. If `${CLAUDE_PLUGIN_ROOT}` did not resolve or the script is not found, tell the user flow position can't be recorded — do not skip silently — and navigate from evidence alone for this session.

--- a/reference/gate-vocabulary.md
+++ b/reference/gate-vocabulary.md
@@ -1,0 +1,34 @@
+# Gate vocabulary — canonical verdict tokens
+
+Canonical source for each gate's exact verdict tokens. Each gate command file (linked below)
+remains the source of truth for *how* it decides between its tokens — this file exists so
+consumers that must react to a specific token, not just display it, cite one spelling instead
+of retyping it, so a rename in the command doesn't silently drift out of sync with its
+consumers. `commands/work-on.md` cites this file instead of restating token definitions.
+
+## The three-outcome shape
+
+Every gate emits exactly one of: **proceed** (continue the flow), **fix and retry** (address
+findings, then re-run this gate), or **stop / rethink** (a deeper problem — the user decides
+how to resolve it). The tokens differ per gate; the shape doesn't.
+
+| Gate | Command (source of truth) | Proceed | Fix and retry | Stop / rethink |
+|------|---------------------------|---------|----------------|-----------------|
+| decide | `commands/gate-should-we-build.md` | `BUILD` · `BUILD SMALLER` | — | `DEFER` · `DON'T BUILD` |
+| design-review | `commands/gate-design-review.md` | `PROCEED TO PLAN` | `REVISE` | `RETHINK` |
+| audit | `commands/gate-audit.md` | `PASS` | `FIX AND RE-AUDIT` | `NEEDS DISCUSSION` |
+| acceptance | `commands/gate-acceptance.md` | `SHIP` | `FIX AND RE-CHECK` | `HOLD` |
+
+Note: `decide` has no "fix and retry" token — `BUILD SMALLER` is a scoped-down proceed, not a
+retry state.
+
+## Consumers that must stay in sync
+
+Update this table first when a gate's tokens change, then update these consumers:
+
+- The matching skill shim (`skills/evaluate-feature-idea`, `skills/review-design-before-build`,
+  `skills/acceptance-check-before-merge`) — each mentions its gate's tokens in one line.
+- `commands/work-on.md`'s per-piece phase-transition mapping (`## Run exactly one piece`) —
+  reacts to every token to decide the next phase.
+- `DESIGN.md`'s "Gate verdict vocabularies" table — documents this same mapping for readers of
+  the interface contract; keep it a mirror of this file, not an independent listing.

--- a/skills/continue-feature-work/SKILL.md
+++ b/skills/continue-feature-work/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: continue-feature-work
+description: Use when the user wants the next step of feature work already in flight — "do the next piece", "what's the next step on this feature", "continue where we left off", "keep the flow going", or naming an in-progress feature and asking to move it forward. This routes to Studious's /work-on navigator, which runs exactly one step of the gate flow. Do NOT use for picking what to work on across the backlog (that's /backlog-priorities), for evaluating a brand-new idea (that's the should-we-build gate), or for questions about how to implement something — building stays with the user's own workflow.
+---
+
+# Do the next piece
+
+The user has a feature mid-flow and wants it moved one step forward without reciting the workflow. Route that to the navigator.
+
+Invoke the `/work-on` command — with no argument to continue the current feature, or with the feature the user named. Do not reimplement its logic here — the command owns position tracking and the step order. It runs exactly one piece (a gate, or a handoff at the design and build steps) and then stops.
+
+One piece per turn. When it finishes, surface its closing position block and wait — never chain into the following step, even if the user seems in a hurry.

--- a/tests/test_gate_ledger.sh
+++ b/tests/test_gate_ledger.sh
@@ -48,6 +48,24 @@ check "ledger is gitignored (not in status)" "" "$(cd "$d" && git status --porce
 check "upsert keeps audit" "PASS" "$(jq -r '.gates.audit.verdict' "$f")"
 check "upsert adds acceptance" "SHIP" "$(jq -r '.gates.acceptance.verdict' "$f")"
 
+# --- gate-get prints the raw ledger JSON for the current branch ---
+out=$(cd "$d" && "$LEDGER" gate-get)
+contains "gate-get prints the current branch's ledger" '"branch": "feat/foo"' "$out"
+contains "gate-get includes recorded verdicts" '"verdict": "PASS"' "$out"
+
+# --- gate-get is empty when no ledger exists for the branch ---
+dgg=$(sandbox)
+out=$(cd "$dgg" && "$LEDGER" gate-get)
+check "gate-get empty when no ledger recorded" "" "$out"
+
+# --- gate-get --branch reads another branch's ledger without checking it out ---
+( cd "$dgg" && "$LEDGER" record --gate audit --verdict PASS )
+( cd "$dgg" && git checkout -q -b feat/other )
+out=$(cd "$dgg" && "$LEDGER" gate-get --branch feat/foo)
+contains "gate-get --branch reads the named branch's ledger" '"branch": "feat/foo"' "$out"
+out=$(cd "$dgg" && "$LEDGER" gate-get)
+check "gate-get with no --branch still reads the current (different) branch" "" "$out"
+
 # --- status: both passing at HEAD ---
 out=$(cd "$d" && "$LEDGER" status)
 contains "status reports clean pass" "proceed" "$out"
@@ -160,6 +178,56 @@ stderr11=$(cd "$d11" && PATH="$fakebin" "$LEDGER" record --gate audit --verdict 
 contains "record signals on stderr when jq is unavailable" "gate-ledger: record skipped (jq and git required)" "$stderr11"
 check "record does not create a ledger file when jq is unavailable" "no" \
   "$([ -f "$d11/.studious/gates/feat-foo.json" ] && echo yes || echo no)"
+
+# --- work-set creates a slugged work file with fields and timestamps ---
+d12=$(sandbox)
+( cd "$d12" && "$LEDGER" work-set --slug "Fancy Feature!!" --title "Fancy feature" --source "issue #7" --phase decide )
+wf12="$d12/.studious/work/fancy-feature.json"
+check "work-set slugs the filename" "yes" "$([ -f "$wf12" ] && echo yes || echo no)"
+check "work-set stores title" "Fancy feature" "$(jq -r '.title' "$wf12")"
+check "work-set stores source" "issue #7" "$(jq -r '.source' "$wf12")"
+check "work-set stores phase" "decide" "$(jq -r '.phase' "$wf12")"
+check "work-set stamps schemaVersion" "1" "$(jq -r '.schemaVersion' "$wf12")"
+check "work-set stamps createdAt" "yes" "$([ "$(jq -r '.createdAt' "$wf12")" != "null" ] && echo yes || echo no)"
+contains "work-set self-heals .gitignore" ".studious/" "$(cat "$d12/.gitignore")"
+
+# --- work-set upserts: later fields land, earlier fields survive ---
+( cd "$d12" && "$LEDGER" work-set --slug fancy-feature --branch feat/foo --phase build )
+check "work-set upsert adds branch" "feat/foo" "$(jq -r '.branch' "$wf12")"
+check "work-set upsert moves phase" "build" "$(jq -r '.phase' "$wf12")"
+check "work-set upsert keeps title" "Fancy feature" "$(jq -r '.title' "$wf12")"
+
+# --- work-log appends history with the HEAD sha and can set phase ---
+( cd "$d12" && "$LEDGER" work-log --slug fancy-feature --step audit --outcome PASS --phase acceptance )
+check "work-log appends a history entry" "1" "$(jq -r '.history | length' "$wf12")"
+check "work-log stores step" "audit" "$(jq -r '.history[0].step' "$wf12")"
+check "work-log stores outcome" "PASS" "$(jq -r '.history[0].outcome' "$wf12")"
+check "work-log stores HEAD sha" "$(git -C "$d12" rev-parse --short HEAD)" "$(jq -r '.history[0].sha' "$wf12")"
+check "work-log sets phase" "acceptance" "$(jq -r '.phase' "$wf12")"
+
+# --- work-get prints the file; work-list summarizes it ---
+out=$(cd "$d12" && "$LEDGER" work-get --slug fancy-feature)
+contains "work-get prints the work file" '"slug": "fancy-feature"' "$out"
+out=$(cd "$d12" && "$LEDGER" work-list)
+contains "work-list reports slug and phase" "$(printf 'fancy-feature\tacceptance')" "$out"
+
+# --- gc prunes work files for deleted branches, keeps branchless and live ones ---
+d13=$(sandbox)
+( cd "$d13" && "$LEDGER" work-set --slug live-work --branch feat/foo --phase build )
+( cd "$d13" && "$LEDGER" work-set --slug ghost-work --branch ghost/branch --phase build )
+( cd "$d13" && "$LEDGER" work-set --slug early-work --phase decide )
+out=$(cd "$d13" && "$LEDGER" gc)
+contains "gc reports the removed stale work file" "removed stale work file: ghost-work.json (branch ghost/branch no longer exists)" "$out"
+check "gc deletes the stale work file" "no" "$([ -f "$d13/.studious/work/ghost-work.json" ] && echo yes || echo no)"
+check "gc keeps the work file for a live branch" "yes" "$([ -f "$d13/.studious/work/live-work.json" ] && echo yes || echo no)"
+check "gc keeps a branchless (pre-branch) work file" "yes" "$([ -f "$d13/.studious/work/early-work.json" ] && echo yes || echo no)"
+
+# --- work-set signals on stderr (but still returns 0) when jq is unavailable ---
+d14=$(sandbox)
+stderr14=$(cd "$d14" && PATH="$fakebin" "$LEDGER" work-set --slug x --phase decide 2>&1 1>/dev/null)
+contains "work-set signals on stderr when jq is unavailable" "gate-ledger: work-set skipped (jq and git required)" "$stderr14"
+check "work-set does not create a work file when jq is unavailable" "no" \
+  "$([ -f "$d14/.studious/work/x.json" ] && echo yes || echo no)"
 
 echo "----"
 if [ "$fails" -eq 0 ]; then echo "all gate-ledger tests passed"; exit 0; else echo "$fails failure(s)"; exit 1; fi


### PR DESCRIPTION
## Summary

A per-feature navigator for the gate flow: each invocation runs exactly one piece (a gate, or a handoff at the design/build steps Studious doesn't own), then stops. No auto-advance by design — `/work-on` with no argument does the next piece, so advancing never requires knowing the full workflow.

- `commands/work-on.md` — evidence-first position checks (gate ledger, design doc, pre-mortem register, commits), verdict-to-next-phase mapping, fixed closing block
- `skills/continue-feature-work` — conservative natural-language shim delegating to `/work-on`
- `bin/gate-ledger` — new `work-set`/`work-log`/`work-get`/`work-list` subcommands for per-feature state at `.studious/work/<slug>.json`, plus `gate-get` to read gate verdicts through the tool instead of a raw file/schema read; `gc` prunes work files tied to a deleted branch
- `gate-should-we-build` and `gate-design-review` now record verdicts to the ledger
- `reference/gate-vocabulary.md` — new canonical listing of each gate's verdict tokens, cited by `/work-on` and `DESIGN.md` instead of restating them
- README, CLAUDE.md, CONTRIBUTING.md, DESIGN.md updated to match

This branch also ran through `/gate-audit` (security, code, docs, architecture auditors in parallel). Verdict: **PASS**, no critical/blocking findings. Four Important findings came back and are fixed in this same commit:
- Gate ledger was being read via a raw file path/schema in `work-on.md` — added `gate-get` so it goes through the tool, consistent with the rule the same file already states for the work store.
- No shared source of truth for gate verdict tokens, worsened by `/work-on` restating them a third time — extracted `reference/gate-vocabulary.md` (mirrors the existing `reference/severity-rubric.md` pattern); DESIGN.md's inconsistency list is updated to note this is a partial fix (the three skill shims still restate their gate's tokens inline and weren't touched).
- Pre-mortem register path assumed the feature slug, but `gate-design-review` actually names it after the design doc's filename — fixed the evidence-check bullet to match.
- CONTRIBUTING.md's description of `bin/gate-ledger` was stale relative to CLAUDE.md's updated description.

Track-tier findings (hardening notes, minor naming/test-coverage gaps) were left as-is — none are blocking.

## Test plan

- [x] `bash tests/test_gate_ledger.sh` — 43 assertions, all pass (including 5 new `gate-get` tests)
- [x] `shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh` — clean
- [x] `uv run --no-project python scripts/check_references.py` — all references resolve
- [x] `uv run --no-project python scripts/validate_plugin.py` — manifest valid
- [x] `npx -y markdownlint-cli2` — 0 errors
- [x] `uv run --no-project --with pytest pytest tests/python -v` — 33 passed