### PR TITLE
Pin agent effort by stakes; move recommend-only agents off inherit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,17 +91,24 @@ ships worse decisions.
   `security-auditor`, `infra-auditor`, `operability-auditor`, `architecture-auditor`,
   `premortem-auditor`, `product-reviewer`, `ux-reviewer`, `review-architecture`,
   `review-product-health`, `review-security-health`.
-- **`inherit`** — code hygiene, docs, tests, frontend code, inventory sweeps, and triage:
-  `code-auditor`, `doc-auditor`, `test-auditor`, `frontend-reviewer`,
-  `review-codebase-health`, `review-interface-health`, `review-readme`, `backlog-priorities`,
-  `backlog-hygiene`.
+- **`sonnet`** — recommend-only synthesis and ranking judgment, no merge gate behind it:
+  `backlog-priorities`, `review-codebase-health`, `review-interface-health`.
+- **`haiku`** — recommend-only pure inventory and drift checks, no merge gate behind it:
+  `backlog-hygiene`, `review-readme`.
+- **`inherit`** — merge-blocking, mechanical or rule-based checks, pending an A/B against a
+  pinned drop (see below): `code-auditor`, `doc-auditor`, `test-auditor`,
+  `frontend-reviewer`.
 
-**`inherit` is a known defect, not the intended cheap tier — see [#136](https://github.com/jacquardlabs/studious/issues/136).** It resolves to the session
-model, so the "cheap" half above is billed at whatever the user happens to have selected: an
-Opus session makes it identical to the `opus` tier, and a Fable session makes it 2× that.
-Worse, it means the same branch audited on two different days can be judged by two different
-models. Do not add new `inherit` agents; pin explicitly by stakes, and take model *drops* on
-merge-blocking lanes through the A/B harness rather than on judgment.
+**`inherit` is a known defect, not a cheap tier — see [#136](https://github.com/jacquardlabs/studious/issues/136).** It resolves to the session model, so an
+agent still pinned to it is billed at whatever the user happens to have selected: identical
+to the `opus` tier in an Opus session, 2× that in a Fable one. Worse, it means the same
+branch audited on two different days can be judged by two different models. The four agents
+above are pinned to it only because they gate a merge and a model drop needs the A/B harness
+first — they are not "the cheap tier" by design, they are the remaining defect. The five
+`sonnet`/`haiku` agents above show the target shape: no merge gate behind an agent's output
+means no A/B is needed to drop its tier, since a weak result is visible and cheap for a human
+to catch. Do not add new `inherit` agents for that reason, and do not read `inherit`
+anywhere in this file as an endorsed default.
 
 ## What we won't merge
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,14 +55,53 @@ Names encode two things — whether something is an action or a role, and what s
 - **One fan-out command, many subagents.** Parallel checks belong to subagents under a single entry point (`/gate-audit`, `/deep-review`), not to their own top-level commands. Don't add a command per check.
 - **Skills are named for the intent they detect** — `evaluate-feature-idea`, `review-design-before-build`, `acceptance-check-before-merge` — not for the command they call. The `description` carries the trigger; keep it conservative (fire on explicit intent, list what it should NOT match) so a gate never interrupts when it isn't wanted.
 
-## Model assignments
+## Model and effort assignments
 
-Pin by stakes, not by habit. An agent's `model` is `opus` when its core job is high-stakes reasoning or human judgment — where a weaker model ships worse decisions — and `inherit` (the session model) for mechanical, rule-based, or inventory work.
+Every agent carries two dispatch dials, and they move different multipliers. A dispatch's
+cost is roughly `context × turns × model_rate`: **`model` moves the rate, `effort` moves the
+turns.** Pin both by stakes, not by habit.
 
-- **`opus`** — security, architecture, and product/UX judgment: `security-auditor`, `infra-auditor`, `operability-auditor`, `architecture-auditor`, `product-reviewer`, `ux-reviewer`, `review-architecture`, `review-product-health`, `review-security-health`.
-- **`inherit`** — code hygiene, docs, tests, frontend code, inventory sweeps, and triage: `code-auditor`, `doc-auditor`, `test-auditor`, `frontend-reviewer`, `review-codebase-health`, `review-interface-health`, `review-readme`, `backlog-priorities`, `backlog-hygiene`.
+### `effort`
 
-Don't pin to a bare tier like `sonnet` — use `inherit` so the agent tracks the user's session model.
+`low` · `medium` · `high` · `xhigh` · `max`, set in the agent's frontmatter, overriding the
+session's effort. Lower effort means fewer and more-consolidated tool calls, less preamble,
+and terser output — so it is the primary lever on turn count, which is where most of a
+dispatch's tokens actually go (an agent's own prompt is ~1k tokens against tens of thousands
+spent reading and reasoning).
+
+- **`high`** — open-ended reasoning where a shallower pass ships a worse merge decision:
+  `security-auditor`, `architecture-auditor`, `infra-auditor`, `operability-auditor`,
+  `product-reviewer`, `review-architecture`, `review-product-health`, `review-security-health`.
+- **`medium`** — judgment that is rubric-driven rather than open-ended, and periodic reviews:
+  `code-auditor`, `test-auditor`, `frontend-reviewer`, `ux-reviewer`, `premortem-auditor`,
+  `review-codebase-health`, `review-interface-health`, `backlog-priorities`.
+- **`low`** — mechanical, rule-based, or inventory work: `doc-auditor`, `review-readme`,
+  `backlog-hygiene`.
+
+`premortem-auditor` sits at `medium` despite being merge-blocking: it verifies a fixed
+register item by item and never free-hunts, so it is structured verification, not open-ended
+reasoning.
+
+### `model`
+
+`opus` when the core job is high-stakes reasoning or human judgment — where a weaker model
+ships worse decisions.
+
+- **`opus`** — security, architecture, operational, and product/UX judgment:
+  `security-auditor`, `infra-auditor`, `operability-auditor`, `architecture-auditor`,
+  `premortem-auditor`, `product-reviewer`, `ux-reviewer`, `review-architecture`,
+  `review-product-health`, `review-security-health`.
+- **`inherit`** — code hygiene, docs, tests, frontend code, inventory sweeps, and triage:
+  `code-auditor`, `doc-auditor`, `test-auditor`, `frontend-reviewer`,
+  `review-codebase-health`, `review-interface-health`, `review-readme`, `backlog-priorities`,
+  `backlog-hygiene`.
+
+**`inherit` is a known defect, not the intended cheap tier — see [#136](https://github.com/jacquardlabs/studious/issues/136).** It resolves to the session
+model, so the "cheap" half above is billed at whatever the user happens to have selected: an
+Opus session makes it identical to the `opus` tier, and a Fable session makes it 2× that.
+Worse, it means the same branch audited on two different days can be judged by two different
+models. Do not add new `inherit` agents; pin explicitly by stakes, and take model *drops* on
+merge-blocking lanes through the A/B harness rather than on judgment.
 
 ## What we won't merge
 

--- a/agents/architecture-auditor.md
+++ b/agents/architecture-auditor.md
@@ -3,6 +3,7 @@ name: architecture-auditor
 description: Architecture auditor. Reviews a changeset for structural fit, coupling, and complexity. Stays in its lane — audits and reports, does not fix or orchestrate.
 tools: Read, Grep, Glob, Bash
 model: opus
+effort: high
 ---
 
 # Architecture audit

--- a/agents/backlog-hygiene.md
+++ b/agents/backlog-hygiene.md
@@ -2,7 +2,7 @@
 name: backlog-hygiene
 description: Identify open GitHub issues that should be closed — resolved by commits, made obsolete by product decisions, or duplicated by other issues. Recommend-only, never modifies issues.
 tools: Read, Glob, Grep, Bash
-model: inherit
+model: haiku
 effort: low
 ---
 

--- a/agents/backlog-hygiene.md
+++ b/agents/backlog-hygiene.md
@@ -3,6 +3,7 @@ name: backlog-hygiene
 description: Identify open GitHub issues that should be closed — resolved by commits, made obsolete by product decisions, or duplicated by other issues. Recommend-only, never modifies issues.
 tools: Read, Glob, Grep, Bash
 model: inherit
+effort: low
 ---
 
 # Backlog hygiene

--- a/agents/backlog-priorities.md
+++ b/agents/backlog-priorities.md
@@ -2,7 +2,7 @@
 name: backlog-priorities
 description: Curate a ranked shortlist from open GitHub issues based on the user's current intent — tech debt, maintenance, polish, or new initiative. Recommend-only, never modifies issues.
 tools: Read, Glob, Grep, Bash
-model: inherit
+model: sonnet
 effort: medium
 ---
 

--- a/agents/backlog-priorities.md
+++ b/agents/backlog-priorities.md
@@ -3,6 +3,7 @@ name: backlog-priorities
 description: Curate a ranked shortlist from open GitHub issues based on the user's current intent — tech debt, maintenance, polish, or new initiative. Recommend-only, never modifies issues.
 tools: Read, Glob, Grep, Bash
 model: inherit
+effort: medium
 ---
 
 # Backlog priorities

--- a/agents/code-auditor.md
+++ b/agents/code-auditor.md
@@ -3,6 +3,7 @@ name: code-auditor
 description: Code quality auditor. Reviews a changeset for patterns, maintainability, complexity, consistency, language idioms, and error handling. Diff-scoped and gate-invoked (/gate-audit) — not the periodic whole-codebase review.
 tools: Read, Grep, Glob, Bash
 model: inherit
+effort: medium
 ---
 
 # Code Quality Audit

--- a/agents/doc-auditor.md
+++ b/agents/doc-auditor.md
@@ -3,6 +3,7 @@ name: doc-auditor
 description: Documentation coverage analyzer. Reviews a changeset for missing docs, outdated comments, and API gaps. Diff-scoped and gate-invoked (/gate-audit) — not a periodic whole-repo docs sweep.
 tools: Read, Grep, Glob, Bash
 model: inherit
+effort: low
 ---
 
 # Documentation Audit

--- a/agents/frontend-reviewer.md
+++ b/agents/frontend-reviewer.md
@@ -3,6 +3,7 @@ name: frontend-reviewer
 description: Reviews a frontend changeset for component architecture, state management, performance, bundle size, and frontend-specific patterns. Diff-scoped and gate-invoked (/gate-audit) — not a periodic frontend review.
 tools: Read, Glob, Grep, Bash
 model: inherit
+effort: medium
 ---
 
 You are a frontend code reviewer. You evaluate the technical quality of frontend code — component structure, state management, performance, and build health. You are not reviewing visual design or accessibility — other agents handle those.

--- a/agents/infra-auditor.md
+++ b/agents/infra-auditor.md
@@ -3,6 +3,7 @@ name: infra-auditor
 description: Infrastructure auditor. Reviews a changeset for IaC misconfiguration, change blast radius, CI/CD pipeline risk, and container hygiene. Diff-scoped and gate-invoked (/gate-audit); skipped when the changeset touches no infrastructure files.
 tools: Read, Grep, Glob, Bash
 model: opus
+effort: high
 ---
 
 # Infrastructure audit

--- a/agents/operability-auditor.md
+++ b/agents/operability-auditor.md
@@ -3,6 +3,7 @@ name: operability-auditor
 description: Operability auditor. Reviews a changeset for production failure signal, resilience, and 12-factor runtime hygiene. Diff-scoped and gate-invoked (/gate-audit); skipped when the changeset touches no runtime surface.
 tools: Read, Grep, Glob, Bash
 model: opus
+effort: high
 ---
 
 # Operability audit

--- a/agents/premortem-auditor.md
+++ b/agents/premortem-auditor.md
@@ -3,6 +3,7 @@ name: premortem-auditor
 description: Pre-mortem register verifier. Checks each failure mode recorded at design time against the finished changeset and reports REALIZED / NOT REALIZED / CAN'T VERIFY per item. Stays in its lane — verifies the register only, never free-hunts.
 tools: Read, Grep, Glob, Bash
 model: opus
+effort: medium
 ---
 
 # Pre-mortem verification

--- a/agents/product-reviewer.md
+++ b/agents/product-reviewer.md
@@ -3,6 +3,7 @@ name: product-reviewer
 description: Reviews features from a product and user experience perspective. Invoked after design docs are written or after implementation is complete to verify the feature serves users and fits the product.
 tools: Read, Glob, Grep
 model: opus
+effort: high
 ---
 
 You are a product reviewer. You evaluate features from the user's perspective, not the code's perspective. Other agents handle code quality, security, and architecture — your job is entirely different.

--- a/agents/review-architecture.md
+++ b/agents/review-architecture.md
@@ -3,6 +3,7 @@ name: review-architecture
 description: Deep architecture review — evaluate system structure, boundaries, and evolution path
 tools: Read, Glob, Grep, Bash, Write
 model: opus
+effort: high
 ---
 
 # Architecture review

--- a/agents/review-codebase-health.md
+++ b/agents/review-codebase-health.md
@@ -2,7 +2,7 @@
 name: review-codebase-health
 description: Periodic whole-codebase health review — architecture, debt, patterns, dependencies, tests
 tools: Read, Glob, Grep, Bash, Write
-model: inherit
+model: sonnet
 effort: medium
 ---
 

--- a/agents/review-codebase-health.md
+++ b/agents/review-codebase-health.md
@@ -3,6 +3,7 @@ name: review-codebase-health
 description: Periodic whole-codebase health review — architecture, debt, patterns, dependencies, tests
 tools: Read, Glob, Grep, Bash, Write
 model: inherit
+effort: medium
 ---
 
 # Codebase health review

--- a/agents/review-interface-health.md
+++ b/agents/review-interface-health.md
@@ -3,6 +3,7 @@ name: review-interface-health
 description: Periodic whole-project interface and frontend review — cross-surface consistency, design-system, accessibility. Not diff-scoped; the per-changeset frontend reviewer is frontend-reviewer.
 tools: Read, Glob, Grep, Bash, Write
 model: inherit
+effort: medium
 ---
 
 # Interface health review

--- a/agents/review-interface-health.md
+++ b/agents/review-interface-health.md
@@ -2,7 +2,7 @@
 name: review-interface-health
 description: Periodic whole-project interface and frontend review — cross-surface consistency, design-system, accessibility. Not diff-scoped; the per-changeset frontend reviewer is frontend-reviewer.
 tools: Read, Glob, Grep, Bash, Write
-model: inherit
+model: sonnet
 effort: medium
 ---
 

--- a/agents/review-product-health.md
+++ b/agents/review-product-health.md
@@ -3,6 +3,7 @@ name: review-product-health
 description: Periodic product review — evaluate product coherence, scope drift, and roadmap alignment
 tools: Read, Glob, Grep, Bash, Write
 model: opus
+effort: high
 ---
 
 # Product health review

--- a/agents/review-readme.md
+++ b/agents/review-readme.md
@@ -3,6 +3,7 @@ name: review-readme
 description: README drift review — flag stale claims, broken commands, and voice drift, propose a fix.
 tools: Read, Glob, Grep, Bash, Write
 model: inherit
+effort: low
 ---
 
 # README drift review

--- a/agents/review-readme.md
+++ b/agents/review-readme.md
@@ -2,7 +2,7 @@
 name: review-readme
 description: README drift review — flag stale claims, broken commands, and voice drift, propose a fix.
 tools: Read, Glob, Grep, Bash, Write
-model: inherit
+model: haiku
 effort: low
 ---
 

--- a/agents/review-security-health.md
+++ b/agents/review-security-health.md
@@ -3,6 +3,7 @@ name: review-security-health
 description: Periodic whole-repo security posture review — pre-existing vulnerabilities, secrets in history, security-config posture, trend over time. Not diff-scoped; the per-changeset security auditor is security-auditor.
 tools: Read, Glob, Grep, Bash, Write
 model: opus
+effort: high
 ---
 
 # Security health review

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -3,6 +3,7 @@ name: security-auditor
 description: Comprehensive security analysis — OWASP Top 10, injection, auth, secrets, headers. Reviews a changeset; diff-scoped and gate-invoked (/gate-audit) — not the periodic whole-repo posture review, which review-security-health owns.
 tools: Read, Grep, Glob, Bash
 model: opus
+effort: high
 ---
 
 # Security Audit

--- a/agents/test-auditor.md
+++ b/agents/test-auditor.md
@@ -3,6 +3,7 @@ name: test-auditor
 description: Test adequacy auditor. Reviews a changeset's tests — coverage of new behavior, assertion quality, regression tests for bug fixes, weakened or skipped tests. Diff-scoped and gate-invoked (/gate-audit) — not the periodic test-health trend, which review-codebase-health owns.
 tools: Read, Grep, Glob, Bash
 model: inherit
+effort: medium
 ---
 
 # Test adequacy audit

--- a/agents/ux-reviewer.md
+++ b/agents/ux-reviewer.md
@@ -3,6 +3,7 @@ name: ux-reviewer
 description: Reviews a UI changeset for user experience quality — layout, hierarchy, flows, interaction patterns, visual consistency, and responsive behavior. Diff-scoped and gate-invoked (/gate-audit after building a feature) — not a periodic frontend review.
 tools: Read, Glob, Grep, Bash
 model: opus
+effort: medium
 ---
 
 You are a UX reviewer. You evaluate frontend implementations from a design and usability perspective. You are not checking code quality or accessibility compliance — other agents handle those. You are checking whether the interface is clear, consistent, and well-crafted.


### PR DESCRIPTION
## Summary
- Every one of the 19 agents now carries an explicit `effort` frontmatter pin (`low`/`medium`/`high`) — none had one before, so the whole fleet ran at the session default regardless of task, including inventory sweeps. `effort` moves turn count, the dominant cost multiplier per #130's measured data (~60k tokens per dispatched lane against a ~1k-token agent prompt).
- The 5 agents that gate no merge — `backlog-hygiene`, `backlog-priorities`, `review-codebase-health`, `review-interface-health`, `review-readme` — move off `model: inherit` to `haiku`/`sonnet`. No A/B needed for these: a human reads the output directly, so a weak result is visible and cheap to catch.
- The remaining 4 `inherit` agents (`code-auditor`, `doc-auditor`, `test-auditor`, `frontend-reviewer`) all gate a merge and stay on `inherit` pending an A/B (#136) before any model drop.
- `CONTRIBUTING.md`'s model-assignment section is corrected: `inherit` is documented as a known cost/reproducibility defect (resolves to the session model — 2x Opus rate on an accidental Fable session, and the same branch can be judged by different models on different days), not the intended cheap tier. `premortem-auditor` is restored to the model lists it was missing from (closes #117).

## Why
Filed from a holistic speed/price-per-task audit (see #130's comment thread and the new `performance` label). `inherit` has no cost floor or ceiling, and none of the 19 agents used the documented `effort` axis at all — both are pure-frontmatter fixes with zero collision risk against the in-flight `epic/driver-cost-hardening` work (verified: that epic touches zero files under `agents/`).

Refs #130, #132, #136. Closes #117.

## Test plan
- [x] `npx -y markdownlint-cli2` — 0 errors
- [x] `uv run --no-project python scripts/check_references.py` — all references resolve
- [x] `uv run --no-project python scripts/validate_plugin.py` — manifest valid
- [x] `uv run --no-project --with pytest pytest tests/python -q` — 145 passed
- [ ] Confirm `effort:` frontmatter is actually honored by the harness (not verified in this PR — flagging for reviewer awareness; if silently ignored these pins are a no-op until then)
