### PR TITLE
board-ui: control-room redesign — the Operator Graphic, two shifts

### DIFF
--- a/assets/board-ui/app.js
+++ b/assets/board-ui/app.js
@@ -143,15 +143,20 @@ function deriveBlocker(storySlug, stories) {
 function classifyGaugeState(storySlug, stories) {
   var all = stories || {};
   var story = all[storySlug] || {};
+  // A story's own terminal status outranks the derived blocked state: a
+  // parked story with a non-landed dependency must read PARKED at the
+  // channel, matching the amber the alarm summary already shows for it
+  // (acceptance finding: precedence previously let AWAIT/STANDBY mask a
+  // park at the channel while CAS showed it amber).
   if (story.status === 'dropped') return { code: 'dropped', label: 'DROPPED' };
+  if (story.status === 'parked') return { code: 'parked', label: 'PARKED' };
+  if (story.status === 'landed') return { code: 'landed', label: 'LANDED' };
   var blocker = deriveBlocker(storySlug, all);
   if (blocker) {
     return blocker.dropped
       ? { code: 'blocked-dead', label: 'AWAIT ' + blocker.slug + ' — DROPPED' }
       : { code: 'blocked', label: 'AWAIT ' + blocker.slug };
   }
-  if (story.status === 'parked') return { code: 'parked', label: 'PARKED' };
-  if (story.status === 'landed') return { code: 'landed', label: 'LANDED' };
   if (story.status === 'pending') return { code: 'pending', label: 'STANDBY' };
   return { code: 'active', label: String(story.status || 'active').toUpperCase() };
 }
@@ -193,7 +198,10 @@ function gaugeAriaLabel(storySlug, stories) {
 function gateBlockState(storySlug, story, gate, events) {
   var s = story || {};
   var n = s.retries && s.retries[gate];
-  var suffix = n ? ' ✕' + n : '';
+  // burn renders with its ceiling (✕1/2) — a bare count tells the operator
+  // nothing about how close to parking without knowing the cap (acceptance
+  // finding); MAX_FIX_CYCLES is the vendored driver cap
+  var suffix = n ? ' ✕' + n + '/' + MAX_FIX_CYCLES : '';
   if (WORKER_PHASES.has(gate)) {
     if (s.status === 'landed' || workerPhaseDone(storySlug, gate, events)) return { state: 'pass', text: 'DONE' };
     return { state: 'unrun', text: '—' };
@@ -395,7 +403,7 @@ function buildCasMessages(stories, events, opts) {
       green.push({ tier: 'green', slug: e.story, message: 'landed', text: e.story + ' landed', at: e.at });
     } else if (e.kind === 'story' && e.bumpRetryGate) {
       var count = e.retries != null ? e.retries : '?';
-      var cycleMsg = 'fix cycle ' + count + ' for ' + e.bumpRetryGate;
+      var cycleMsg = 'fix cycle ' + count + ' of ' + MAX_FIX_CYCLES + ' for ' + e.bumpRetryGate;
       green.push({ tier: 'green', slug: e.story, message: cycleMsg, text: e.story + ': ' + cycleMsg, at: e.at });
     }
   }
@@ -606,11 +614,24 @@ function channelRow(storySlug) {
 function renderChannels() {
   var wrap = document.getElementById('channels');
   wrap.textContent = '';
+  var any = false;
   board.order.forEach(function (slug) {
     if (Object.prototype.hasOwnProperty.call(board.snapshot.stories, slug)) {
       wrap.appendChild(channelRow(slug));
+      any = true;
     }
   });
+  if (!any) {
+    // A missing blackboard must not look like a healthy epic with no work:
+    // board-server returns status "unknown" with empty stories for a slug it
+    // can't resolve, and the board's whole job is at-a-glance legibility
+    // (acceptance finding: wrong slug rendered identically to all-nominal).
+    var epicStatus = (board.snapshot.epic && board.snapshot.epic.status) || 'unknown';
+    var text = epicStatus === 'unknown'
+      ? 'No blackboard found for this epic — check the slug passed to board-server.'
+      : 'No stories recorded for this epic yet.';
+    wrap.appendChild(el('div', { class: 'channels-empty', text: text }));
+  }
 }
 
 function renderCas() {
@@ -655,7 +676,9 @@ function renderHeader() {
   var counts = document.getElementById('epic-counts');
   counts.textContent = '';
   counts.appendChild(document.createTextNode(landed + '/' + slugs.length + ' LANDED · '));
-  counts.appendChild(el('span', { class: 'alarm', text: alarms + ' ALARM' + (alarms === 1 ? '' : 'S') }));
+  // amber only when there IS something demanding attention — "0 ALARMS" in
+  // the caution hue would dilute the amber=alarm-tier reservation
+  counts.appendChild(el('span', { class: alarms > 0 ? 'alarm' : '', text: alarms + ' ALARM' + (alarms === 1 ? '' : 'S') }));
   counts.appendChild(document.createTextNode(' · CAP ' + (epic.concurrency != null ? epic.concurrency : '—')));
 }
 
@@ -700,9 +723,17 @@ function renderDrawer() {
 
   document.getElementById('drawer-worktree').textContent = story.worktree || '(not recorded)';
 
-  var cmd = buildResolutionCommand(epicSlug, drawerStorySlug, story, MAX_FIX_CYCLES);
+  // The un-park recipe exists only for parked stories — offering it on any
+  // other drawer hands the operator a copy-able command that would flip a
+  // healthy or landed story back to pending (acceptance finding: the same
+  // trust hazard the conditional --reset-retry logic exists to prevent, one
+  // layer up). Non-parked drawers say so instead of arming the command.
+  var isParked = story.status === 'parked';
+  document.getElementById('drawer-resolution').hidden = !isParked;
+  document.getElementById('drawer-no-resolution').hidden = isParked;
   var cmdField = document.getElementById('drawer-command');
-  cmdField.value = cmd;
+  cmdField.value = isParked ? buildResolutionCommand(epicSlug, drawerStorySlug, story, MAX_FIX_CYCLES) : '';
+  if (!isParked) document.getElementById('copy-status').textContent = '';
 }
 
 function copyDrawerCommand() {

--- a/assets/board-ui/app.js
+++ b/assets/board-ui/app.js
@@ -11,7 +11,7 @@
 // Inlined verbatim into the page bin/board-server's `GET /` serves (see that
 // file's render_page()) so the shipped document stays one self-contained
 // HTML file with no external <script src>. Also loadable via plain
-// require() from tests/js/test_board_ui_app.js, which exercises the pure
+// require() from tests/js/test-board-ui-app.js, which exercises the pure
 // derivation functions below directly. No import/export syntax anywhere in
 // this file so it runs unmodified both inlined into a <script> tag (no
 // module system there) and under Node's default CommonJS loader (no
@@ -167,28 +167,50 @@ function gaugeAriaLabel(storySlug, stories) {
   return title + ', status ' + cls.label;
 }
 
-// The per-gate state a channel block renders. One of:
-//   'pass'  — worker phase done, or a proceed verdict recorded
+// Everything a channel's gate block renders, derived once: `state` is the
+// styling enum, `text` the display token beside the gate label.
+//   'pass'  — worker phase done, or a proceed verdict recorded; text is the
+//             verdict token verbatim, or 'DONE' where none exists (worker
+//             phases carry no verdict vocabulary; a landed story's feed may
+//             be too thin to carry one)
 //   'fix'   — a non-proceed verdict recorded, or (for a parked story) the
 //             gate its recorded park reason names — the burn is visible even
 //             when the resumed event feed is too thin to carry the verdict
-//   'unrun' — nothing recorded yet
+//             event; text is the verdict token (from the event, or parsed
+//             from the park reason) plus a '✕n' retry suffix when that
+//             gate's fix budget has burned
+//   'unrun' — nothing recorded yet; text is the em-dash placeholder
 // A landed story renders every block 'pass': the status field is
 // authoritative (a story cannot land without its final profiled gate's
-// proceed token); events enrich but never veto it — the same status-wins
-// rule the drawer's verdict trail does NOT apply, because there the events
-// ARE the content.
+// proceed token); events enrich but never veto it — a stale non-proceed
+// verdict on a landed story's thin feed degrades to 'DONE' rather than
+// contradicting the green block with a fix token. (The drawer's verdict
+// trail does NOT apply this status-wins rule, because there the events ARE
+// the content.)
+// Both halves live here in the pure core so the DOM layer renders verbatim
+// (audit finding: the text half previously lived untested in gateBlock,
+// duplicating these branches and re-scanning events).
 function gateBlockState(storySlug, story, gate, events) {
   var s = story || {};
-  if (s.status === 'landed') return 'pass';
-  if (WORKER_PHASES.has(gate)) return workerPhaseDone(storySlug, gate, events) ? 'pass' : 'unrun';
+  var n = s.retries && s.retries[gate];
+  var suffix = n ? ' ✕' + n : '';
+  if (WORKER_PHASES.has(gate)) {
+    if (s.status === 'landed' || workerPhaseDone(storySlug, gate, events)) return { state: 'pass', text: 'DONE' };
+    return { state: 'unrun', text: '—' };
+  }
   var v = latestVerdict(storySlug, gate, events);
-  if (v) return PROCEED_VERDICTS.has(v) ? 'pass' : 'fix';
+  if (s.status === 'landed') {
+    return { state: 'pass', text: v && PROCEED_VERDICTS.has(v) ? v : 'DONE' };
+  }
+  if (v) {
+    if (PROCEED_VERDICTS.has(v)) return { state: 'pass', text: v };
+    return { state: 'fix', text: v + suffix };
+  }
   if (s.status === 'parked') {
     var parsed = parseParkReasonGate(s.reason);
-    if (parsed && parsed.gate === gate) return 'fix';
+    if (parsed && parsed.gate === gate) return { state: 'fix', text: (parsed.verdict || 'FIX') + suffix };
   }
-  return 'unrun';
+  return { state: 'unrun', text: '—' };
 }
 
 // Most recent gate-verdict event's verdict for (story, gate), or null if
@@ -336,6 +358,10 @@ function latestParkEventAt(storySlug, events) {
 // always sorts above every green (advisory) entry regardless of timestamp;
 // within a tier, newest first. No parked stories and no advisory activity
 // renders one explicit empty-state entry — never a silently blank list.
+// Each entry carries `message` (the body without the slug) as its own field
+// alongside the composed `text`, so a columned renderer presents fields
+// instead of parsing the slug prefix back off a string this same function
+// just joined (audit finding: compose-then-parse at the point of use).
 function buildCasMessages(stories, events, opts) {
   var limit = (opts && opts.limit) || GREEN_CAS_LIMIT;
   var all = stories || {};
@@ -345,10 +371,12 @@ function buildCasMessages(stories, events, opts) {
   for (var i = 0; i < storySlugs.length; i++) {
     var slug = storySlugs[i];
     if (all[slug] && all[slug].status === 'parked') {
+      var reason = all[slug].reason || '(no reason recorded)';
       amber.push({
         tier: 'amber',
         slug: slug,
-        text: slug + ': ' + (all[slug].reason || '(no reason recorded)'),
+        message: reason,
+        text: slug + ': ' + reason,
         at: latestParkEventAt(slug, events) || '',
       });
     }
@@ -361,12 +389,14 @@ function buildCasMessages(stories, events, opts) {
     var e = list[j];
     if (!e) continue;
     if (e.kind === 'gate-verdict' && PROCEED_VERDICTS.has(e.verdict)) {
-      green.push({ tier: 'green', slug: e.story, text: e.story + ': ' + e.gate + ' → ' + e.verdict, at: e.at });
+      var verdictMsg = e.gate + ' → ' + e.verdict;
+      green.push({ tier: 'green', slug: e.story, message: verdictMsg, text: e.story + ': ' + verdictMsg, at: e.at });
     } else if (e.kind === 'story' && e.status === 'landed') {
-      green.push({ tier: 'green', slug: e.story, text: e.story + ' landed', at: e.at });
+      green.push({ tier: 'green', slug: e.story, message: 'landed', text: e.story + ' landed', at: e.at });
     } else if (e.kind === 'story' && e.bumpRetryGate) {
       var count = e.retries != null ? e.retries : '?';
-      green.push({ tier: 'green', slug: e.story, text: e.story + ': fix cycle ' + count + ' for ' + e.bumpRetryGate, at: e.at });
+      var cycleMsg = 'fix cycle ' + count + ' for ' + e.bumpRetryGate;
+      green.push({ tier: 'green', slug: e.story, message: cycleMsg, text: e.story + ': ' + cycleMsg, at: e.at });
     }
   }
   green.reverse(); // events are oldest-first; newest-first within tier
@@ -374,9 +404,23 @@ function buildCasMessages(stories, events, opts) {
 
   var combined = amber.concat(trimmedGreen);
   if (combined.length === 0) {
-    return [{ tier: 'empty', slug: null, text: 'ALL SYSTEMS NOMINAL', at: '' }];
+    return [{ tier: 'empty', slug: null, message: 'ALL SYSTEMS NOMINAL', text: 'ALL SYSTEMS NOMINAL', at: '' }];
   }
   return combined;
+}
+
+// Alarm-journal clock label. The schema's `at` is UTC (reference/
+// events-format.md; bin/gate-ledger stamps `date -u`), but the operator
+// correlates journal rows with their own terminal, so this renders the
+// LOCAL wall clock — a positional slice of the ISO string showed an event
+// at 11:03 PDT as 18:03 (audit finding). Absent or unparseable timestamps
+// degrade to the em-dash placeholder, never a junk substring.
+function casTimeLabel(at) {
+  if (!at) return '—';
+  var d = new Date(at);
+  if (isNaN(d.getTime())) return '—';
+  function two(n) { return (n < 10 ? '0' : '') + n; }
+  return two(d.getHours()) + ':' + two(d.getMinutes());
 }
 
 // Parses parkPrompt's own recorded reason-string shape
@@ -460,7 +504,6 @@ function el(tag, attrs, children) {
   attrs = attrs || {};
   Object.keys(attrs).forEach(function (k) {
     if (k === 'text') node.textContent = attrs[k];
-    else if (k === 'html') node.innerHTML = attrs[k]; // fixed, hand-authored SVG markup only — never user data
     else if (k.indexOf('on') === 0 && typeof attrs[k] === 'function') node.addEventListener(k.slice(2), attrs[k]);
     else node.setAttribute(k, attrs[k]);
   });
@@ -504,26 +547,10 @@ function feedSvg(open) {
 }
 
 function gateBlock(storySlug, story, gate) {
-  var events = board.snapshot.events;
-  var st = gateBlockState(storySlug, story, gate, events);
-  var stateText;
-  if (WORKER_PHASES.has(gate)) {
-    stateText = st === 'pass' ? 'DONE' : '—';
-  } else {
-    var v = latestVerdict(storySlug, gate, events);
-    if (!v && st === 'fix') {
-      // thin resumed feed: the park reason is the only carrier of the verdict
-      var parsed = parseParkReasonGate(story.reason);
-      v = parsed && parsed.verdict;
-    }
-    if (!v && st === 'pass') v = 'DONE'; // landed story, feed too thin for the verdict event
-    stateText = v || '—';
-    var n = story.retries && story.retries[gate];
-    if (st === 'fix' && n) stateText += ' ✕' + n;
-  }
-  return el('div', { class: 'gblock ' + st }, [
+  var block = gateBlockState(storySlug, story, gate, board.snapshot.events);
+  return el('div', { class: 'gblock ' + block.state }, [
     el('div', { class: 'glabel', text: abbrevGate(gate) }),
-    el('div', { class: 'gstate', text: stateText }),
+    el('div', { class: 'gstate', text: block.text }),
   ]);
 }
 
@@ -592,16 +619,9 @@ function renderCas() {
   var messages = buildCasMessages(board.snapshot.stories, board.snapshot.events);
   messages.forEach(function (m) {
     var li = el('li', { class: 'cas-' + m.tier });
-    li.appendChild(el('span', { class: 't', text: (m.at || '').slice(11, 16) || '—' }));
-    // Column split is display-only: buildCasMessages's text is always either
-    // "<slug>: <message>" or "<slug> <message>" for slug-carrying tiers, so
-    // the tag column is m.slug and the message column is the remainder — no
-    // re-derivation, just presentation of the same string.
-    var msg = m.text;
-    if (m.slug && msg.indexOf(m.slug + ': ') === 0) msg = msg.slice(m.slug.length + 2);
-    else if (m.slug && msg.indexOf(m.slug + ' ') === 0) msg = msg.slice(m.slug.length + 1);
+    li.appendChild(el('span', { class: 't', text: casTimeLabel(m.at) }));
     if (m.slug) li.appendChild(el('span', { class: 'tag', text: m.slug }));
-    li.appendChild(el('span', { class: 'msg', text: msg }));
+    li.appendChild(el('span', { class: 'msg', text: m.message }));
     list.appendChild(li);
   });
 }
@@ -760,6 +780,7 @@ if (typeof module !== 'undefined' && module.exports) {
     classifyGaugeState: classifyGaugeState,
     gaugeAriaLabel: gaugeAriaLabel,
     gateBlockState: gateBlockState,
+    casTimeLabel: casTimeLabel,
     latestVerdict: latestVerdict,
     workerPhaseDone: workerPhaseDone,
     hasPriorRetryBump: hasPriorRetryBump,

--- a/assets/board-ui/app.js
+++ b/assets/board-ui/app.js
@@ -593,7 +593,15 @@ function renderCas() {
   messages.forEach(function (m) {
     var li = el('li', { class: 'cas-' + m.tier });
     li.appendChild(el('span', { class: 't', text: (m.at || '').slice(11, 16) || '—' }));
-    li.appendChild(el('span', { text: m.text }));
+    // Column split is display-only: buildCasMessages's text is always either
+    // "<slug>: <message>" or "<slug> <message>" for slug-carrying tiers, so
+    // the tag column is m.slug and the message column is the remainder — no
+    // re-derivation, just presentation of the same string.
+    var msg = m.text;
+    if (m.slug && msg.indexOf(m.slug + ': ') === 0) msg = msg.slice(m.slug.length + 2);
+    else if (m.slug && msg.indexOf(m.slug + ' ') === 0) msg = msg.slice(m.slug.length + 1);
+    if (m.slug) li.appendChild(el('span', { class: 'tag', text: m.slug }));
+    li.appendChild(el('span', { class: 'msg', text: msg }));
     list.appendChild(li);
   });
 }
@@ -612,7 +620,13 @@ function renderMasterCaution() {
 
 function renderHeader() {
   var epic = board.snapshot.epic || {};
-  document.getElementById('epic-title').textContent = (epic.title || epic.slug || 'epic') + ' · ' + (epic.status || 'unknown');
+  // UNIT speaks the slug — the identifier every gate-ledger command and CAS
+  // row uses — so the title block matches the vocabulary of the commands the
+  // drawer hands out; the human-readable title rides along as a tooltip.
+  var unit = document.getElementById('epic-title');
+  unit.textContent = epic.slug || 'epic';
+  if (epic.title) unit.setAttribute('title', epic.title);
+  document.getElementById('epic-mode').textContent = epic.status || 'unknown';
 
   var stories = board.snapshot.stories || {};
   var slugs = Object.keys(stories);

--- a/assets/board-ui/app.js
+++ b/assets/board-ui/app.js
@@ -1,6 +1,12 @@
 'use strict';
 
-// Flight Deck — the board-ui client script.
+// Epic Overview (the Operator Graphic) — the board-ui client script.
+//
+// The rendering idiom is a utilities control room: each story is a process
+// channel fed from a dependency bus, each gate a block on that channel
+// carrying its verdict token verbatim, and the message panel is an alarm
+// summary. The two themes are two shifts of the same room (see index.html's
+// token comment); this script is theme-blind — it renders structure only.
 //
 // Inlined verbatim into the page bin/board-server's `GET /` serves (see that
 // file's render_page()) so the shipped document stays one self-contained
@@ -53,10 +59,9 @@ var GATE_ABBREV = {
 // never as a key in `retries` (only `--bump-retry <gate>` on an actual gate
 // touches that map; a failed worker phase parks the story outright — see
 // `park()`'s `WORKER_PHASES.includes` branch in the driver — it is never
-// retried). `activeGate` below must skip them: without this, a story past
-// design/build with every real gate proceeding would still read as "stuck
-// at design" forever, since `design` can structurally never carry a proceed
-// verdict.
+// retried). Their channel blocks must therefore derive from phase/step
+// events via `workerPhaseDone` below, never from `latestVerdict`, which is
+// null for them by construction.
 var WORKER_PHASES = makeSet(['design', 'build']);
 
 var DEFAULT_GATES = ['design', 'design-review', 'build', 'audit', 'acceptance'];
@@ -128,20 +133,24 @@ function deriveBlocker(storySlug, stories) {
   return liveBlocker;
 }
 
-// Visual/label classification for a gauge's "off" states. Left to build-time
-// craft by the design doc's Open Questions #2 — this gives pending/blocked/
-// dropped each a distinct, legible label rather than one generic "off".
+// Visual/label classification for a channel's "off" states — pending/
+// blocked/dropped each get a distinct, legible label rather than one
+// generic "off". Labels speak the schema's own vocabulary where one exists
+// (PARKED is the ledger word; issue #98 principle 4 — no web-only words):
+// the aviation-era CAUTION/OFF — ON spellings were replaced when the board
+// moved to the control-room idiom. Codes are the stable contract the tests
+// pin; labels are the visible/aria text.
 function classifyGaugeState(storySlug, stories) {
   var all = stories || {};
   var story = all[storySlug] || {};
-  if (story.status === 'dropped') return { code: 'dropped', label: 'OFF — DROPPED' };
+  if (story.status === 'dropped') return { code: 'dropped', label: 'DROPPED' };
   var blocker = deriveBlocker(storySlug, all);
   if (blocker) {
     return blocker.dropped
-      ? { code: 'blocked-dead', label: 'OFF — ' + blocker.slug + ' DROPPED' }
-      : { code: 'blocked', label: 'OFF — ON ' + blocker.slug };
+      ? { code: 'blocked-dead', label: 'AWAIT ' + blocker.slug + ' — DROPPED' }
+      : { code: 'blocked', label: 'AWAIT ' + blocker.slug };
   }
-  if (story.status === 'parked') return { code: 'parked', label: 'CAUTION' };
+  if (story.status === 'parked') return { code: 'parked', label: 'PARKED' };
   if (story.status === 'landed') return { code: 'landed', label: 'LANDED' };
   if (story.status === 'pending') return { code: 'pending', label: 'STANDBY' };
   return { code: 'active', label: String(story.status || 'active').toUpperCase() };
@@ -158,31 +167,28 @@ function gaugeAriaLabel(storySlug, stories) {
   return title + ', status ' + cls.label;
 }
 
-function fixBudgetFraction(story, gate, maxFixCycles) {
-  var cap = maxFixCycles || MAX_FIX_CYCLES;
-  var n = (story && story.retries && story.retries[gate]) || 0;
-  return Math.max(0, Math.min(1, n / cap));
-}
-
-// The gate this story is currently working through, for wedge placement:
-// the first verdict-bearing gate in its own `gates` order with no proceed
-// verdict yet, or the last gate if every verdict-bearing gate has already
-// proceeded. Worker-phase entries (`design`/`build`, see WORKER_PHASES
-// above) are skipped while scanning — they can never carry a proceed
-// verdict, so treating them as candidates would strand every story at
-// `design` forever — but one is still returned as the fallback if `gates`
-// somehow contains nothing else (degrades to that phase's own "not yet
-// run" lamp rather than throwing).
-function activeGate(storySlug, stories, events) {
-  var all = stories || {};
-  var story = all[storySlug] || {};
-  var gates = story.gates && story.gates.length ? story.gates : DEFAULT_GATES;
-  for (var i = 0; i < gates.length; i++) {
-    if (WORKER_PHASES.has(gates[i])) continue;
-    var v = latestVerdict(storySlug, gates[i], events);
-    if (!(v && PROCEED_VERDICTS.has(v))) return gates[i];
+// The per-gate state a channel block renders. One of:
+//   'pass'  — worker phase done, or a proceed verdict recorded
+//   'fix'   — a non-proceed verdict recorded, or (for a parked story) the
+//             gate its recorded park reason names — the burn is visible even
+//             when the resumed event feed is too thin to carry the verdict
+//   'unrun' — nothing recorded yet
+// A landed story renders every block 'pass': the status field is
+// authoritative (a story cannot land without its final profiled gate's
+// proceed token); events enrich but never veto it — the same status-wins
+// rule the drawer's verdict trail does NOT apply, because there the events
+// ARE the content.
+function gateBlockState(storySlug, story, gate, events) {
+  var s = story || {};
+  if (s.status === 'landed') return 'pass';
+  if (WORKER_PHASES.has(gate)) return workerPhaseDone(storySlug, gate, events) ? 'pass' : 'unrun';
+  var v = latestVerdict(storySlug, gate, events);
+  if (v) return PROCEED_VERDICTS.has(v) ? 'pass' : 'fix';
+  if (s.status === 'parked') {
+    var parsed = parseParkReasonGate(s.reason);
+    if (parsed && parsed.gate === gate) return 'fix';
   }
-  return gates[gates.length - 1];
+  return 'unrun';
 }
 
 // Most recent gate-verdict event's verdict for (story, gate), or null if
@@ -420,30 +426,6 @@ function buildResolutionCommand(epicSlug, storySlug, story, maxFixCycles) {
   return cmd;
 }
 
-// Arc-endpoint math for the fix-budget wedge — dialSvg's functional core,
-// pulled out so this specific degenerate case is unit-testable without a
-// DOM shim (the "DOM wiring" note below still holds for dialSvg itself;
-// this piece has no DOM in it at all).
-//
-// SVG's elliptical-arc command degenerates to a zero-length no-op when its
-// endpoint is identical to its start point (SVG 1.1 §9.5.1, "Zero-length
-// path segments"). The wedge's arc always starts at the dial's 12 o'clock,
-// (20,3); at fraction===1 (retries[gate] >= MAX_FIX_CYCLES, the "fix budget
-// exhausted" state this gauge exists to surface) a literal 360-degree sweep
-// lands the endpoint back on that exact start point, so the browser drops
-// the arc silently and the exhausted-budget gauge renders a bare radius
-// line instead of a full wedge. The sweep is capped just short of a full
-// revolution (359.999deg) — visually indistinguishable from 360 but
-// numerically distinct, so start and end never coincide.
-function wedgePathD(fraction) {
-  var deg = Math.min(Math.round(fraction * 360), 359.999);
-  var large = deg > 180 ? 1 : 0;
-  var rad = (deg - 90) * (Math.PI / 180);
-  var x = 20 + 17 * Math.cos(rad);
-  var y = 20 + 17 * Math.sin(rad);
-  return 'M20,20 L20,3 A17,17 0 ' + large + ' 1 ' + x + ',' + y + ' Z';
-}
-
 // ---------------------------------------------------------------------------
 // DOM wiring — everything below touches `document`/`window`/`fetch`/
 // `EventSource`/`navigator`. Not unit-tested directly (that would need a DOM
@@ -454,22 +436,22 @@ function wedgePathD(fraction) {
 // decision this code makes.
 // ---------------------------------------------------------------------------
 
-var flightDeck = {
+var board = {
   order: [],
   acked: {},
   snapshot: { schemaVersion: 1, epic: { slug: '', status: 'unknown' }, stories: {}, events: [] },
 };
 
 function applySnapshot(snapshot) {
-  flightDeck.order = computeGaugeOrder(flightDeck.order, snapshot.stories);
+  board.order = computeGaugeOrder(board.order, snapshot.stories);
   var parked = parkedSlugs(snapshot.stories);
-  flightDeck.acked = reconcileAcked(flightDeck.acked, parked);
-  flightDeck.snapshot = snapshot;
+  board.acked = reconcileAcked(board.acked, parked);
+  board.snapshot = snapshot;
   render();
 }
 
 function ackMasterCaution() {
-  flightDeck.acked = parkedSlugs(flightDeck.snapshot.stories);
+  board.acked = parkedSlugs(board.snapshot.stories);
   render();
 }
 
@@ -486,63 +468,120 @@ function el(tag, attrs, children) {
   return node;
 }
 
-function dialSvg(fraction, code) {
+function svgLine(svg, x1, y1, x2, y2, cls) {
+  var l = document.createElementNS(svg.namespaceURI, 'line');
+  l.setAttribute('x1', x1); l.setAttribute('y1', y1);
+  l.setAttribute('x2', x2); l.setAttribute('y2', y2);
+  l.setAttribute('class', cls);
+  svg.appendChild(l);
+}
+
+// The feed symbol between the dependency bus and a channel's tag block.
+// Closed (a plain line): the channel is live — its dependencies have landed
+// or it's already past dispatch. Open (a lifted blade between two
+// terminals, one-line-diagram style): the story is pending behind a
+// dependency; the tag block's await line names it. Decoration only
+// (aria-hidden) — the blocked state is carried by the await text and the
+// tag block's aria-label.
+function feedSvg(open) {
   var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  svg.setAttribute('viewBox', '0 0 40 40');
-  svg.setAttribute('class', 'dial dial-' + code);
-  svg.setAttribute('aria-hidden', 'true'); // meaning lives in the button's aria-label and lamp text, not this graphic
-  var ring = document.createElementNS(svg.namespaceURI, 'circle');
-  ring.setAttribute('cx', '20'); ring.setAttribute('cy', '20'); ring.setAttribute('r', '17');
-  ring.setAttribute('class', 'dial-ring');
-  svg.appendChild(ring);
-  if (fraction > 0) {
-    var wedge = document.createElementNS(svg.namespaceURI, 'path');
-    wedge.setAttribute('d', wedgePathD(fraction));
-    wedge.setAttribute('class', 'dial-wedge');
-    svg.appendChild(wedge);
+  svg.setAttribute('width', '30'); svg.setAttribute('height', '14');
+  svg.setAttribute('aria-hidden', 'true');
+  if (!open) {
+    svgLine(svg, 0, 7, 30, 7, 'feed-line');
+    return svg;
   }
+  svgLine(svg, 0, 7, 9, 7, 'feed-line');
+  svgLine(svg, 9, 7, 23, 1, 'feed-blade');
+  svgLine(svg, 23, 7, 30, 7, 'feed-line');
+  ['9', '23'].forEach(function (cx) {
+    var c = document.createElementNS(svg.namespaceURI, 'circle');
+    c.setAttribute('cx', cx); c.setAttribute('cy', '7'); c.setAttribute('r', '2');
+    c.setAttribute('class', 'feed-terminal');
+    svg.appendChild(c);
+  });
   return svg;
 }
 
-function gaugeButton(storySlug) {
-  var stories = flightDeck.snapshot.stories;
-  var story = stories[storySlug] || {};
-  var cls = classifyGaugeState(storySlug, stories);
-  var gate = activeGate(storySlug, stories, flightDeck.snapshot.events);
-  var fraction = fixBudgetFraction(story, gate, MAX_FIX_CYCLES);
-  var gates = story.gates && story.gates.length ? story.gates : DEFAULT_GATES;
-
-  var lamps = el('div', { class: 'lamps' }, gates.map(function (g) {
-    if (WORKER_PHASES.has(g)) {
-      var done = workerPhaseDone(storySlug, g, flightDeck.snapshot.events);
-      var doneSymbol = done ? '●' : '○'; // filled / empty — worker phases have no "fix" (half) state: a failed one parks outright, never retries in place
-      var doneText = abbrevGate(g) + ' ' + doneSymbol + ' ' + (done ? 'done' : 'not yet run');
-      return el('span', { class: 'lamp lamp-' + (done ? 'pass' : 'unrun'), text: doneText });
+function gateBlock(storySlug, story, gate) {
+  var events = board.snapshot.events;
+  var st = gateBlockState(storySlug, story, gate, events);
+  var stateText;
+  if (WORKER_PHASES.has(gate)) {
+    stateText = st === 'pass' ? 'DONE' : '—';
+  } else {
+    var v = latestVerdict(storySlug, gate, events);
+    if (!v && st === 'fix') {
+      // thin resumed feed: the park reason is the only carrier of the verdict
+      var parsed = parseParkReasonGate(story.reason);
+      v = parsed && parsed.verdict;
     }
-    var verdict = latestVerdict(storySlug, g, flightDeck.snapshot.events);
-    var on = !!verdict && PROCEED_VERDICTS.has(verdict);
-    var symbol = verdict ? (on ? '●' : '◐') : '○'; // filled / half / empty — form, not hue
-    var text = abbrevGate(g) + ' ' + symbol + ' ' + (verdict || 'not yet run');
-    return el('span', { class: 'lamp lamp-' + (verdict ? (on ? 'pass' : 'fix') : 'unrun'), text: text });
-  }));
-
-  var label = el('div', { class: 'gauge-label', text: story.title || storySlug });
-  var status = el('div', { class: 'gauge-status status-' + cls.code, text: cls.label });
-
-  return el('button', {
-    type: 'button',
-    class: 'gauge',
-    'aria-label': gaugeAriaLabel(storySlug, stories),
-    onclick: function () { openDrawer(storySlug); },
-  }, [dialSvg(fraction, cls.code), label, status, lamps]);
+    if (!v && st === 'pass') v = 'DONE'; // landed story, feed too thin for the verdict event
+    stateText = v || '—';
+    var n = story.retries && story.retries[gate];
+    if (st === 'fix' && n) stateText += ' ✕' + n;
+  }
+  return el('div', { class: 'gblock ' + st }, [
+    el('div', { class: 'glabel', text: abbrevGate(gate) }),
+    el('div', { class: 'gstate', text: stateText }),
+  ]);
 }
 
-function renderGauges() {
-  var grid = document.getElementById('gauges');
-  grid.textContent = '';
-  flightDeck.order.forEach(function (slug) {
-    if (Object.prototype.hasOwnProperty.call(flightDeck.snapshot.stories, slug)) {
-      grid.appendChild(gaugeButton(slug));
+function channelRow(storySlug) {
+  var stories = board.snapshot.stories;
+  var story = stories[storySlug] || {};
+  var cls = classifyGaugeState(storySlug, stories);
+  var gates = story.gates && story.gates.length ? story.gates : DEFAULT_GATES;
+  var isOpen = cls.code === 'blocked' || cls.code === 'blocked-dead';
+
+  var feed = el('span', { class: 'feed' }, [
+    el('span', { class: 'wire' }),
+    feedSvg(isOpen),
+    el('span', { class: 'wire' }),
+  ]);
+
+  var tagChildren = [
+    el('span', { class: 'slug', text: storySlug.toUpperCase() }),
+    el('span', { class: 'title', text: story.title || storySlug }),
+  ];
+  if (isOpen) tagChildren.push(el('span', { class: 'await', text: 'FEED OPEN — ' + cls.label }));
+  var tag = el('button', {
+    type: 'button',
+    class: 'tagblock',
+    'aria-label': gaugeAriaLabel(storySlug, stories),
+    onclick: function () { openDrawer(storySlug); },
+  }, tagChildren);
+
+  var run = el('span', { class: 'run' });
+  gates.forEach(function (g) {
+    run.appendChild(el('span', { class: 'connector' }));
+    run.appendChild(gateBlock(storySlug, story, g));
+  });
+
+  var endText =
+    cls.code === 'landed' ? 'LANDED' :
+    cls.code === 'parked' ? 'PARKED' :
+    cls.code === 'dropped' ? 'DROPPED' :
+    cls.code === 'active' ? cls.label :
+    'STANDBY'; // pending, blocked, blocked-dead — the await line carries the rest
+  var end = el('span', {
+    class: 'endstate' + (cls.code === 'landed' ? ' landed' : '') + (cls.code === 'parked' ? ' parked' : ''),
+    text: endText,
+  });
+
+  return el('div', {
+    class: 'channel' +
+      (cls.code === 'landed' ? ' is-landed' : '') +
+      (cls.code === 'parked' ? ' is-parked' : ''),
+  }, [feed, tag, run, end]);
+}
+
+function renderChannels() {
+  var wrap = document.getElementById('channels');
+  wrap.textContent = '';
+  board.order.forEach(function (slug) {
+    if (Object.prototype.hasOwnProperty.call(board.snapshot.stories, slug)) {
+      wrap.appendChild(channelRow(slug));
     }
   });
 }
@@ -550,32 +589,45 @@ function renderGauges() {
 function renderCas() {
   var list = document.getElementById('cas-list');
   list.textContent = '';
-  var messages = buildCasMessages(flightDeck.snapshot.stories, flightDeck.snapshot.events);
+  var messages = buildCasMessages(board.snapshot.stories, board.snapshot.events);
   messages.forEach(function (m) {
-    list.appendChild(el('li', { class: 'cas-' + m.tier, text: m.text }));
+    var li = el('li', { class: 'cas-' + m.tier });
+    li.appendChild(el('span', { class: 't', text: (m.at || '').slice(11, 16) || '—' }));
+    li.appendChild(el('span', { text: m.text }));
+    list.appendChild(li);
   });
 }
 
 function renderMasterCaution() {
-  var parked = parkedSlugs(flightDeck.snapshot.stories);
+  var parked = parkedSlugs(board.snapshot.stories);
   var active = Object.keys(parked).length > 0;
-  var blinking = isMasterCautionBlinking(flightDeck.acked, parked);
+  var blinking = isMasterCautionBlinking(board.acked, parked);
   var btn = document.getElementById('master-caution');
   btn.disabled = !active;
   btn.classList.toggle('active', active);
   btn.classList.toggle('blinking', blinking);
   btn.setAttribute('aria-pressed', String(!blinking && active));
-  btn.textContent = active ? (blinking ? 'MASTER CAUTION — acknowledge' : 'MASTER CAUTION — acknowledged') : 'MASTER CAUTION';
+  btn.textContent = active ? (blinking ? 'ALARM ACK — acknowledge' : 'ALARM ACK — acknowledged') : 'ALARM ACK';
 }
 
 function renderHeader() {
-  var epic = flightDeck.snapshot.epic || {};
+  var epic = board.snapshot.epic || {};
   document.getElementById('epic-title').textContent = (epic.title || epic.slug || 'epic') + ' · ' + (epic.status || 'unknown');
+
+  var stories = board.snapshot.stories || {};
+  var slugs = Object.keys(stories);
+  var landed = slugs.filter(function (k) { return stories[k] && stories[k].status === 'landed'; }).length;
+  var alarms = Object.keys(parkedSlugs(stories)).length;
+  var counts = document.getElementById('epic-counts');
+  counts.textContent = '';
+  counts.appendChild(document.createTextNode(landed + '/' + slugs.length + ' LANDED · '));
+  counts.appendChild(el('span', { class: 'alarm', text: alarms + ' ALARM' + (alarms === 1 ? '' : 'S') }));
+  counts.appendChild(document.createTextNode(' · CAP ' + (epic.concurrency != null ? epic.concurrency : '—')));
 }
 
 function render() {
   renderHeader();
-  renderGauges();
+  renderChannels();
   renderCas();
   renderMasterCaution();
   renderDrawer(); // no-op (returns early) when the drawer is closed — see renderDrawer's own guard
@@ -599,15 +651,15 @@ function closeDrawer() {
 
 function renderDrawer() {
   if (!drawerStorySlug) return;
-  var stories = flightDeck.snapshot.stories;
+  var stories = board.snapshot.stories;
   var story = stories[drawerStorySlug] || {};
-  var epicSlug = (flightDeck.snapshot.epic && flightDeck.snapshot.epic.slug) || '';
+  var epicSlug = (board.snapshot.epic && board.snapshot.epic.slug) || '';
 
   document.getElementById('drawer-title').textContent = story.title || drawerStorySlug;
 
   var trailList = document.getElementById('drawer-trail');
   trailList.textContent = '';
-  buildVerdictTrail(drawerStorySlug, flightDeck.snapshot.events).forEach(function (v) {
+  buildVerdictTrail(drawerStorySlug, board.snapshot.events).forEach(function (v) {
     var text = v.gate + ': ' + v.verdict + (v.freshEyes ? ' (fresh eyes)' : '') + (v.sha ? ' @ ' + v.sha : '');
     trailList.appendChild(el('li', { text: text }));
   });
@@ -693,9 +745,7 @@ if (typeof module !== 'undefined' && module.exports) {
     deriveBlocker: deriveBlocker,
     classifyGaugeState: classifyGaugeState,
     gaugeAriaLabel: gaugeAriaLabel,
-    fixBudgetFraction: fixBudgetFraction,
-    wedgePathD: wedgePathD,
-    activeGate: activeGate,
+    gateBlockState: gateBlockState,
     latestVerdict: latestVerdict,
     workerPhaseDone: workerPhaseDone,
     hasPriorRetryBump: hasPriorRetryBump,

--- a/assets/board-ui/index.html
+++ b/assets/board-ui/index.html
@@ -3,71 +3,120 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Flight Deck</title>
+<title>Epic Overview</title>
 <!--
-  Flight Deck — bin/board-server's GET / response.
+  Epic Overview (the Operator Graphic) — bin/board-server's GET / response.
 
   Self-contained by construction: no external stylesheet, font, script, or
   image anywhere in this document — every rule lives in the <style> block
   below, every behavior in the inlined <script> block near the end (its
   body is substituted in verbatim from assets/board-ui/app.js by
   bin/board-server's render_page(); see that file for the actual logic and
-  tests/js/test_board_ui_app.js for its test coverage). This file itself
+  tests/js/test-board-ui-app.js for its test coverage). This file itself
   holds only markup and presentation, hand-authored, no build step.
+
+  The visual idiom is a utilities control room, one design with two shifts:
+  the light theme is a day-shift engineering one-line diagram (paper ground,
+  ink linework, a drawing title block); the dark theme is a night-shift
+  monochrome phosphor tube (green world, amber spent only on alarm-tier
+  state). Both are the same markup — every difference between them is a
+  token below, so the theme toggle moves between shifts without touching
+  structure. Parked is amber, never red; red appears nowhere in either
+  theme (issue #98 principle 3).
 -->
 <style>
+  /* ---- day shift: the engineering drawing ---- */
   :root {
     color-scheme: light dark;
-    --bg: #f4f5f7;
-    --surface: #ffffff;
-    --text: #1b1e23;
-    --text-dim: #545b66;
-    --border: #c7ccd4;
+    --bg: #edefe9;
+    --panel: #e2e5dd;
+    --text: #22281f;
+    --text-mid: #56604f;
+    --text-dim: #8b9483;
+    --strong: #22281f;
+    --wire: #22281f;
+    --rule: #b9c0af;
+    --hairline: #22281f;
     --focus: #0b5fff;
-    --amber: #7a4b00;
-    --amber-bg: #fff1d6;
-    --green: #14532d;
-    --green-bg: #e5f6ea;
-    --lamp-pass: #14532d;
-    --lamp-fix: #7a4b00;
-    --lamp-unrun: #6b7280;
-    --caution-bg: #d64545;
-    --caution-text: #ffffff;
+    --unrun-bg: #f6f7f3;
+    --unrun-border: #8b9483;
+    --unrun-text: #8b9483;
+    --pass-bg: #21833f;
+    --pass-border: #21833f;
+    --pass-text: #f0f7ef;
+    --fix-bg: #eda210;
+    --fix-border: #b57c07;
+    --fix-text: #2c1f01;
+    --amber: #9c6a05;
+    --amber-border: #eda210;
+    --amber-fill: #f7ecd2;
+    --alarm-row-bg: #f5e5bb;
+    --alarm-row-text: #6b4a04;
+    --landed: #21833f;
+    --glow-green: none;
+    --glow-amber: none;
+    --scanlines: none;
+    --mono: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, "Roboto Mono", monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   }
 
+  /* ---- night shift: the phosphor tube ---- */
   @media (prefers-color-scheme: dark) {
     :root {
-      --bg: #14161a;
-      --surface: #1d2026;
-      --text: #eef0f3;
-      --text-dim: #a7adb8;
-      --border: #383e48;
-      --focus: #6ea8ff;
-      --amber: #ffcf7a;
-      --amber-bg: #3a2a05;
-      --green: #86e0a4;
-      --green-bg: #0f2c19;
-      --lamp-pass: #86e0a4;
-      --lamp-fix: #ffcf7a;
-      --lamp-unrun: #8b93a1;
-      --caution-bg: #ff6b6b;
-      --caution-text: #1b1e23;
+      --bg: #070c08;
+      --panel: #050907;
+      --text: #9df5ae;
+      --text-mid: #2b9c44;
+      --text-dim: #1d6b30;
+      --strong: #46ec66;
+      --wire: #164f27;
+      --rule: #164f27;
+      --hairline: #164f27;
+      --focus: #46ec66;
+      --unrun-bg: transparent;
+      --unrun-border: #164f27;
+      --unrun-text: #2b9c44;
+      --pass-bg: #2b9c44;
+      --pass-border: #46ec66;
+      --pass-text: #04170a;
+      --fix-bg: repeating-linear-gradient(45deg, #ffb01f 0 7px, #b57708 7px 14px);
+      --fix-border: #ffb01f;
+      --fix-text: #2b1d00;
+      --amber: #ffb01f;
+      --amber-border: #ffb01f;
+      --amber-fill: #241804;
+      --alarm-row-bg: transparent;
+      --alarm-row-text: #ffb01f;
+      --landed: #46ec66;
+      --glow-green: 0 0 10px rgba(70, 236, 102, 0.25);
+      --glow-amber: 0 0 12px rgba(255, 176, 31, 0.3);
+      --scanlines: repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.16) 0 1px, transparent 1px 3px);
     }
   }
 
   /* Explicit override wins over the media query in either direction —
      set by the theme toggle button (see app.js's toggleTheme()). */
   :root[data-theme="light"] {
-    --bg: #f4f5f7; --surface: #ffffff; --text: #1b1e23; --text-dim: #545b66;
-    --border: #c7ccd4; --focus: #0b5fff; --amber: #7a4b00; --amber-bg: #fff1d6;
-    --green: #14532d; --green-bg: #e5f6ea; --lamp-pass: #14532d; --lamp-fix: #7a4b00;
-    --lamp-unrun: #6b7280; --caution-bg: #d64545; --caution-text: #ffffff;
+    --bg: #edefe9; --panel: #e2e5dd; --text: #22281f; --text-mid: #56604f; --text-dim: #8b9483;
+    --strong: #22281f; --wire: #22281f; --rule: #b9c0af; --hairline: #22281f; --focus: #0b5fff;
+    --unrun-bg: #f6f7f3; --unrun-border: #8b9483; --unrun-text: #8b9483;
+    --pass-bg: #21833f; --pass-border: #21833f; --pass-text: #f0f7ef;
+    --fix-bg: #eda210; --fix-border: #b57c07; --fix-text: #2c1f01;
+    --amber: #9c6a05; --amber-border: #eda210; --amber-fill: #f7ecd2;
+    --alarm-row-bg: #f5e5bb; --alarm-row-text: #6b4a04; --landed: #21833f;
+    --glow-green: none; --glow-amber: none; --scanlines: none;
   }
   :root[data-theme="dark"] {
-    --bg: #14161a; --surface: #1d2026; --text: #eef0f3; --text-dim: #a7adb8;
-    --border: #383e48; --focus: #6ea8ff; --amber: #ffcf7a; --amber-bg: #3a2a05;
-    --green: #86e0a4; --green-bg: #0f2c19; --lamp-pass: #86e0a4; --lamp-fix: #ffcf7a;
-    --lamp-unrun: #8b93a1; --caution-bg: #ff6b6b; --caution-text: #1b1e23;
+    --bg: #070c08; --panel: #050907; --text: #9df5ae; --text-mid: #2b9c44; --text-dim: #1d6b30;
+    --strong: #46ec66; --wire: #164f27; --rule: #164f27; --hairline: #164f27; --focus: #46ec66;
+    --unrun-bg: transparent; --unrun-border: #164f27; --unrun-text: #2b9c44;
+    --pass-bg: #2b9c44; --pass-border: #46ec66; --pass-text: #04170a;
+    --fix-bg: repeating-linear-gradient(45deg, #ffb01f 0 7px, #b57708 7px 14px);
+    --fix-border: #ffb01f; --fix-text: #2b1d00;
+    --amber: #ffb01f; --amber-border: #ffb01f; --amber-fill: #241804;
+    --alarm-row-bg: transparent; --alarm-row-text: #ffb01f; --landed: #46ec66;
+    --glow-green: 0 0 10px rgba(70, 236, 102, 0.25); --glow-amber: 0 0 12px rgba(255, 176, 31, 0.3);
+    --scanlines: repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.16) 0 1px, transparent 1px 3px);
   }
 
   * { box-sizing: border-box; }
@@ -75,52 +124,84 @@
   body {
     background: var(--bg);
     color: var(--text);
-    font: 15px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font: 13px/1.5 var(--mono);
+  }
+  /* night-shift tube texture — decoration only (static, no motion); every
+     meaning this page carries lives in text, form, and aria, never here */
+  body::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background: var(--scanlines);
   }
 
   a, button, input { font: inherit; color: inherit; }
 
   :focus-visible {
-    outline: 3px solid var(--focus);
+    outline: 2px solid var(--focus);
     outline-offset: 2px;
   }
 
+  /* ---- title block (drawing header / tube status bar) ---- */
   header {
     display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem 1rem;
-    background: var(--surface);
-    border-bottom: 1px solid var(--border);
+    flex-wrap: wrap;
+    border-bottom: 2px solid var(--hairline);
+    background: var(--bg);
     position: sticky;
     top: 0;
+    z-index: 1;
   }
-  header h1 { font-size: 1rem; margin: 0; font-weight: 600; }
-  #epic-title { color: var(--text-dim); font-weight: 400; }
-  #conn-status { margin-left: auto; color: var(--text-dim); font-size: 0.85rem; }
+  .tb-cell {
+    padding: 0.45rem 0.9rem;
+    border-right: 1.5px solid var(--hairline);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-width: 0;
+  }
+  .tb-cell .k { font-size: 0.55rem; letter-spacing: 0.14em; color: var(--text-dim); text-transform: uppercase; }
+  .tb-cell .v { font-size: 0.78rem; font-weight: 700; letter-spacing: 0.06em; color: var(--strong); overflow-wrap: anywhere; }
+  .tb-cell.name .v { font-size: 0.9rem; letter-spacing: 0.12em; }
+  .tb-cell.actions {
+    border-right: none;
+    margin-left: auto;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  #conn-status { color: var(--text-mid); font-size: 0.72rem; }
+  #epic-counts .alarm { color: var(--amber); }
 
   #theme-toggle {
-    border: 1px solid var(--border);
-    background: var(--surface);
-    border-radius: 6px;
+    border: 1.5px solid var(--hairline);
+    background: var(--panel);
+    border-radius: 2px;
     padding: 0.35rem 0.6rem;
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
     cursor: pointer;
+    color: var(--text);
   }
 
   #master-caution {
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    padding: 0.5rem 0.9rem;
+    border: 1.5px solid var(--hairline);
+    border-radius: 2px;
+    padding: 0.42rem 0.8rem;
     font-weight: 700;
-    letter-spacing: 0.02em;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
     cursor: pointer;
-    background: var(--surface);
-    color: var(--text-dim);
+    background: var(--panel);
+    color: var(--text-mid);
   }
   #master-caution.active {
-    background: var(--caution-bg);
-    color: var(--caution-text);
-    border-color: var(--caution-bg);
+    background: var(--amber-fill);
+    color: var(--amber);
+    border-color: var(--amber-border);
+    box-shadow: var(--glow-amber);
   }
   #master-caution.blinking {
     animation: mc-blink 1s steps(1, end) infinite;
@@ -131,180 +212,191 @@
       /* Meaning (active + unacked) is carried in the button's own text
          ("acknowledge" vs "acknowledged") and aria-pressed regardless of
          whether this highlight animates. */
-      box-shadow: 0 0 0 3px var(--caution-bg) inset;
+      box-shadow: 0 0 0 3px var(--amber-border) inset;
     }
   }
   @keyframes mc-blink {
     0%, 49% { opacity: 1; }
     50%, 100% { opacity: 0.55; }
   }
-  #master-caution:disabled { cursor: default; opacity: 0.6; }
+  #master-caution:disabled { cursor: default; opacity: 0.55; }
 
-  main {
-    display: grid;
-    grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
-    gap: 1rem;
-    padding: 1rem;
-    align-items: start;
-  }
-  @media (max-width: 780px) {
-    main { grid-template-columns: 1fr; }
-  }
-
-  section.panel {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 10px;
-    padding: 0.85rem;
-  }
+  /* ---- panels ---- */
+  main { padding-bottom: 1rem; }
+  section.panel { padding: 1.2rem 1rem 1.4rem; }
+  section.panel + section.panel { border-top: 2px solid var(--hairline); background: var(--panel); }
   section.panel > h2 {
-    margin: 0 0 0.6rem 0;
-    font-size: 0.8rem;
-    letter-spacing: 0.06em;
+    margin: 0 0 1.1rem;
+    font-size: 0.68rem;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--text-mid);
+    font-weight: 400;
   }
 
-  #gauges {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-    gap: 0.75rem;
-  }
+  /* ---- story channels on the dependency bus ---- */
+  #channels-scroll { overflow-x: auto; }
+  #channels { position: relative; margin-left: 26px; display: flex; flex-direction: column; gap: 15px; min-width: max-content; }
+  /* the bus itself */
+  #channels::before { content: ""; position: absolute; left: -18px; top: 8px; bottom: 8px; width: 2px; background: var(--wire); }
 
-  .gauge {
+  .channel { display: flex; align-items: center; min-height: 54px; }
+
+  .feed { display: flex; align-items: center; width: 74px; flex-shrink: 0; }
+  .feed .wire { height: 2px; background: var(--wire); flex: 1; }
+  .feed svg { flex-shrink: 0; }
+  .feed-line { stroke: var(--wire); stroke-width: 2; }
+  .feed-blade { stroke: var(--text-mid); stroke-width: 2; }
+  .feed-terminal { fill: var(--bg); stroke: var(--wire); stroke-width: 1.5; }
+
+  .tagblock {
+    width: 190px;
+    flex-shrink: 0;
+    border: 1.5px solid var(--hairline);
+    padding: 0.4rem 0.6rem;
+    background: var(--panel);
+    text-align: left;
+    cursor: pointer;
+  }
+  .tagblock .slug { font-size: 0.72rem; font-weight: 700; letter-spacing: 0.06em; color: var(--strong); overflow-wrap: anywhere; display: block; }
+  .tagblock .title { font-size: 0.62rem; color: var(--text-mid); line-height: 1.35; margin-top: 2px; display: block; }
+  .tagblock .await { font-size: 0.6rem; letter-spacing: 0.06em; color: var(--text-mid); margin-top: 3px; display: block; font-style: italic; }
+  .channel.is-landed .tagblock { border-color: var(--landed); box-shadow: var(--glow-green); }
+  .channel.is-landed .tagblock .slug { color: var(--landed); }
+  .channel.is-parked .tagblock { border-color: var(--amber-border); background: var(--amber-fill); box-shadow: var(--glow-amber); }
+  .channel.is-parked .tagblock .slug { color: var(--amber); }
+
+  .run { display: flex; align-items: center; }
+  .connector { width: 16px; height: 2px; background: var(--wire); flex-shrink: 0; }
+  .gblock {
+    width: 96px;
+    height: 40px;
+    flex-shrink: 0;
+    border: 1.5px solid var(--unrun-border);
+    background: var(--unrun-bg);
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.35rem;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: 10px;
-    padding: 0.6rem 0.5rem;
-    cursor: pointer;
-    text-align: center;
-  }
-  .gauge:hover { border-color: var(--focus); }
-
-  .dial { width: 64px; height: 64px; }
-  .dial-ring { fill: none; stroke: var(--border); stroke-width: 3; }
-  .dial-wedge { fill: var(--amber); opacity: 0.85; }
-  @media (prefers-reduced-motion: no-preference) {
-    .dial-wedge { transition: d 0.25s ease; }
-  }
-
-  .gauge-label {
-    font-weight: 600;
-    font-size: 0.85rem;
-    overflow-wrap: anywhere;
-  }
-  .gauge-status {
-    font-size: 0.72rem;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-    color: var(--text-dim);
-  }
-  .gauge-status.status-parked { color: var(--amber); font-weight: 700; }
-  .gauge-status.status-landed { color: var(--green); font-weight: 700; }
-  .gauge-status.status-blocked-dead { color: var(--amber); font-weight: 700; }
-
-  .lamps {
-    display: flex;
-    flex-wrap: wrap;
     justify-content: center;
-    gap: 0.25rem;
-    font-size: 0.68rem;
+    font-size: 0.66rem;
+    letter-spacing: 0.08em;
+    color: var(--unrun-text);
+    padding: 0 3px;
   }
-  .lamp {
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    padding: 0.1rem 0.3rem;
+  .gblock .glabel { font-weight: 700; }
+  .gblock .gstate { font-size: 0.56rem; margin-top: 1px; letter-spacing: 0.02em; text-align: center; }
+  .gblock.pass { background: var(--pass-bg); border-color: var(--pass-border); box-shadow: var(--glow-green); }
+  .gblock.pass .glabel, .gblock.pass .gstate { color: var(--pass-text); }
+  .gblock.fix { background: var(--fix-bg); border-color: var(--fix-border); box-shadow: var(--glow-amber); }
+  .gblock.fix .glabel, .gblock.fix .gstate { color: var(--fix-text); font-weight: 700; }
+
+  .endstate {
+    margin-left: 16px;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    padding: 0.3rem 0.55rem;
+    border: 1.5px solid var(--unrun-border);
+    color: var(--text-mid);
     white-space: nowrap;
   }
-  .lamp-pass { color: var(--lamp-pass); }
-  .lamp-fix { color: var(--lamp-fix); }
-  .lamp-unrun { color: var(--lamp-unrun); }
+  .endstate.landed { border-color: var(--landed); color: var(--landed); box-shadow: var(--glow-green); }
+  .endstate.parked { border-color: var(--amber-border); color: var(--amber); background: var(--amber-fill); box-shadow: var(--glow-amber); }
 
+  /* ---- alarm summary / event journal ---- */
   #cas-list {
     list-style: none;
     margin: 0;
     padding: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
-    font-size: 0.85rem;
   }
   #cas-list li {
-    border-radius: 6px;
-    padding: 0.4rem 0.5rem;
-    border: 1px solid var(--border);
+    display: flex;
+    gap: 0.9rem;
+    padding: 0.32rem 0.2rem;
+    font-size: 0.74rem;
+    letter-spacing: 0.03em;
+    border-bottom: 1px solid var(--rule);
+    align-items: baseline;
   }
-  .cas-amber { background: var(--amber-bg); color: var(--amber); font-weight: 600; }
-  .cas-green { background: var(--green-bg); color: var(--green); }
-  .cas-empty { color: var(--text-dim); font-style: italic; }
+  #cas-list li .t { color: var(--text-dim); white-space: nowrap; width: 42px; flex-shrink: 0; }
+  .cas-amber { background: var(--alarm-row-bg); color: var(--alarm-row-text); font-weight: 700; }
+  .cas-green { color: var(--text-mid); }
+  .cas-empty { color: var(--text-dim); letter-spacing: 0.1em; }
 
+  /* ---- drawer (unchanged mechanics; re-skinned) ---- */
   dialog#drawer {
-    border: 1px solid var(--border);
-    border-radius: 12px;
+    border: 1.5px solid var(--hairline);
+    border-radius: 3px;
     padding: 0;
     width: min(560px, 92vw);
     color: var(--text);
-    background: var(--surface);
+    background: var(--bg);
   }
-  dialog#drawer::backdrop { background: rgba(0, 0, 0, 0.45); }
+  dialog#drawer::backdrop { background: rgba(0, 0, 0, 0.55); }
   .drawer-inner { padding: 1rem 1.1rem; }
-  .drawer-inner h2 { margin: 0 0 0.6rem 0; }
+  .drawer-inner h2 { margin: 0 0 0.6rem; font-size: 0.95rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--strong); }
   .drawer-inner h3 {
     margin: 0.9rem 0 0.35rem 0;
-    font-size: 0.75rem;
-    letter-spacing: 0.05em;
+    font-size: 0.66rem;
+    letter-spacing: 0.14em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--text-mid);
+    font-weight: 400;
   }
-  #drawer-trail { margin: 0; padding-left: 1.1rem; }
-  #drawer-worktree {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-    font-size: 0.85rem;
-    overflow-wrap: anywhere;
-  }
+  #drawer-trail { margin: 0; padding-left: 1.1rem; font-size: 0.8rem; }
+  #drawer-trail li { margin-bottom: 0.2rem; }
+  #drawer-worktree { font-size: 0.78rem; overflow-wrap: anywhere; color: var(--text-mid); }
   .command-row { display: flex; gap: 0.4rem; }
   #drawer-command {
     flex: 1;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-    font-size: 0.82rem;
+    font-size: 0.76rem;
     padding: 0.4rem 0.5rem;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    background: var(--bg);
+    border: 1.5px solid var(--unrun-border);
+    border-radius: 2px;
+    background: var(--panel);
     color: var(--text);
   }
   #drawer-copy, #drawer-close {
-    border: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 6px;
+    border: 1.5px solid var(--hairline);
+    background: var(--panel);
+    border-radius: 2px;
     padding: 0.4rem 0.7rem;
     cursor: pointer;
+    font-size: 0.72rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
   }
-  #copy-status { color: var(--text-dim); font-size: 0.8rem; min-height: 1.2em; margin-top: 0.3rem; }
+  #copy-status { color: var(--text-mid); font-size: 0.74rem; min-height: 1.2em; margin-top: 0.3rem; }
   .drawer-footer { margin-top: 1rem; display: flex; justify-content: flex-end; }
+
+  @media (max-width: 780px) {
+    .tb-cell { border-right: none; }
+    .tb-cell.actions { margin-left: 0; }
+  }
 </style>
 </head>
 <body>
 <header>
-  <h1>Flight Deck</h1>
-  <span id="epic-title">loading…</span>
-  <button type="button" id="master-caution" aria-pressed="false" disabled>MASTER CAUTION</button>
-  <button type="button" id="theme-toggle" aria-label="Toggle light/dark theme">Theme</button>
-  <span id="conn-status" role="status"></span>
+  <div class="tb-cell name"><span class="k">Board</span><span class="v">EPIC OVERVIEW — ONE-LINE</span></div>
+  <div class="tb-cell"><span class="k">Unit</span><span class="v" id="epic-title">loading…</span></div>
+  <div class="tb-cell"><span class="k">Status</span><span class="v" id="epic-counts">—</span></div>
+  <div class="tb-cell actions">
+    <span id="conn-status" role="status"></span>
+    <button type="button" id="master-caution" aria-pressed="false" disabled>ALARM ACK</button>
+    <button type="button" id="theme-toggle" aria-label="Toggle light/dark theme">Theme</button>
+  </div>
 </header>
 
 <main>
-  <section class="panel" aria-labelledby="gauges-heading">
-    <h2 id="gauges-heading">Instruments</h2>
-    <div id="gauges"></div>
+  <section class="panel" aria-labelledby="channels-heading">
+    <h2 id="channels-heading">Story channels — dependency bus</h2>
+    <div id="channels-scroll"><div id="channels"></div></div>
   </section>
 
   <section class="panel" aria-labelledby="cas-heading">
-    <h2 id="cas-heading">CAS messages</h2>
+    <h2 id="cas-heading">Alarm summary / event journal</h2>
     <ul id="cas-list" aria-live="polite"></ul>
   </section>
 </main>

--- a/assets/board-ui/index.html
+++ b/assets/board-ui/index.html
@@ -52,6 +52,8 @@
     --amber-fill: #f7ecd2;
     --alarm-row-bg: #f5e5bb;
     --alarm-row-text: #6b4a04;
+    --alarm-rule: #b9c0af;
+    --alarm-text-glow: none;
     --landed: #21833f;
     --glow-green: none;
     --glow-amber: none;
@@ -87,6 +89,8 @@
       --amber-fill: #241804;
       --alarm-row-bg: transparent;
       --alarm-row-text: #ffb01f;
+      --alarm-rule: transparent;
+      --alarm-text-glow: 0 0 8px rgba(255, 176, 31, 0.35);
       --landed: #46ec66;
       --glow-green: 0 0 10px rgba(70, 236, 102, 0.25);
       --glow-amber: 0 0 12px rgba(255, 176, 31, 0.3);
@@ -103,7 +107,8 @@
     --pass-bg: #21833f; --pass-border: #21833f; --pass-text: #f0f7ef;
     --fix-bg: #eda210; --fix-border: #b57c07; --fix-text: #2c1f01;
     --amber: #9c6a05; --amber-border: #eda210; --amber-fill: #f7ecd2;
-    --alarm-row-bg: #f5e5bb; --alarm-row-text: #6b4a04; --landed: #21833f;
+    --alarm-row-bg: #f5e5bb; --alarm-row-text: #6b4a04; --alarm-rule: #b9c0af;
+    --alarm-text-glow: none; --landed: #21833f;
     --glow-green: none; --glow-amber: none; --scanlines: none;
   }
   :root[data-theme="dark"] {
@@ -114,7 +119,8 @@
     --fix-bg: repeating-linear-gradient(45deg, #ffb01f 0 7px, #b57708 7px 14px);
     --fix-border: #ffb01f; --fix-text: #2b1d00;
     --amber: #ffb01f; --amber-border: #ffb01f; --amber-fill: #241804;
-    --alarm-row-bg: transparent; --alarm-row-text: #ffb01f; --landed: #46ec66;
+    --alarm-row-bg: transparent; --alarm-row-text: #ffb01f; --alarm-rule: transparent;
+    --alarm-text-glow: 0 0 8px rgba(255, 176, 31, 0.35); --landed: #46ec66;
     --glow-green: 0 0 10px rgba(70, 236, 102, 0.25); --glow-amber: 0 0 12px rgba(255, 176, 31, 0.3);
     --scanlines: repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.16) 0 1px, transparent 1px 3px);
   }
@@ -162,7 +168,7 @@
     min-width: 0;
   }
   .tb-cell .k { font-size: 0.55rem; letter-spacing: 0.14em; color: var(--text-dim); text-transform: uppercase; }
-  .tb-cell .v { font-size: 0.78rem; font-weight: 700; letter-spacing: 0.06em; color: var(--strong); overflow-wrap: anywhere; }
+  .tb-cell .v { font-size: 0.78rem; font-weight: 700; letter-spacing: 0.06em; color: var(--strong); overflow-wrap: anywhere; text-transform: uppercase; }
   .tb-cell.name .v { font-size: 0.9rem; letter-spacing: 0.12em; }
   .tb-cell.actions {
     border-right: none;
@@ -312,18 +318,27 @@
     flex-direction: column;
   }
   #cas-list li {
-    display: flex;
-    gap: 0.9rem;
-    padding: 0.32rem 0.2rem;
+    display: grid;
+    grid-template-columns: 52px minmax(180px, 230px) 1fr;
+    gap: 0 0.9rem;
+    padding: 0.32rem 0.3rem;
     font-size: 0.74rem;
     letter-spacing: 0.03em;
-    border-bottom: 1px solid var(--rule);
+    border-bottom: 1px solid var(--alarm-rule);
     align-items: baseline;
+    text-transform: uppercase;
   }
-  #cas-list li .t { color: var(--text-dim); white-space: nowrap; width: 42px; flex-shrink: 0; }
-  .cas-amber { background: var(--alarm-row-bg); color: var(--alarm-row-text); font-weight: 700; }
+  #cas-list li .t { color: var(--text-dim); white-space: nowrap; }
+  #cas-list li .tag { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .cas-amber { background: var(--alarm-row-bg); color: var(--alarm-row-text); font-weight: 700; text-shadow: var(--alarm-text-glow); }
   .cas-green { color: var(--text-mid); }
   .cas-empty { color: var(--text-dim); letter-spacing: 0.1em; }
+  .cas-empty span:last-child { grid-column: 2 / -1; }
+  @media (max-width: 780px) {
+    #cas-list li { grid-template-columns: 52px 1fr; }
+    #cas-list li .tag { grid-column: 2; }
+    #cas-list li .msg { grid-column: 2; }
+  }
 
   /* ---- drawer (unchanged mechanics; re-skinned) ---- */
   dialog#drawer {
@@ -381,6 +396,7 @@
 <header>
   <div class="tb-cell name"><span class="k">Board</span><span class="v">EPIC OVERVIEW — ONE-LINE</span></div>
   <div class="tb-cell"><span class="k">Unit</span><span class="v" id="epic-title">loading…</span></div>
+  <div class="tb-cell"><span class="k">Mode</span><span class="v" id="epic-mode">—</span></div>
   <div class="tb-cell"><span class="k">Status</span><span class="v" id="epic-counts">—</span></div>
   <div class="tb-cell actions">
     <span id="conn-status" role="status"></span>

--- a/assets/board-ui/index.html
+++ b/assets/board-ui/index.html
@@ -252,6 +252,14 @@
 
   .channel { display: flex; align-items: center; min-height: 54px; }
 
+  .channels-empty {
+    padding: 1.4rem 0.5rem;
+    color: var(--text-mid);
+    font-size: 0.78rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
   .feed { display: flex; align-items: center; width: 74px; flex-shrink: 0; }
   .feed .wire { height: 2px; background: var(--wire); flex: 1; }
   .feed svg { flex-shrink: 0; }
@@ -280,7 +288,7 @@
   .connector { width: 16px; height: 2px; background: var(--wire); flex-shrink: 0; }
   .gblock {
     width: 96px;
-    height: 40px;
+    min-height: 40px; /* auto-grows so a wrapped verdict token + ✕n/2 suffix never spills the border */
     flex-shrink: 0;
     border: 1.5px solid var(--unrun-border);
     background: var(--unrun-bg);
@@ -388,6 +396,7 @@
     text-transform: uppercase;
   }
   #copy-status { color: var(--text-mid); font-size: 0.74rem; min-height: 1.2em; margin-top: 0.3rem; }
+  #drawer-no-resolution { margin: 0.9rem 0 0; font-size: 0.78rem; color: var(--text-mid); }
   .drawer-footer { margin-top: 1rem; display: flex; justify-content: flex-end; }
 
   @media (max-width: 780px) {
@@ -431,12 +440,15 @@
     <h3>Worktree</h3>
     <p id="drawer-worktree"></p>
 
-    <h3>Resolution command</h3>
-    <div class="command-row">
-      <input id="drawer-command" type="text" readonly aria-label="Copy-able resolution command">
-      <button type="button" id="drawer-copy">Copy</button>
+    <div id="drawer-resolution">
+      <h3>Resolution command</h3>
+      <div class="command-row">
+        <input id="drawer-command" type="text" readonly aria-label="Copy-able resolution command">
+        <button type="button" id="drawer-copy">Copy</button>
+      </div>
+      <div id="copy-status" role="status"></div>
     </div>
-    <div id="copy-status" role="status"></div>
+    <p id="drawer-no-resolution" hidden>No resolution needed — story is not parked.</p>
 
     <div class="drawer-footer">
       <button type="button" id="drawer-close">Close</button>

--- a/assets/board-ui/index.html
+++ b/assets/board-ui/index.html
@@ -242,9 +242,13 @@
 
   /* ---- story channels on the dependency bus ---- */
   #channels-scroll { overflow-x: auto; }
-  #channels { position: relative; margin-left: 26px; display: flex; flex-direction: column; gap: 15px; min-width: max-content; }
-  /* the bus itself */
-  #channels::before { content: ""; position: absolute; left: -18px; top: 8px; bottom: 8px; width: 2px; background: var(--wire); }
+  #channels { position: relative; margin-left: 10px; display: flex; flex-direction: column; gap: 15px; min-width: max-content; }
+  /* The bus itself. Its right edge sits exactly at the content-box origin
+     (left: -2px + width: 2px = 0), which is where every channel's leading
+     feed wire begins — rail and feeds meet with no gap (audit finding: at
+     the previous left: -18px offset the feeds floated 16px off the rail,
+     visually severing the "fed from a dependency bus" metaphor). */
+  #channels::before { content: ""; position: absolute; left: -2px; top: 8px; bottom: 8px; width: 2px; background: var(--wire); }
 
   .channel { display: flex; align-items: center; min-height: 54px; }
 

--- a/bin/board-server
+++ b/bin/board-server
@@ -12,8 +12,9 @@ Serves two read-only endpoints for exactly one epic slug, scoped to the two file
   GET /events  an SSE stream; pushes a fresh whole snapshot when a poll tick notices
                either file changed. No computed diff — "a delta" is satisfied by
                "something changed, here is the fresh state" (see the design doc).
-  GET /        the Flight Deck: one self-contained HTML document (assets/board-ui/)
-               that fetches /state once, then renders live off /events. No external
+  GET /        the board page (Epic Overview): one self-contained HTML document
+               (assets/board-ui/) that fetches /state once, then renders live off
+               /events. No external
                stylesheet, font, script, or image — see docs/superpowers/specs/
                2026-07-11-board-ui-design.md.
 
@@ -50,7 +51,7 @@ HOST = "127.0.0.1"  # loopback only — deliberately not a flag; see module docs
 DEFAULT_INTERVAL = 1.0  # seconds; a build-time constant per the design doc's own
 # Open Questions ("sub-second vs. one second is a build-time judgment call").
 
-# The Flight Deck page's on-disk assets — part of this plugin's own install,
+# The board page's on-disk assets — part of this plugin's own install,
 # never the consuming project's repo (that's what epics_dir_for()/repo_root()
 # resolve instead). Anchored to this script's own location, the same way
 # every command/reference file this repo's agents read is anchored to "the
@@ -313,7 +314,7 @@ class Handler(BaseHTTPRequestHandler):
             try:
                 self._send_html(200, render_page())
             except (OSError, ValueError):
-                self._send_html(500, b"board-server: could not read Flight Deck assets")
+                self._send_html(500, b"board-server: could not read board-ui assets")
         elif path == "/state":
             self._send_json(200, self.server.board_state.snapshot())
         elif path == "/events":

--- a/tests/js/test-board-ui-app.js
+++ b/tests/js/test-board-ui-app.js
@@ -1,6 +1,6 @@
 // Tests for assets/board-ui/app.js's pure derivation functions — the logic
-// that decides gauge position/order, blocked-instrument labeling, lamp
-// state, fresh-eyes labeling, CAS severity sort, and the copy-able
+// that decides channel position/order, blocked-channel labeling, gate-block
+// state, fresh-eyes labeling, alarm-summary severity sort, and the copy-able
 // --reset-retry resolution command. DOM wiring (render(), init(), the
 // EventSource plumbing) is exercised live against a running bin/board-
 // server instead (see this story's Operational readiness section) — a DOM
@@ -84,79 +84,52 @@ test('classifyGaugeState: blocked-on-dropped-dep is distinct from ordinary block
 });
 
 // ---------------------------------------------------------------------------
-// fixBudgetFraction
+// gateBlockState — what each channel block renders. Worker phases (design/
+// build) derive from phase/step events, never gate-verdict; landed status is
+// authoritative over a thin event feed; a parked story's stuck gate burns
+// amber even when the resumed feed carries no verdict event for it
 // ---------------------------------------------------------------------------
 
-test('fixBudgetFraction: zero retries is zero', () => {
-  assert.equal(app.fixBudgetFraction({ retries: {} }, 'audit', 2), 0);
+test('gateBlockState: a gate with a proceed verdict is pass', () => {
+  const events = [{ kind: 'gate-verdict', story: 'x', gate: 'audit', verdict: 'PASS' }];
+  assert.equal(app.gateBlockState('x', { status: 'audit' }, 'audit', events), 'pass');
 });
 
-test('fixBudgetFraction: at cap is 1', () => {
-  assert.equal(app.fixBudgetFraction({ retries: { audit: 2 } }, 'audit', 2), 1);
+test('gateBlockState: a gate with a fix-and-retry verdict is fix', () => {
+  const events = [{ kind: 'gate-verdict', story: 'x', gate: 'audit', verdict: 'FIX AND RE-AUDIT' }];
+  assert.equal(app.gateBlockState('x', { status: 'audit' }, 'audit', events), 'fix');
 });
 
-test('fixBudgetFraction: never exceeds 1 even if retries somehow exceed the cap', () => {
-  assert.equal(app.fixBudgetFraction({ retries: { audit: 5 } }, 'audit', 2), 1);
+test('gateBlockState: no verdict yet is unrun, never an inferred pass', () => {
+  assert.equal(app.gateBlockState('x', { status: 'audit' }, 'audit', []), 'unrun');
 });
 
-// ---------------------------------------------------------------------------
-// wedgePathD — the fix-budget wedge's SVG arc must never let its endpoint
-// collapse onto its own start point; an SVG elliptical arc with identical
-// start/end is a documented zero-length no-op (SVG 1.1 §9.5.1), so at
-// fraction===1 (fix budget exhausted, the state this gauge exists to
-// surface) a literal 360-degree sweep silently dropped the wedge and left
-// just a bare radius line (audit finding, board-ui epic)
-// ---------------------------------------------------------------------------
-
-function parseWedgeArc(d) {
-  var m = /^M20,20 L20,3 A17,17 0 (\d) 1 (-?[\d.]+),(-?[\d.]+) Z$/.exec(d);
-  assert.ok(m, 'unexpected wedge path shape: ' + d);
-  return { large: Number(m[1]), x: Number(m[2]), y: Number(m[3]) };
-}
-
-test('wedgePathD: at fraction 1 the arc endpoint does not collapse onto the arc\'s own start point (20,3)', () => {
-  const arc = parseWedgeArc(app.wedgePathD(1));
-  assert.notEqual(arc.x + ',' + arc.y, '20,3');
+test('gateBlockState: worker phases derive from phase/step events, not gate verdicts', () => {
+  const events = [{ kind: 'phase', story: 'x', phase: 'design-review' }];
+  assert.equal(app.gateBlockState('x', { status: 'build' }, 'design', events), 'pass');
+  assert.equal(app.gateBlockState('x', { status: 'build' }, 'build', events), 'unrun');
 });
 
-test('wedgePathD: at fraction 1 the endpoint still lands within a hair of true 360deg — visually a full circle', () => {
-  const arc = parseWedgeArc(app.wedgePathD(1));
-  assert.equal(arc.large, 1); // large-arc-flag: still sweeps the long way around
-  assert.ok(Math.abs(arc.x - 20) < 0.01);
-  assert.ok(Math.abs(arc.y - 3) < 0.01);
+test('gateBlockState: a HANDED-OFF takeover step does not mark build pass', () => {
+  const events = [{ kind: 'step', story: 'x', step: 'build', outcome: 'HANDED-OFF' }];
+  assert.equal(app.gateBlockState('x', { status: 'build' }, 'build', events), 'unrun');
 });
 
-test('wedgePathD: fraction 0.5 sweeps an exact half circle, unaffected by the near-360 cap', () => {
-  const arc = parseWedgeArc(app.wedgePathD(0.5));
-  assert.deepEqual(arc, { large: 0, x: 20, y: 37 });
+test('gateBlockState: landed status is authoritative — every block is pass even on a thin feed', () => {
+  assert.equal(app.gateBlockState('x', { status: 'landed' }, 'audit', []), 'pass');
+  assert.equal(app.gateBlockState('x', { status: 'landed' }, 'design', []), 'pass');
 });
 
-// ---------------------------------------------------------------------------
-// activeGate — design/build are worker phases, never verdict-bearing gates;
-// scanning must skip them or a story strands at 'design' forever, since
-// design can structurally never carry a proceed verdict (audit finding,
-// board-ui story: the fix-budget wedge and DSN/BLD lamps stuck at "not yet
-// run" past design/build because the pre-fix scan treated them as candidates)
-// ---------------------------------------------------------------------------
-
-test('activeGate: skips design/build, lands on the first real gate with no proceed verdict', () => {
-  const stories = { x: { gates: ['design', 'build', 'design-review', 'audit', 'acceptance'] } };
-  assert.equal(app.activeGate('x', stories, []), 'design-review');
+test('gateBlockState: a parked story\'s reason-named gate is fix even with no verdict event', () => {
+  const story = { status: 'parked', reason: 'audit: FIX AND RE-AUDIT — merge conflict' };
+  assert.equal(app.gateBlockState('x', story, 'audit', []), 'fix');
+  assert.equal(app.gateBlockState('x', story, 'acceptance', []), 'unrun');
 });
 
-test('activeGate: with every verdict-bearing gate proceeded, lands on the last gate — not stuck at design', () => {
-  const stories = { x: { gates: ['design', 'build', 'design-review', 'audit', 'acceptance'] } };
-  const events = [
-    { kind: 'gate-verdict', story: 'x', gate: 'design-review', verdict: 'PROCEED TO PLAN' },
-    { kind: 'gate-verdict', story: 'x', gate: 'audit', verdict: 'PASS' },
-    { kind: 'gate-verdict', story: 'x', gate: 'acceptance', verdict: 'SHIP' },
-  ];
-  assert.equal(app.activeGate('x', stories, events), 'acceptance');
-});
-
-test('activeGate: a gates array of only worker phases falls back to the last entry', () => {
-  const stories = { x: { gates: ['design', 'build'] } };
-  assert.equal(app.activeGate('x', stories, []), 'build');
+test('gateBlockState: a parked story\'s reason does not mark a different gate fix', () => {
+  const story = { status: 'parked', reason: 'acceptance: HOLD — needs a product decision' };
+  assert.equal(app.gateBlockState('x', story, 'audit', []), 'unrun');
+  assert.equal(app.gateBlockState('x', story, 'acceptance', []), 'fix');
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/js/test-board-ui-app.js
+++ b/tests/js/test-board-ui-app.js
@@ -83,6 +83,16 @@ test('classifyGaugeState: blocked-on-dropped-dep is distinct from ordinary block
   assert.equal(app.classifyGaugeState('x', stories).code, 'blocked-dead');
 });
 
+test('classifyGaugeState: a story\'s own terminal status outranks a derived blocked state', () => {
+  // acceptance finding: a parked story with a non-landed dep previously read
+  // AWAIT/STANDBY at the channel while the alarm summary showed it amber —
+  // the same story telling two severities at once.
+  const stories = { x: { status: 'parked', deps: ['y'] }, y: { status: 'audit' } };
+  assert.equal(app.classifyGaugeState('x', stories).code, 'parked');
+  const landed = { x: { status: 'landed', deps: ['y'] }, y: { status: 'dropped' } };
+  assert.equal(app.classifyGaugeState('x', landed).code, 'landed');
+});
+
 // ---------------------------------------------------------------------------
 // gateBlockState — everything a channel block renders: {state, text}, derived
 // once in the pure core (audit finding: the text half previously lived
@@ -97,11 +107,11 @@ test('gateBlockState: a gate with a proceed verdict is pass, text is the token v
   assert.deepEqual(app.gateBlockState('x', { status: 'audit' }, 'audit', events), { state: 'pass', text: 'PASS' });
 });
 
-test('gateBlockState: a fix-and-retry verdict is fix, with the retry count suffixed', () => {
+test('gateBlockState: a fix-and-retry verdict is fix, with the burn and its ceiling suffixed', () => {
   const events = [{ kind: 'gate-verdict', story: 'x', gate: 'audit', verdict: 'FIX AND RE-AUDIT' }];
   assert.deepEqual(
     app.gateBlockState('x', { status: 'audit', retries: { audit: 1 } }, 'audit', events),
-    { state: 'fix', text: 'FIX AND RE-AUDIT ✕1' }
+    { state: 'fix', text: 'FIX AND RE-AUDIT ✕1/2' }
   );
 });
 
@@ -148,7 +158,7 @@ test('gateBlockState: landed outranks a stale non-proceed verdict — pass, degr
 
 test('gateBlockState: a parked story\'s reason-named gate is fix, verdict recovered from the reason', () => {
   const story = { status: 'parked', reason: 'audit: FIX AND RE-AUDIT — merge conflict', retries: { audit: 2 } };
-  assert.deepEqual(app.gateBlockState('x', story, 'audit', []), { state: 'fix', text: 'FIX AND RE-AUDIT ✕2' });
+  assert.deepEqual(app.gateBlockState('x', story, 'audit', []), { state: 'fix', text: 'FIX AND RE-AUDIT ✕2/2' });
   assert.deepEqual(app.gateBlockState('x', story, 'acceptance', []), { state: 'unrun', text: '—' });
 });
 
@@ -351,7 +361,7 @@ test('buildCasMessages: every entry carries message as a structured field, never
   messages.slice(1).forEach((m) => { bySlug[m.slug] = m.message; });
   assert.equal(bySlug.a, 'audit → PASS');
   assert.equal(bySlug.b, 'landed');
-  assert.equal(bySlug.c, 'fix cycle 1 for audit');
+  assert.equal(bySlug.c, 'fix cycle 1 of 2 for audit');
   const empty = app.buildCasMessages({}, []);
   assert.equal(empty[0].message, 'ALL SYSTEMS NOMINAL');
 });

--- a/tests/js/test-board-ui-app.js
+++ b/tests/js/test-board-ui-app.js
@@ -84,52 +84,98 @@ test('classifyGaugeState: blocked-on-dropped-dep is distinct from ordinary block
 });
 
 // ---------------------------------------------------------------------------
-// gateBlockState — what each channel block renders. Worker phases (design/
-// build) derive from phase/step events, never gate-verdict; landed status is
-// authoritative over a thin event feed; a parked story's stuck gate burns
-// amber even when the resumed feed carries no verdict event for it
+// gateBlockState — everything a channel block renders: {state, text}, derived
+// once in the pure core (audit finding: the text half previously lived
+// untested in the DOM layer, duplicating these branches). Worker phases
+// (design/build) derive from phase/step events, never gate-verdict; landed
+// status is authoritative over the event feed; a parked story's stuck gate
+// burns amber even when the resumed feed carries no verdict event for it
 // ---------------------------------------------------------------------------
 
-test('gateBlockState: a gate with a proceed verdict is pass', () => {
+test('gateBlockState: a gate with a proceed verdict is pass, text is the token verbatim', () => {
   const events = [{ kind: 'gate-verdict', story: 'x', gate: 'audit', verdict: 'PASS' }];
-  assert.equal(app.gateBlockState('x', { status: 'audit' }, 'audit', events), 'pass');
+  assert.deepEqual(app.gateBlockState('x', { status: 'audit' }, 'audit', events), { state: 'pass', text: 'PASS' });
 });
 
-test('gateBlockState: a gate with a fix-and-retry verdict is fix', () => {
+test('gateBlockState: a fix-and-retry verdict is fix, with the retry count suffixed', () => {
   const events = [{ kind: 'gate-verdict', story: 'x', gate: 'audit', verdict: 'FIX AND RE-AUDIT' }];
-  assert.equal(app.gateBlockState('x', { status: 'audit' }, 'audit', events), 'fix');
+  assert.deepEqual(
+    app.gateBlockState('x', { status: 'audit', retries: { audit: 1 } }, 'audit', events),
+    { state: 'fix', text: 'FIX AND RE-AUDIT ✕1' }
+  );
 });
 
-test('gateBlockState: no verdict yet is unrun, never an inferred pass', () => {
-  assert.equal(app.gateBlockState('x', { status: 'audit' }, 'audit', []), 'unrun');
+test('gateBlockState: a fix verdict with no retries recorded carries the bare token', () => {
+  const events = [{ kind: 'gate-verdict', story: 'x', gate: 'audit', verdict: 'FIX AND RE-AUDIT' }];
+  assert.deepEqual(
+    app.gateBlockState('x', { status: 'audit' }, 'audit', events),
+    { state: 'fix', text: 'FIX AND RE-AUDIT' }
+  );
+});
+
+test('gateBlockState: no verdict yet is unrun with the placeholder, never an inferred pass', () => {
+  assert.deepEqual(app.gateBlockState('x', { status: 'audit' }, 'audit', []), { state: 'unrun', text: '—' });
 });
 
 test('gateBlockState: worker phases derive from phase/step events, not gate verdicts', () => {
   const events = [{ kind: 'phase', story: 'x', phase: 'design-review' }];
-  assert.equal(app.gateBlockState('x', { status: 'build' }, 'design', events), 'pass');
-  assert.equal(app.gateBlockState('x', { status: 'build' }, 'build', events), 'unrun');
+  assert.deepEqual(app.gateBlockState('x', { status: 'build' }, 'design', events), { state: 'pass', text: 'DONE' });
+  assert.deepEqual(app.gateBlockState('x', { status: 'build' }, 'build', events), { state: 'unrun', text: '—' });
 });
 
 test('gateBlockState: a HANDED-OFF takeover step does not mark build pass', () => {
   const events = [{ kind: 'step', story: 'x', step: 'build', outcome: 'HANDED-OFF' }];
-  assert.equal(app.gateBlockState('x', { status: 'build' }, 'build', events), 'unrun');
+  assert.deepEqual(app.gateBlockState('x', { status: 'build' }, 'build', events), { state: 'unrun', text: '—' });
 });
 
 test('gateBlockState: landed status is authoritative — every block is pass even on a thin feed', () => {
-  assert.equal(app.gateBlockState('x', { status: 'landed' }, 'audit', []), 'pass');
-  assert.equal(app.gateBlockState('x', { status: 'landed' }, 'design', []), 'pass');
+  assert.deepEqual(app.gateBlockState('x', { status: 'landed' }, 'audit', []), { state: 'pass', text: 'DONE' });
+  assert.deepEqual(app.gateBlockState('x', { status: 'landed' }, 'design', []), { state: 'pass', text: 'DONE' });
 });
 
-test('gateBlockState: a parked story\'s reason-named gate is fix even with no verdict event', () => {
-  const story = { status: 'parked', reason: 'audit: FIX AND RE-AUDIT — merge conflict' };
-  assert.equal(app.gateBlockState('x', story, 'audit', []), 'fix');
-  assert.equal(app.gateBlockState('x', story, 'acceptance', []), 'unrun');
+test('gateBlockState: landed keeps the recorded proceed token when the feed carries it', () => {
+  const events = [{ kind: 'gate-verdict', story: 'x', gate: 'acceptance', verdict: 'SHIP' }];
+  assert.deepEqual(app.gateBlockState('x', { status: 'landed' }, 'acceptance', events), { state: 'pass', text: 'SHIP' });
+});
+
+test('gateBlockState: landed outranks a stale non-proceed verdict — pass, degraded to DONE not the fix token', () => {
+  // "events enrich but never veto": a landed story whose thin feed ends on a
+  // FIX AND RE-AUDIT (the later PASS never made it into the feed) must not
+  // render a green block captioned with a fix token.
+  const events = [{ kind: 'gate-verdict', story: 'x', gate: 'audit', verdict: 'FIX AND RE-AUDIT' }];
+  assert.deepEqual(app.gateBlockState('x', { status: 'landed' }, 'audit', events), { state: 'pass', text: 'DONE' });
+});
+
+test('gateBlockState: a parked story\'s reason-named gate is fix, verdict recovered from the reason', () => {
+  const story = { status: 'parked', reason: 'audit: FIX AND RE-AUDIT — merge conflict', retries: { audit: 2 } };
+  assert.deepEqual(app.gateBlockState('x', story, 'audit', []), { state: 'fix', text: 'FIX AND RE-AUDIT ✕2' });
+  assert.deepEqual(app.gateBlockState('x', story, 'acceptance', []), { state: 'unrun', text: '—' });
 });
 
 test('gateBlockState: a parked story\'s reason does not mark a different gate fix', () => {
   const story = { status: 'parked', reason: 'acceptance: HOLD — needs a product decision' };
-  assert.equal(app.gateBlockState('x', story, 'audit', []), 'unrun');
-  assert.equal(app.gateBlockState('x', story, 'acceptance', []), 'fix');
+  assert.deepEqual(app.gateBlockState('x', story, 'audit', []), { state: 'unrun', text: '—' });
+  assert.deepEqual(app.gateBlockState('x', story, 'acceptance', []), { state: 'fix', text: 'HOLD' });
+});
+
+// ---------------------------------------------------------------------------
+// casTimeLabel — the alarm-journal clock renders the operator's LOCAL wall
+// clock from the schema's UTC `at` (audit finding: a positional slice of the
+// ISO string displayed UTC unlabeled, offset from the operator's terminal)
+// ---------------------------------------------------------------------------
+
+test('casTimeLabel: converts a UTC timestamp to the local wall clock', () => {
+  const at = '2026-07-11T15:42:00Z';
+  const d = new Date(at);
+  const expected = String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0');
+  assert.equal(app.casTimeLabel(at), expected);
+  assert.match(app.casTimeLabel(at), /^([01]\d|2[0-3]):[0-5]\d$/);
+});
+
+test('casTimeLabel: absent or unparseable timestamps degrade to the placeholder, never junk', () => {
+  assert.equal(app.casTimeLabel(''), '—');
+  assert.equal(app.casTimeLabel(null), '—');
+  assert.equal(app.casTimeLabel('not-a-date'), '—');
 });
 
 // ---------------------------------------------------------------------------
@@ -288,6 +334,26 @@ test('buildCasMessages: amber uses the story\'s reason verbatim', () => {
   const stories = { p: { status: 'parked', reason: 'audit: FIX AND RE-AUDIT — flaky network mock' } };
   const messages = app.buildCasMessages(stories, []);
   assert.ok(messages[0].text.includes('flaky network mock'));
+});
+
+test('buildCasMessages: every entry carries message as a structured field, never re-parsed from text', () => {
+  // audit finding: the renderer previously prefix-stripped the slug back off
+  // the composed text string; the body must arrive as its own field.
+  const stories = { p: { status: 'parked', reason: 'audit: HOLD — a decision' } };
+  const events = [
+    { at: '2026-07-11T10:00:00Z', kind: 'gate-verdict', story: 'a', gate: 'audit', verdict: 'PASS' },
+    { at: '2026-07-11T10:01:00Z', kind: 'story', story: 'b', status: 'landed' },
+    { at: '2026-07-11T10:02:00Z', kind: 'story', story: 'c', bumpRetryGate: 'audit', retries: 1 },
+  ];
+  const messages = app.buildCasMessages(stories, events);
+  assert.equal(messages[0].message, 'audit: HOLD — a decision'); // amber: reason verbatim, no slug prefix
+  const bySlug = {};
+  messages.slice(1).forEach((m) => { bySlug[m.slug] = m.message; });
+  assert.equal(bySlug.a, 'audit → PASS');
+  assert.equal(bySlug.b, 'landed');
+  assert.equal(bySlug.c, 'fix cycle 1 for audit');
+  const empty = app.buildCasMessages({}, []);
+  assert.equal(empty[0].message, 'ALL SYSTEMS NOMINAL');
 });
 
 test('buildCasMessages: green tier is newest-first', () => {


### PR DESCRIPTION
## Summary

Replaces the board's aviation Flight Deck rendering with a utilities control-room **Operator Graphic**, per the corrected design brief (direction studies and comprehension comparison in the owner's session artifacts). Stacked on `epic/worker-evidence-and-board`; 4 commits, 4 files.

- **Channels on a dependency bus** — each story renders as a process channel fed from a bus rail; a blocked story shows an open contact on its feed line naming its awaited dependency. The DAG is now visible topology, which the dial layout never showed.
- **Gate blocks carry verdict tokens verbatim** — `PASS`, `FIX AND RE-AUDIT ✕1/2` (burn with its ceiling, sourced from the vendored `MAX_FIX_CYCLES`), per `reference/gate-vocabulary.md`.
- **Two themes as two shifts of one room** — light is a day-shift engineering one-line diagram (paper, ink, drawing title block); dark is a night-shift monochrome phosphor tube where amber is spent only on alarm-tier state. Every difference is a CSS token; the script is theme-blind.
- **Alarm summary / event journal** — severity-major sort, local wall-clock times via a pure tested `casTimeLabel` (was an unlabeled UTC slice), structured `message` fields instead of compose-then-parse.
- **Pure core widened, DOM thinned** — `gateBlockState` returns `{state, text}` so all display derivation is unit-tested; deleted the dial-era `activeGate`/`fixBudgetFraction`/`wedgePathD` with their tests and the dead `innerHTML` branch in `el()` (the file's one HTML-parsing sink).
- **Acceptance-driven guardrails** — the copy-able un-park command arms only on parked stories (a landed story's drawer previously offered a command that would revert shipped work); terminal statuses outrank derived blocked state; a wrong slug renders "no blackboard found" instead of an all-nominal lookalike.

Chrome vocabulary moved to the control-room idiom (ALARM ACK, alarm summary); verdict tokens, schema words, and the parked-is-amber-never-red rule are unchanged. `bin/board-server` diff is docstring wording only.

## Gates

- `/gate-audit`: FIX AND RE-AUDIT at d6e4592 (2 confirmed Criticals: bus/feed junction gap, UTC journal times) → fixed → **PASS** at 2acbd1b
- `/gate-acceptance`: FIX AND RE-CHECK at 2acbd1b (2 SHOULD FIX) → fixed → **SHIP** at 029eb29
- Honest note: the audit PASS predates the final acceptance-fix commit by one commit; the delta is 5 small test-covered changes verified visually. Deferred cleanup from both gates is filed as #129 (board-ui polish backlog) and #128 (epic-driver robustness defects observed during this epic's run).

## Test plan

- [x] 61 JS tests (`node --test tests/js/*.js`) — 15 new across the redesign
- [x] 145 Python tests, gate-ledger + evidence-capture bash suites
- [x] markdownlint, shellcheck, check_references, validate_plugin
- [x] Both themes + 420px width rendered against a populated synthetic state (parked at cap, mid-fix-cycle, blocked, landed); drawer verified for parked and landed stories; wrong-slug empty state verified
- [x] Live server smoke: GET / serves the page, 404/501 guardrails, /state and SSE unchanged