### PR TITLE
fix: invoke gate-ledger by bare name, not via ${CLAUDE_PLUGIN_ROOT}

### DIFF
--- a/commands/gate-acceptance.md
+++ b/commands/gate-acceptance.md
@@ -42,9 +42,9 @@ can be specific. Run (substituting the verdict token you just assigned — `SHIP
 `FIX AND RE-CHECK`, or `HOLD`):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" record --gate acceptance --verdict "SHIP"
+gate-ledger record --gate acceptance --verdict "SHIP"
 ```
 
-The ledger is local and gitignored — it never enters the repo. If `${CLAUDE_PLUGIN_ROOT}`
-did not resolve or the script is not found, tell the user the verdict could not be
-recorded to the gate ledger — do not skip silently.
+The ledger is local and gitignored — it never enters the repo. If `gate-ledger` is not
+found (the plugin's `bin/` isn't on `PATH` in this environment), tell the user the
+verdict could not be recorded to the gate ledger — do not skip silently.

--- a/commands/gate-audit.md
+++ b/commands/gate-audit.md
@@ -74,9 +74,9 @@ can be specific. Run (substituting the verdict token you just assigned — `PASS
 `FIX AND RE-AUDIT`, or `NEEDS DISCUSSION`):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" record --gate audit --verdict "PASS"
+gate-ledger record --gate audit --verdict "PASS"
 ```
 
-The ledger is local and gitignored — it never enters the repo. If `${CLAUDE_PLUGIN_ROOT}`
-did not resolve or the script is not found, tell the user the verdict could not be
-recorded to the gate ledger — do not skip silently.
+The ledger is local and gitignored — it never enters the repo. If `gate-ledger` is not
+found (the plugin's `bin/` isn't on `PATH` in this environment), tell the user the
+verdict could not be recorded to the gate ledger — do not skip silently.

--- a/commands/gate-design-review.md
+++ b/commands/gate-design-review.md
@@ -72,9 +72,9 @@ gates can see where the feature stands. Run (substituting the verdict token you 
 assigned — `PROCEED TO PLAN`, `REVISE`, or `RETHINK`):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" record --gate design-review --verdict "PROCEED TO PLAN"
+gate-ledger record --gate design-review --verdict "PROCEED TO PLAN"
 ```
 
-The ledger is local and gitignored — it never enters the repo. If `${CLAUDE_PLUGIN_ROOT}`
-did not resolve or the script is not found, tell the user the verdict could not be
-recorded to the gate ledger — do not skip silently.
+The ledger is local and gitignored — it never enters the repo. If `gate-ledger` is not
+found (the plugin's `bin/` isn't on `PATH` in this environment), tell the user the
+verdict could not be recorded to the gate ledger — do not skip silently.

--- a/commands/gate-should-we-build.md
+++ b/commands/gate-should-we-build.md
@@ -34,9 +34,9 @@ and later gates can see where the feature stands. Run (substituting the verdict
 token you just assigned — `BUILD`, `BUILD SMALLER`, `DEFER`, or `DON'T BUILD`):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" record --gate should-we-build --verdict "BUILD"
+gate-ledger record --gate should-we-build --verdict "BUILD"
 ```
 
-The ledger is local and gitignored — it never enters the repo. If `${CLAUDE_PLUGIN_ROOT}`
-did not resolve or the script is not found, tell the user the verdict could not be
-recorded to the gate ledger — do not skip silently.
+The ledger is local and gitignored — it never enters the repo. If `gate-ledger` is not
+found (the plugin's `bin/` isn't on `PATH` in this environment), tell the user the
+verdict could not be recorded to the gate ledger — do not skip silently.

--- a/commands/work-on.md
+++ b/commands/work-on.md
@@ -32,7 +32,7 @@ For the gate pieces, run that slash command's workflow now, with the flow's cont
 Flow position lives in a per-feature work file, `.studious/work/<slug>.json`, read and written only through the ledger tool (see Record keeping). See what's in flight with:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" work-list
+gate-ledger work-list
 ```
 
 - **`$ARGUMENTS` is empty — "do the next piece."** If a work file's branch matches the current branch, that's the feature. Otherwise, if exactly one work file is active (phase not `done`/`stopped`), use it. If several are active, list them and ask which — don't guess. If none exist, say there's no feature in flight and invite `/work-on [idea or issue]`.
@@ -40,14 +40,14 @@ Flow position lives in a per-feature work file, `.studious/work/<slug>.json`, re
 - **Anything else starts a new feature** — a raw idea or an issue reference. For an issue, fetch its title and body with `gh issue view` and use them as the gate input. Derive a short slug from the title, then create the work file at phase `decide`:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" work-set --slug "<slug>" --title "<title>" --source "<issue #N or: idea>" --phase decide
+gate-ledger work-set --slug "<slug>" --title "<title>" --source "<issue #N or: idea>" --phase decide
 ```
 
 ## Find the next piece — evidence first
 
 The work file's `phase` names the next piece, but verify it against evidence before running anything, and correct the file when they disagree — evidence wins:
 
-- **Gate verdicts** — read via the ledger tool, never the raw file: `"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" gate-get` prints the current branch's recorded verdicts as JSON (`.gates.<gate>.verdict` / `.gates.<gate>.sha`); empty output means nothing recorded yet. For audit and acceptance a passing verdict counts only at the current HEAD sha; commits since mean that gate is due again.
+- **Gate verdicts** — read via the ledger tool, never the raw file: `gate-ledger gate-get` prints the current branch's recorded verdicts as JSON (`.gates.<gate>.verdict` / `.gates.<gate>.sha`); empty output means nothing recorded yet. For audit and acceptance a passing verdict counts only at the current HEAD sha; commits since mean that gate is due again.
 - **Design doc** — the `designDoc` path in the work file, else discover a candidate the way `/gate-design-review` does. When found, record it: `work-set --design-doc "<path>"`.
 - **Pre-mortem register** — `docs/studious/premortems/<doc-slug>.md`, where `<doc-slug>` is the recorded `designDoc`'s filename without its extension — `/gate-design-review` names the register after the design doc, not the feature slug, so don't reuse this flow's `<slug>` here. A register found at that path with a `Branch:` header matching the current branch is evidence design-review already returned **PROCEED TO PLAN**.
 - **Build progress** — implementation commits since the design-review sha. If the phase says `build` and there are none, the build piece isn't done: say so rather than advancing (re-offering the handoff is fine).
@@ -67,7 +67,7 @@ Run `/gate-should-we-build` with the feature as its argument, then set the next 
 - **DEFER** / **DON'T BUILD** → phase `stopped`; surface the gate's reasoning and end the flow (the user can explicitly restart it later)
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" work-log --slug "<slug>" --step decide --outcome "<verdict>" --phase "<next phase>"
+gate-ledger work-log --slug "<slug>" --step decide --outcome "<verdict>" --phase "<next phase>"
 ```
 
 ### 2 · design — handoff
@@ -140,4 +140,4 @@ Then stop. Do not start the next piece, do part of it "to save time," or ask whe
 
 ## Record keeping
 
-All flow state goes through `"${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger"` — `work-set`, `work-log`, `work-get`, `work-list` for this flow's own state, and `gate-get` to read gate verdicts — never hand-edit the JSON or read either store's files directly. The files are local and gitignored; they never enter the repo. If `${CLAUDE_PLUGIN_ROOT}` did not resolve or the script is not found, tell the user flow position can't be recorded — do not skip silently — and navigate from evidence alone for this session.
+All flow state goes through `gate-ledger` — `work-set`, `work-log`, `work-get`, `work-list` for this flow's own state, and `gate-get` to read gate verdicts — never hand-edit the JSON or read either store's files directly. The files are local and gitignored; they never enter the repo. If `gate-ledger` is not found (the plugin's `bin/` isn't on `PATH` in this environment), tell the user flow position can't be recorded — do not skip silently — and navigate from evidence alone for this session.

--- a/tests/test_gate_ledger.sh
+++ b/tests/test_gate_ledger.sh
@@ -120,11 +120,15 @@ hook_embedded=$(cd "$d6" && CLAUDE_PLUGIN_ROOT="$ROOT" \
   bash "$HOOK" <<<'{"tool_input":{"command":"git log --grep=\"gh pr create\""}}')
 contains "hook matches gh pr create embedded in a longer command" '"permissionDecision": "ask"' "$hook_embedded"
 
-# --- command prompts invoke the ledger via ${CLAUDE_PLUGIN_ROOT}, not a bare name ---
-# Plugins don't add bin/ to PATH, so a bare `gate-ledger ...` in a command prompt
-# is "command not found" at runtime. Every invocation must resolve the script path.
-bare=$(grep -rnE '^[[:space:]]*gate-ledger ' "$ROOT/commands" 2>/dev/null || true)
-check "no command invokes gate-ledger without \${CLAUDE_PLUGIN_ROOT}" "" "$bare"
+# --- command prompts invoke the ledger by its bare name, not via ${CLAUDE_PLUGIN_ROOT} ---
+# ${CLAUDE_PLUGIN_ROOT} only expands in JSON-config-driven processes (hooks.json,
+# MCP/LSP configs) that the harness spawns directly — never in commands/*.md body
+# text, which the model runs verbatim through the Bash tool (upstream Claude Code
+# limitation, anthropics/claude-code#9354). A plugin's bin/ IS added to the Bash
+# tool's PATH while the plugin is enabled, so the bare name is what actually
+# resolves at runtime (see #83).
+prefixed=$(grep -rnF "\${CLAUDE_PLUGIN_ROOT}/bin/gate-ledger" "$ROOT/commands" 2>/dev/null || true)
+check "no command invokes gate-ledger via \${CLAUDE_PLUGIN_ROOT}" "" "$prefixed"
 
 # --- record from a subdirectory still anchors the ledger at the repo root (#55) ---
 d7=$(sandbox)


### PR DESCRIPTION
## Summary

- `${CLAUDE_PLUGIN_ROOT}` only expands in JSON-config-driven processes Claude Code spawns directly (hooks.json, MCP/LSP configs) — never in `commands/*.md` body text, which the model runs verbatim through the Bash tool. This is a known, still-open upstream limitation (anthropics/claude-code#9354).
- PR #52 had "fixed" a bare `gate-ledger` command-not-found error by prefixing it with `${CLAUDE_PLUGIN_ROOT}/bin/`, but that variable never resolves in command markdown, so every gate command silently lost its ability to record/read verdicts — exactly what #83 reports.
- Claude Code documents (and this session's own PATH confirms) that a plugin's `bin/` is added to the Bash tool's PATH while the plugin is enabled, so the bare `gate-ledger` invocation was correct all along.
- Reverts all 5 gate/work-on command files to the bare invocation and flips the regression test in `tests/test_gate_ledger.sh` to assert the new invariant. `hooks/hooks.json` and `hooks/gate-reminder.sh` are untouched — those are real hook subprocesses where `${CLAUDE_PLUGIN_ROOT}` is documented to work.

## Gates run

- `/gate-audit` — **PASS** (4 backend auditors, no frontend changes/pre-mortem register on this branch)
- `/gate-acceptance` — **SHIP** (product-reviewer + implementation walkthrough; only MINOR/OBSERVATION findings, no BLOCKER/SHOULD FIX)

Non-blocking follow-up noted by both: the "verdict could not be recorded" fallback text doesn't tell the user what to do about it (e.g. enable the plugin) — worth a small follow-up PR, doesn't block this fix.

## Test plan

- [x] `bash tests/test_gate_ledger.sh` — all 55 checks pass
- [x] `npx -y markdownlint-cli2` — 0 errors
- [x] `uv run --no-project python scripts/check_references.py` — passes
- [x] `uv run --no-project python scripts/validate_plugin.py` — passes
- [x] `shellcheck bin/gate-ledger hooks/gate-reminder.sh tests/test_gate_ledger.sh scripts/install-dev.sh` — clean
- [x] `uv run --no-project --with pytest pytest tests/python -v` — 33 passed

Fixes #83