### PR TITLE
docs: overhaul README around work-on/work-through, fix auditor-count drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Studious adds that judgment back as one discipline entered at the scope of the w
 
 Studious runs on 2 rhythms. A per-feature gate flow that checks each piece of work before and after you build it, and a per-project health loop that reviews the whole on a cadence. Both read from 3 context documents (PRODUCT.md, DESIGN.md, CLAUDE.md) that hold your product's through-lines, so every judgment is grounded in the same context. That's the whole system.
 
-## Install
+## Quick start
 
 Via the Jacquard Labs marketplace:
 
@@ -38,28 +38,49 @@ This creates your context documents (PRODUCT.md and DESIGN.md, extracted from th
 
 Run `/studious-doctor` any time after — right after install, after a marketplace update, or whenever a gate feels like it ran with less than it should have. It's a read-only check, not a gate: required tooling (git/gh/jq), whether every shipped agent and skill actually registered this session, and whether your context docs are missing or still unedited templates. It fixes nothing, just tells you what to fix. Also fires from natural language — "is my Studious install healthy?".
 
-## Building a feature
+**From here, the fastest way in is to stop reading and run one command:**
 
-Studious wraps feature development in quality gates. Between them you build, and Studious doesn't care how. Each gate exists to catch a specific failure:
+- Building one thing? `/work-on [idea or issue]`. It runs one step of the flow, tells you what's next, and hands back to you at the two steps Studious doesn't own (writing the design, writing the code). Run it again — or just say "next" — when you're ready to keep going.
+- Driving a batch? `/work-through [milestone, epic issue, or label]`. It proposes a story plan for your approval, then dispatched agents design, build, and gate each story in parallel, gated exactly like anything else.
+
+Everything past this point is what those two commands are driving underneath — read on for the detail, or to run a piece by hand.
+
+## The gate flow
+
+Studious wraps feature development in quality gates. Between them you build, and Studious doesn't care how. You can drive this yourself one gate at a time, or let a navigator run it for you.
+
+### Let `/work-on` navigate one feature
+
+`/work-on [idea or issue]` walks a feature through the gate sequence below, one piece per invocation. Each invocation runs exactly one step — a gate, or a handoff at the two steps Studious doesn't own (design doc, build) — then stops and tells you what the next piece is. There is no auto-advance. When you're ready, `/work-on` with no argument (or just "next", or "do the next piece") runs it; you never have to remember which gate comes after which. Position is tracked per feature in local, gitignored `.studious/` state, so the flow survives across sessions and picks up where the feature actually stands — including gates you ran by hand.
+
+### Let `/work-through` drive a whole milestone
+
+`/work-through [milestone, epic issue, or label]` scales the flow up a level. The first run reads the milestone's issues (read-only) and proposes a story plan — dependency order, acceptance criteria per story, which gates each story needs, an epic-level pre-mortem — then stops for your approval; nothing runs before it. Every run after that drives: agents design, build, and gate stories in parallel worktrees (3 at once by default), stories that pass their gates merge into an `epic/<name>` integration branch, and fix-it verdicts get at most 2 repair cycles with a fresh auditor each time. Judgment verdicts — RETHINK, NEEDS DISCUSSION, HOLD — never retry: that story parks for you while independent stories keep moving. When everything lands, the whole epic diff gets a final audit plus an acceptance check against the epic's goal, and the branch is yours (`gh pr create` — same ledger, same PR-time hook). Any parked story is a normal `/work-on` feature, so you can always take one over by hand. Fair warning: an epic run spends tokens like the 5–10 supervised flows it replaces.
+
+The driver has two execution modes with identical semantics, interchangeable mid-epic: the primary mode runs the scheduling as a deterministic Workflow script (`workflows/epic-driver.js` — DAG order, concurrency, retry caps, and merge order in code, so bookkeeping never burns model context and cannot be improvised), and a prompt-driven fallback covers environments without the Workflow tool. Judgment — decompositions, gate verdicts, fixes, park explanations — lives in dispatched agents in both modes.
+
+### Run a gate directly
+
+Each gate exists to catch a specific failure. Reach for one on its own when you don't need the full navigator — a small fix, or picking up a feature mid-flow by hand:
 
 - Pick what to build with `/backlog-priorities` (ranks your open GitHub issues by severity/alignment/unblocking potential) or `/gate-should-we-build [idea]` (scores a raw idea against PRODUCT.md and the smallest version worth shipping). Catches building the wrong thing.
-- Gate the design with `/gate-design-review`. It walks your design doc as your primary persona would and flags where they'd get confused or frustrated. Catches a bad design before you spend build effort on it.
+- Gate the design with `/gate-design-review`. It walks your design doc as your primary persona would and flags where they'd get confused or frustrated. Catches a bad design before you spend build effort on it. On a passing verdict, it also writes a pre-mortem register (`docs/studious/premortems/<slug>.md`) — failure modes predicted at design time, checked back against the finished changeset at the end of the flow.
 - Build it with your own workflow — by hand or with any executor (Superpowers works well here). Studious steps back in the supervised flow; in `/work-through` epics, dispatched workers build to `reference/worker-contract.md` and are gated like anyone else.
-- Audit before merge with `/gate-audit`: 6 auditors in parallel (security, code quality, docs, architecture, UX, frontend), each staying in its lane, plus an accessibility pass via the `web-design-guidelines` skill (Web Interface Guidelines) when it's installed. The 3 web auditors skip automatically on projects with no web surface and on branches with no frontend changes.
-- Gate acceptance with `/gate-acceptance`. Product review, not code review: does the implementation actually deliver the experience? It walks every user-facing change, checks error states for human-friendly messaging, and regression-tests the critical journeys in PRODUCT.md.
+- Audit before merge with `/gate-audit`. Security, code quality, docs, and architecture always run; UX, frontend, and an accessibility pass (via the `web-design-guidelines` skill, or a vendored fallback when it isn't installed) join in on projects with a web surface; and if the design-review gate recorded a pre-mortem register for this branch, a dedicated auditor checks each predicted failure mode — REALIZED / NOT REALIZED / CAN'T VERIFY, evidence attached. Up to 8 auditors, each staying in its lane.
+- Gate acceptance with `/gate-acceptance`. Product review, not code review: does the implementation actually deliver the experience? It walks every user-facing change, checks error states for human-friendly messaging, regression-tests the critical journeys in PRODUCT.md, and — same register, other half — verifies the pre-mortem's product-lane items against what shipped.
 
 ```
 /backlog-priorities  or  /gate-should-we-build [idea]
          ↓
    design doc
          ↓
-   /gate-design-review
+   /gate-design-review  →  writes pre-mortem register
          ↓
    implement
          ↓
-   /gate-audit
+   /gate-audit  →  verifies technical-lane register items
          ↓
-   /gate-acceptance
+   /gate-acceptance  →  verifies product-lane register items
          ↓
    gh pr create
          ↓
@@ -70,39 +91,11 @@ When you run `gh pr create`, a PR-time hook reads the gate verdicts recorded to 
 
 You don't need every gate every time. For small fixes, `/gate-audit` alone is enough. The gates exist to catch building the wrong thing or shipping a bad experience. Use judgment about when that risk applies.
 
-The three product gates also fire from natural language, not just the slash command — asking "should we build this?", "review this design before I build it", or "does this actually deliver?" routes to the matching gate. So does flow continuation — "do the next piece" resumes `/work-on` (below). Triggers are deliberately conservative, so you'll still reach for the commands directly most of the time.
-
-### Or have Studious navigate
-
-`/work-on [idea or issue]` walks a feature through that same sequence one piece at a time. Each invocation runs exactly one step — a gate, or a handoff at the two steps Studious doesn't own (design doc, build) — then stops and tells you what the next piece is. There is no auto-advance. When you're ready, `/work-on` with no argument (or just "next", or "do the next piece") runs it; you never have to remember which gate comes after which. Position is tracked per feature in the same local, gitignored `.studious/` state as the gate ledger, so the flow survives across sessions and picks up where the feature actually stands — including gates you ran by hand.
-
-### Or run a whole milestone
-
-`/work-through [milestone, epic issue, or label]` scales the flow up a level. The first
-run reads the milestone's issues (read-only) and proposes a story plan — dependency
-order, acceptance criteria per story, which gates each story needs, an epic-level
-pre-mortem — then stops for your approval; nothing runs before it. Every run after
-that drives: agents design, build, and gate stories in parallel worktrees (3 at once
-by default), stories that pass their gates merge into an `epic/<name>` integration
-branch, and fix-it verdicts get at most 2 repair cycles with a fresh auditor each
-time. Judgment verdicts — RETHINK, NEEDS DISCUSSION, HOLD — never retry: that story
-parks for you while independent stories keep moving. When everything lands, the whole
-epic diff gets a final audit plus an acceptance check against the epic's goal, and the
-branch is yours (`gh pr create` — same ledger, same PR-time hook). Any parked story is
-a normal `/work-on` feature, so you can always take one over by hand. Fair warning: an
-epic run spends tokens like the 5–10 supervised flows it replaces.
-
-The driver has two execution modes with identical semantics, interchangeable
-mid-epic: the primary mode runs the scheduling as a deterministic Workflow script
-(`workflows/epic-driver.js` — DAG order, concurrency, retry caps, and merge order in
-code, so bookkeeping never burns model context and cannot be improvised), and a
-prompt-driven fallback covers environments without the Workflow tool. Judgment —
-decompositions, gate verdicts, fixes, park explanations — lives in dispatched agents
-in both modes.
+The three product gates also fire from natural language, not just the slash command — asking "should we build this?", "review this design before I build it", or "does this actually deliver?" routes to the matching gate. So does flow continuation — "do the next piece" resumes `/work-on`. Triggers are deliberately conservative, so you'll still reach for the commands directly most of the time.
 
 ## CI mode (optional)
 
-`.github/workflows/gate-audit-pr.yml` runs `/gate-audit` non-interactively against a PR and posts the report as a PR comment — the same 6-7 auditor fan-out you'd get locally, without anyone having to remember to run it. It ships **dormant** (manual `workflow_dispatch` trigger only): pick a PR, run the workflow from the Actions tab with that PR's number as input, and it audits that PR and comments on it. It does not fire automatically on every PR yet.
+`.github/workflows/gate-audit-pr.yml` runs `/gate-audit` non-interactively against a PR and posts the report as a PR comment — the same auditor fan-out you'd get locally (up to 8, depending on the project's web surface and whether a pre-mortem register exists), without anyone having to remember to run it. It ships **dormant** (manual `workflow_dispatch` trigger only): pick a PR, run the workflow from the Actions tab with that PR's number as input, and it audits that PR and comments on it. It does not fire automatically on every PR yet.
 
 To set it up:
 

--- a/commands/gate-audit.md
+++ b/commands/gate-audit.md
@@ -1,11 +1,11 @@
 ---
-description: Run the audit suite — security, code quality, docs, architecture, UX, and frontend in parallel, plus an optional accessibility pass
+description: Run the audit suite — security, code quality, docs, and architecture always run; UX, frontend, and an accessibility pass join in on projects with a web surface; pre-mortem verification joins in when a register exists for this branch
 allowed-tools: Read, Glob, Grep, Bash, Task, Write
 ---
 
 # Audit gate — all auditors
 
-Run every auditor in parallel against the current branch. This combines the backend audit suite, frontend audit suite, and accessibility checks into a single pass.
+Run every auditor in parallel against the current branch. This combines the backend audit suite, frontend audit suite, accessibility checks, and pre-mortem verification into a single pass.
 
 Read CLAUDE.md, PRODUCT.md, and DESIGN.md first.
 


### PR DESCRIPTION
## Summary
- Restructures README.md to lead with `/work-on` and `/work-through` as the fast path for a dev getting up to speed, demoting the manual per-gate walkthrough to "run a gate directly" — the primitives those two commands drive underneath.
- Documents the pre-mortem register (`/gate-design-review` writes it; `/gate-audit` and `/gate-acceptance` each verify their half) — shipped in #82, never mentioned in the README.
- Fixes stale auditor counts: README said "6 auditors" / CI mode said "6-7 fan-out" — it's up to 8 now (6 core + accessibility on web surfaces + pre-mortem verification when a register exists). Same fix applied to `commands/gate-audit.md`'s own frontmatter `description` and body summary, which had the identical drift.

## Test plan
- [x] `npx -y markdownlint-cli2` — 0 errors
- [x] `uv run --no-project python scripts/check_references.py` — all references resolve
- [x] Verified auditor counts, retry caps (2), and concurrency default (3) against `workflows/epic-driver.js` and `commands/gate-audit.md`/`gate-acceptance.md` source before writing the claims