### PR TITLE
perf: fan out story-level acceptance gate, bound precedent search

### DIFF
--- a/commands/gate-acceptance.md
+++ b/commands/gate-acceptance.md
@@ -57,6 +57,8 @@ Map the product-reviewer's severities — and the premortem-auditor's REALIZED f
 - **FIX AND RE-CHECK** — one or more SHOULD FIX findings, or a BLOCKER fixable with targeted work. List them with severity, then re-run this gate.
 - **HOLD** — a BLOCKER that's a fundamental gap between design intent and implementation, needing rework beyond quick fixes.
 
+If calibrating a finding's severity against precedent — has this exact gap been flagged before, and how was it classified — search cheaply first: `git log --oneline --grep <topic>` against commit messages, not full diffs. Read a matching commit's full diff (`git show`) only if the message/summary doesn't resolve the question; don't default to a full-diff read for a precedent lookup (#142).
+
 For FIX AND RE-CHECK items, be specific enough that they can go directly into the engineering chain as fix tasks.
 
 ## Record the verdict

--- a/tests/python/test_acceptance_fanout.py
+++ b/tests/python/test_acceptance_fanout.py
@@ -1,0 +1,285 @@
+"""Regression tests for the acceptance-gate fan-out story (perf item 10).
+
+`commands/gate-acceptance.md` dispatches @agent-product-reviewer for Part 1 and
+self-performs the Part 3 walkthrough serially inside one agent — the shape that
+produced issue #142's case study (a single acceptance dispatch that took 117
+minutes). `workflows/epic-driver.js`'s story-level acceptance gate mirrored that
+same single-dispatch shape (`gatePrompt`, "perform those roles' checks
+yourself"). This story adds a fan-out mirroring auditRound's own: a mechanical
+scope-check (product-reviewer has no Bash and cannot compute the diff or find
+its own design doc — issue #89), then product-review and the walkthrough
+dispatched concurrently, then a compile step that maps both into one verdict.
+
+Scope: story-level only. The finale acceptance dispatch and the design-review
+gate are NOT part of this story — both stay the single self-performing dispatch
+they were before (see epic-driver.js's own comment above acceptanceRound).
+
+These tests run the real driver source end-to-end via `_run_driver` (imported
+from `test_driver_crash_hardening`, this file's own established reuse
+convention — see test_delta_scoped_reaudit.py and test_audit_first_round_routing.py
+for the same import shape), proving the fan-out's dispatch shape and its
+fail-closed missing-lane guarantee, not just that the compiled prompt text
+looks right.
+"""
+
+from __future__ import annotations
+
+import json
+
+from test_driver_crash_hardening import (
+    DRIVER,
+    FINALE_AUDITORS_PASS,
+    _run_driver,
+)
+
+
+def _one_story_acceptance_epic() -> dict:
+    return {
+        "slug": "epx",
+        "title": "Test epic",
+        "goal": "prove the acceptance fan-out",
+        "concurrency": 1,
+        "stories": {
+            "a": {"title": "Story A", "criteria": "a criteria", "gates": ["acceptance"]},
+        },
+    }
+
+
+SCOPE_WITH_DOC = {"findings": json.dumps({"files": ["foo.py"], "designDoc": "docs/design-foo.md"})}
+SCOPE_NO_DOC = {"findings": json.dumps({"files": ["foo.py"], "designDoc": ""})}
+
+
+def test_normal_round_dispatches_all_four_lanes_in_shape() -> None:
+    """A clean round dispatches the scope-check, both parallel lanes, and the
+    compile step — one label each, none silently skipped or duplicated — and
+    the story actually lands end-to-end through the fan-out (the full finale
+    chain is mocked too, since this is a one-story epic and landing triggers
+    it, matching test_driver_crash_hardening.py's own FINALE_AUDITORS_PASS
+    convention)."""
+    epic = _one_story_acceptance_epic()
+    rules = [
+        {"match": r"^acceptance:scope:a$", "result": SCOPE_WITH_DOC},
+        {"match": r"^acceptance:product-review:a$", "result": {"findings": "looks good"}},
+        {"match": r"^acceptance:walkthrough:a$", "result": {"findings": "no complaints"}},
+        {"match": r"^acceptance:compile:a$", "result": {"verdict": "SHIP", "sha": "a0", "summary": "ship it"}},
+        {"match": r"^merge:a$", "result": {"merged": True, "sha": "a1", "notes": "clean"}},
+        *FINALE_AUDITORS_PASS,
+        {"match": r"^finale:audit-compile$", "result": {"verdict": "PASS", "sha": "f1", "summary": "clean"}},
+        {"match": r"^finale:acceptance$", "result": {"verdict": "SHIP", "sha": "f2", "summary": "ship it"}},
+        {"match": r"^finale:ready$", "result": {"verdict": "READY", "sha": "f3", "summary": "marked ready"}},
+    ]
+    out = _run_driver(epic, rules)
+    assert out["ok"], f"driver crashed: {out.get('error')}"
+    labels = [c["label"] for c in out["calls"]]
+    for expected in (
+        "acceptance:scope:a",
+        "acceptance:product-review:a",
+        "acceptance:walkthrough:a",
+        "acceptance:compile:a",
+    ):
+        assert labels.count(expected) == 1, f"expected exactly one {expected!r} dispatch, saw {labels.count(expected)} in {labels}"
+
+    result = out["result"]
+    assert result["landed"] == 1, f"story should land on a clean SHIP: {result}"
+
+
+def test_product_review_prompt_names_the_resolved_design_doc() -> None:
+    """The product-review dispatch gets the design doc the scope-check resolved,
+    not a pointer it has to go discover itself (product-reviewer has no Bash)."""
+    epic = _one_story_acceptance_epic()
+    rules = [
+        {"match": r"^acceptance:scope:a$", "result": SCOPE_WITH_DOC},
+        {"match": r"^acceptance:product-review:a$", "result": {"findings": "looks good"}},
+        {"match": r"^acceptance:walkthrough:a$", "result": {"findings": "no complaints"}},
+        {"match": r"^acceptance:compile:a$", "result": {"verdict": "SHIP", "sha": "a0", "summary": "ship it"}},
+        # merge:a deliberately unmocked — the story parking on a crashed merge
+        # (rather than actually landing) keeps this test from tripping the
+        # one-story epic's finale, which is out of scope for a prompt-content
+        # assertion; the acceptance round's dispatches already happened and
+        # were recorded before the merge phase even starts.
+    ]
+    out = _run_driver(epic, rules)
+    assert out["ok"], f"driver crashed: {out.get('error')}"
+    review_calls = [c for c in out["calls"] if c["label"] == "acceptance:product-review:a"]
+    assert len(review_calls) == 1
+    prompt = review_calls[0]["prompt"]
+    assert "Design doc: /repo/.studious/worktrees/epx/a/docs/design-foo.md." in prompt
+    assert '["foo.py"]' in prompt, "product-review prompt does not name the resolved changeset file list"
+
+
+def test_product_review_prompt_falls_back_when_no_design_doc_recorded() -> None:
+    """An empty designDoc (no design phase recorded one, or acceptance runs on a
+    trimmed profile with no design step) reads as a graceful fallback, not a gap
+    the reviewer has to bounce back over."""
+    epic = _one_story_acceptance_epic()
+    rules = [
+        {"match": r"^acceptance:scope:a$", "result": SCOPE_NO_DOC},
+        {"match": r"^acceptance:product-review:a$", "result": {"findings": "looks good"}},
+        {"match": r"^acceptance:walkthrough:a$", "result": {"findings": "no complaints"}},
+        {"match": r"^acceptance:compile:a$", "result": {"verdict": "SHIP", "sha": "a0", "summary": "ship it"}},
+        # merge:a deliberately unmocked — see the same note in
+        # test_product_review_prompt_names_the_resolved_design_doc above.
+    ]
+    out = _run_driver(epic, rules)
+    assert out["ok"], f"driver crashed: {out.get('error')}"
+    review_calls = [c for c in out["calls"] if c["label"] == "acceptance:product-review:a"]
+    assert len(review_calls) == 1
+    prompt = review_calls[0]["prompt"]
+    assert "No design doc is recorded for this story" in prompt
+    assert "Design doc:" not in prompt
+
+
+def test_died_product_review_lane_forces_a_ship_compile_down_to_hold() -> None:
+    """A died product-reviewer (agent() resolves null — the documented shape for
+    a subagent that dies on a terminal API error) must never let the compiler's
+    own SHIP stand: the belt-and-braces override forces HOLD, same posture as
+    auditRound's missing-lane guard forcing NEEDS DISCUSSION."""
+    epic = _one_story_acceptance_epic()
+    rules = [
+        {"match": r"^acceptance:scope:a$", "result": SCOPE_WITH_DOC},
+        {"match": r"^acceptance:product-review:a$", "result": None},
+        {"match": r"^acceptance:walkthrough:a$", "result": {"findings": "no complaints"}},
+        # The compiler never sees this dispatch die — the driver overrides its
+        # own SHIP regardless of what the compiling agent said, proving the
+        # guard doesn't just trust prompt compliance.
+        {"match": r"^acceptance:compile:a$", "result": {"verdict": "SHIP", "sha": "a0", "summary": "looked fine to me"}},
+        # park:a deliberately unmocked, matching SIBLING_LANDS_RULES's own
+        # convention: it falls through to park()'s own try/catch hardening, so
+        # the recorded reason is exactly the summary runGate returned.
+    ]
+    out = _run_driver(epic, rules)
+    assert out["ok"], f"driver crashed: {out.get('error')}"
+    result = out["result"]
+    needs_you = {e["story"]: e for e in result["needsYou"]}
+    assert "epx--a" in needs_you, f"story a should have parked on a forced HOLD: {result}"
+    entry = needs_you["epx--a"]
+    assert entry["gate"] == "acceptance"
+    assert entry["verdict"] == "HOLD"
+    assert "unreviewed lane(s)" in entry["reason"]
+    assert "product-reviewer" in entry["reason"]
+    assert result["landed"] == 0
+
+
+def test_died_scope_check_skips_the_product_review_dispatch_entirely() -> None:
+    """A died/unparseable scope-check must not hand product-reviewer an empty
+    scope — it has no Bash to fall back on, and an empty scope is the exact
+    failure mode issue #89 fixed the interactive command against. The lane is
+    marked UNREVIEWED without ever being dispatched."""
+    epic = _one_story_acceptance_epic()
+    rules = [
+        # acceptance:scope:a deliberately unmocked — falls through to the
+        # mock's UNMOCKED rejection, caught by acceptanceRound's own try/catch
+        # (same fail-closed-to-null posture as ledgerAuditPrior/
+        # resolveRoutingMatchFlags above it in the file).
+        {"match": r"^acceptance:walkthrough:a$", "result": {"findings": "no complaints"}},
+        {"match": r"^acceptance:compile:a$", "result": {"verdict": "SHIP", "sha": "a0", "summary": "looked fine to me"}},
+    ]
+    out = _run_driver(epic, rules)
+    assert out["ok"], f"driver crashed: {out.get('error')}"
+    labels = [c["label"] for c in out["calls"]]
+    assert "acceptance:product-review:a" not in labels, (
+        "product-reviewer must never be dispatched with an unresolved scope"
+    )
+    assert "acceptance:walkthrough:a" in labels, "the walkthrough lane does not depend on the scope-check and must still run"
+
+    result = out["result"]
+    needs_you = {e["story"]: e for e in result["needsYou"]}
+    assert "epx--a" in needs_you
+    assert needs_you["epx--a"]["verdict"] == "HOLD"
+    assert "product-reviewer" in needs_you["epx--a"]["reason"]
+
+
+def test_died_walkthrough_lane_also_forces_hold() -> None:
+    """The missing-lane guard is symmetric — a died walkthrough is exactly as
+    disqualifying as a died product-reviewer, not a lesser-weighted lane."""
+    epic = _one_story_acceptance_epic()
+    rules = [
+        {"match": r"^acceptance:scope:a$", "result": SCOPE_WITH_DOC},
+        {"match": r"^acceptance:product-review:a$", "result": {"findings": "looks good"}},
+        {"match": r"^acceptance:walkthrough:a$", "result": None},
+        {"match": r"^acceptance:compile:a$", "result": {"verdict": "SHIP", "sha": "a0", "summary": "looked fine to me"}},
+    ]
+    out = _run_driver(epic, rules)
+    assert out["ok"], f"driver crashed: {out.get('error')}"
+    result = out["result"]
+    needs_you = {e["story"]: e for e in result["needsYou"]}
+    assert "epx--a" in needs_you
+    entry = needs_you["epx--a"]
+    assert entry["verdict"] == "HOLD"
+    assert "walkthrough" in entry["reason"]
+
+
+def test_missing_lane_guard_never_touches_an_already_non_ship_verdict() -> None:
+    """The override only intercepts an unearned SHIP — a compiler that already
+    judged HOLD on its own (a missing lane was visible in its own prompt) must
+    pass through with its verdict and summary untouched, not get a second,
+    redundant 'unreviewed lane(s)' prefix stapled on top. Deliberately uses
+    HOLD rather than FIX AND RE-CHECK: the latter is acceptance's own retry
+    token, and would route through runGate's fixer loop instead of exercising
+    this guard in isolation."""
+    epic = _one_story_acceptance_epic()
+    rules = [
+        {"match": r"^acceptance:scope:a$", "result": SCOPE_WITH_DOC},
+        {"match": r"^acceptance:product-review:a$", "result": None},
+        {"match": r"^acceptance:walkthrough:a$", "result": {"findings": "no complaints"}},
+        {"match": r"^acceptance:compile:a$", "result": {"verdict": "HOLD", "sha": "a0", "summary": "cannot certify with a dead lane"}},
+    ]
+    out = _run_driver(epic, rules)
+    assert out["ok"], f"driver crashed: {out.get('error')}"
+    result = out["result"]
+    needs_you = {e["story"]: e for e in result["needsYou"]}
+    assert "epx--a" in needs_you
+    entry = needs_you["epx--a"]
+    assert entry["verdict"] == "HOLD"
+    assert entry["reason"] == "cannot certify with a dead lane", (
+        "the guard must not rewrite a verdict/summary the compiler already got right on its own"
+    )
+
+
+def test_compile_prompt_names_the_unreviewed_lane_by_name() -> None:
+    """The compile step itself is told which lane died, in its own prompt — not
+    just the driver's after-the-fact override — so a compiler judging in good
+    faith already knows it cannot certify a SHIP."""
+    epic = _one_story_acceptance_epic()
+    rules = [
+        {"match": r"^acceptance:scope:a$", "result": SCOPE_WITH_DOC},
+        {"match": r"^acceptance:product-review:a$", "result": None},
+        {"match": r"^acceptance:walkthrough:a$", "result": {"findings": "no complaints"}},
+        {"match": r"^acceptance:compile:a$", "result": {"verdict": "HOLD", "sha": "a0", "summary": "cannot certify with a dead lane"}},
+    ]
+    out = _run_driver(epic, rules)
+    assert out["ok"], f"driver crashed: {out.get('error')}"
+    compile_calls = [c for c in out["calls"] if c["label"] == "acceptance:compile:a"]
+    assert len(compile_calls) == 1
+    prompt = compile_calls[0]["prompt"]
+    assert "UNREVIEWED" in prompt
+    assert "product-reviewer" in prompt
+
+
+# ---------- structural: the model/effort pins are actually wired in ----------
+
+
+def test_scope_check_is_pinned_to_haiku_low_effort() -> None:
+    """The mechanical scope-check dispatch follows this file's own established
+    posture for fact-checks (ledgerAuditPrior, resolveRoutingMatchFlags): haiku,
+    low effort — never the session model."""
+    source = DRIVER.read_text()
+    anchor = "acceptanceScopeCheckPrompt(dir, base, workSlug(story))"
+    assert anchor in source, "acceptanceRound no longer dispatches the scope-check as documented"
+    start = source.index(anchor)
+    # The dispatch call wraps onto a second line for its options object — take
+    # both lines (through the next line's own newline) rather than just the first.
+    first_nl = source.index("\n", start)
+    second_nl = source.index("\n", first_nl + 1)
+    window = source[start:second_nl]
+    assert "model: 'haiku'" in window and "effort: 'low'" in window, (
+        f"scope-check dispatch is not pinned to haiku/low effort: {window}"
+    )
+
+
+def test_product_review_dispatch_uses_the_registered_agent_type() -> None:
+    """Confirms the fan-out actually dispatches the real, registered
+    product-reviewer subagent — not a generic agent told to imitate it, which
+    was the old single-dispatch shape's whole limitation."""
+    source = DRIVER.read_text()
+    assert "agentType: 'studious:product-reviewer'" in source

--- a/tests/python/test_audit_first_round_routing.py
+++ b/tests/python/test_audit_first_round_routing.py
@@ -518,7 +518,10 @@ def test_finale_routing_mirrors_the_story_level_mechanism() -> None:
     }
     always_run = ["security-auditor", "code-auditor", "doc-auditor", "architecture-auditor", "test-auditor", "operability-auditor"]
     rules = [
-        {"match": r"^acceptance:a$", "result": {"verdict": "SHIP", "sha": "a0", "summary": "ok"}},
+        {"match": r"^acceptance:scope:a$", "result": {"findings": json.dumps({"files": ["a.py"], "designDoc": ""})}},
+        {"match": r"^acceptance:product-review:a$", "result": {"findings": "looks good"}},
+        {"match": r"^acceptance:walkthrough:a$", "result": {"findings": "looks good"}},
+        {"match": r"^acceptance:compile:a$", "result": {"verdict": "SHIP", "sha": "a0", "summary": "ok"}},
         {"match": r"^merge:a$", "result": {"merged": True, "sha": "a1", "notes": "clean"}},
         {"match": r"^finale:routing-scope$", "result": {"findings": json.dumps({"infraMatch": False, "frontendMatch": False, "depMatch": False, "promptMatch": False})}},
         *[{"match": rf"^finale:{name}$", "result": {"findings": "clean"}} for name in always_run],

--- a/tests/python/test_contract_injection.py
+++ b/tests/python/test_contract_injection.py
@@ -86,8 +86,9 @@ OLD_POINTER_MARKER = "Shared contract: before you begin"
 CONTRACT_ARG_SUBSTRING = "contract: CONTRACT"
 # auditRound (auditor dispatch), auditRound (fix-delta pass, #130, narrowed rounds
 # only), finaleAuditRound (auditor dispatch), finaleAuditRound (fix-delta pass, #130),
-# premortem dispatch.
-EXPECTED_CONTRACT_ARG_COUNT = 5
+# premortem dispatch, acceptanceRound (product-review dispatch, perf item 10),
+# acceptanceRound (walkthrough dispatch, perf item 10).
+EXPECTED_CONTRACT_ARG_COUNT = 7
 
 # The driver's pure, explicitly-parameterized prompt-assembly functions (see
 # workflows/epic-driver.js). Extracted verbatim below and executed by a plain Node

--- a/tests/python/test_driver_crash_hardening.py
+++ b/tests/python/test_driver_crash_hardening.py
@@ -294,7 +294,13 @@ def _two_story_epic(story_a_gates: list[str]) -> dict:
 
 
 SIBLING_LANDS_RULES = [
-    {"match": r"^acceptance:b$", "result": {"verdict": "SHIP", "sha": "b1", "summary": "ok"}},
+    # Story b's acceptance gate is the story-level fan-out (perf item 10): a
+    # mechanical scope-check, then product-review + walkthrough, then a compile
+    # step — four dispatches replacing what was one `acceptance:b` label before.
+    {"match": r"^acceptance:scope:b$", "result": {"findings": json.dumps({"files": ["b.py"], "designDoc": ""})}},
+    {"match": r"^acceptance:product-review:b$", "result": {"findings": "looks good"}},
+    {"match": r"^acceptance:walkthrough:b$", "result": {"findings": "looks good"}},
+    {"match": r"^acceptance:compile:b$", "result": {"verdict": "SHIP", "sha": "b1", "summary": "ok"}},
     {"match": r"^merge:b$", "result": {"merged": True, "sha": "b2", "notes": "clean"}},
     # `park:a` is deliberately left unmocked in the three crash scenarios below:
     # it falls through to the mock's "UNMOCKED" rejection, which exercises
@@ -332,7 +338,14 @@ def test_worker_throw_parks_that_story_blocked_and_sibling_lands() -> None:
 def test_gate_throw_parks_that_story_blocked_and_sibling_lands() -> None:
     epic = _two_story_epic(story_a_gates=["acceptance"])
     rules = [
-        {"match": r"^acceptance:a$", "throw": "gate agent exploded"},
+        # The compile step is the one acceptance-round dispatch left unwrapped by
+        # try/catch or parallel()'s per-lane fault isolation (matching auditFanIn's
+        # own precedent) — a throw here is the equivalent of the old single
+        # `acceptance:a` dispatch throwing.
+        {"match": r"^acceptance:scope:a$", "result": {"findings": json.dumps({"files": ["a.py"], "designDoc": ""})}},
+        {"match": r"^acceptance:product-review:a$", "result": {"findings": "looks good"}},
+        {"match": r"^acceptance:walkthrough:a$", "result": {"findings": "looks good"}},
+        {"match": r"^acceptance:compile:a$", "throw": "gate agent exploded"},
         *SIBLING_LANDS_RULES,
     ]
     out = _run_driver(epic, rules)
@@ -355,7 +368,10 @@ def test_gate_throw_parks_that_story_blocked_and_sibling_lands() -> None:
 def test_merge_throw_parks_that_story_blocked_and_sibling_lands() -> None:
     epic = _two_story_epic(story_a_gates=["acceptance"])
     rules = [
-        {"match": r"^acceptance:a$", "result": {"verdict": "SHIP", "sha": "a0", "summary": "ok"}},
+        {"match": r"^acceptance:scope:a$", "result": {"findings": json.dumps({"files": ["a.py"], "designDoc": ""})}},
+        {"match": r"^acceptance:product-review:a$", "result": {"findings": "looks good"}},
+        {"match": r"^acceptance:walkthrough:a$", "result": {"findings": "looks good"}},
+        {"match": r"^acceptance:compile:a$", "result": {"verdict": "SHIP", "sha": "a0", "summary": "ok"}},
         {"match": r"^merge:a$", "throw": "merge agent exploded"},
         *SIBLING_LANDS_RULES,
     ]
@@ -389,7 +405,10 @@ def _one_story_epic_ready_for_finale() -> dict:
 
 
 LAND_STORY_A_RULES = [
-    {"match": r"^acceptance:a$", "result": {"verdict": "SHIP", "sha": "a0", "summary": "ok"}},
+    {"match": r"^acceptance:scope:a$", "result": {"findings": json.dumps({"files": ["a.py"], "designDoc": ""})}},
+    {"match": r"^acceptance:product-review:a$", "result": {"findings": "looks good"}},
+    {"match": r"^acceptance:walkthrough:a$", "result": {"findings": "looks good"}},
+    {"match": r"^acceptance:compile:a$", "result": {"verdict": "SHIP", "sha": "a0", "summary": "ok"}},
     {"match": r"^merge:a$", "result": {"merged": True, "sha": "a1", "notes": "clean"}},
 ]
 FINALE_AUDITORS_PASS = [
@@ -456,8 +475,7 @@ def test_needs_you_is_empty_on_an_unremarkable_two_story_run() -> None:
     """
     epic = _two_story_epic(story_a_gates=["acceptance"])
     rules = [
-        {"match": r"^acceptance:a$", "result": {"verdict": "SHIP", "sha": "a0", "summary": "ok"}},
-        {"match": r"^merge:a$", "result": {"merged": True, "sha": "a1", "notes": "clean"}},
+        *LAND_STORY_A_RULES,
         *SIBLING_LANDS_RULES,
         *FINALE_AUDITORS_PASS,
         {"match": r"^finale:audit-compile$", "result": {"verdict": "PASS", "sha": "f1", "summary": "clean"}},

--- a/tests/python/test_scheduler_fixes.py
+++ b/tests/python/test_scheduler_fixes.py
@@ -40,7 +40,8 @@ DRIVER = REPO_ROOT / "workflows" / "epic-driver.js"
 # The four gate-ledger verbs whose --slug argument must carry the epic-qualified
 # slug. epic-story-set is deliberately excluded: it takes its own --epic argument
 # and is out of scope for this story (see the design doc's "Out of scope").
-WORK_VERB_SLUG_CALL_COUNT = 6
+# Perf item 10 added acceptanceFanIn's own work-log call site, bumping this from 6.
+WORK_VERB_SLUG_CALL_COUNT = 7
 EPIC_STORY_SET_BARE_SLUG_COUNT = 4
 DISPLAY_WORK_SLUG_COUNT = 6
 

--- a/workflows/epic-driver.js
+++ b/workflows/epic-driver.js
@@ -74,8 +74,12 @@ const AUDITORS = [
 // missing, rather than silently reverting to the old pointer sentence or splicing an
 // empty string into an auditor's prompt — a directly-dispatched auditor, security
 // included, never runs unguarded on the fully-automatic epic path.
-// The design-review/acceptance gates need no equivalent: they dispatch a single agent
-// that reads the gate command and runs its workflow, so the command does the injecting.
+// The design-review gate needs no equivalent yet: it dispatches a single agent that
+// reads the gate command and runs its workflow, so the command does the injecting.
+// The acceptance gate's story-level fan-out (perf item 10) stamps CONTRACT directly
+// into its own product-reviewer/walkthrough dispatches below, same as the auditors
+// above — the finale acceptance dispatch is a deliberately separate follow-up, not
+// yet fanned out, and still self-injects the same way design-review does.
 const CONTRACT = input.contract
 
 // Fails closed at the exact dispatch that needed it — called from inside each of the
@@ -193,6 +197,115 @@ function premortemDispatchPrompt(fields) {
   const { repoRoot: repoRootVal, premortemPath, slug: slugVal, epicWorktreePath, contract, diff } =
     requireFields(fields, ['repoRoot', 'premortemPath', 'slug', 'epicWorktreePath'], 'premortemDispatchPrompt')
   return `Verify the epic pre-mortem register at ${repoRootVal}/${premortemPath} against the epic branch epic/${slugVal} (worktree ${epicWorktreePath}), per your role. Report REALIZED / NOT REALIZED / CAN'T VERIFY per item.${diffBlock(diff)}\n\n${requireContract(contract)}`
+}
+
+// Perf item 10 (2026-07-20): fans out the acceptance gate the way auditRound above
+// already fans out audit — the interactive gate-acceptance.md dispatches
+// @agent-product-reviewer for Part 1 and self-performs the Part 3 walkthrough
+// serially inside one agent (case study: issue #142, a single acceptance dispatch
+// that took 117 minutes); this driver dispatches both concurrently instead, using
+// the same registered product-reviewer agentType the interactive command reads
+// from ${CLAUDE_PLUGIN_ROOT}. Part 2 (pre-mortem verification) is deliberately
+// never part of this fan-out: no per-story register exists to verify — the epic's
+// cross-story register is verified once, at the finale (see auditFanIn's own
+// comment above). The finale acceptance dispatch is a separate, deliberately
+// unfanned-out follow-up (still the single self-performing dispatch below): its
+// scope is the epic goal plus every story's acceptance criteria, not one design
+// doc, so it doesn't reuse acceptanceScopeCheckPrompt's design-doc resolution
+// unchanged the way finaleAuditDispatchPrompt reuses auditDispatchPrompt's shape.
+
+// product-reviewer has no Bash (agents/product-reviewer.md: tools: Read, Glob,
+// Grep) and cannot compute the diff or find its own design doc —
+// commands/gate-acceptance.md's Part 0 resolves both before dispatching for
+// exactly this reason (issue #89); this mechanical, judgment-free dispatch does
+// the same resolution so the driver can hand the real agentType the same explicit
+// scope the interactive command does. Same posture as every other mechanical
+// fact-check in this file: pinned to haiku, fails closed to null (no files
+// resolved) on a died or unparseable dispatch — acceptanceRound below treats that
+// as an UNREVIEWED product-reviewer lane, never a silent empty scope handed to an
+// agent with no Bash to fall back on.
+function acceptanceScopeCheckPrompt(dir, base, workSlugVal) {
+  return `This is a mechanical fact-check, not a judgment call — report exactly what the commands show, never interpret or editorialize. From ${dir}: compute the merge-base with ${base} (git merge-base ${base} HEAD) and run git diff --name-only <that merge-base> HEAD to get the changeset file list. Then run gate-ledger work-get --slug "${workSlugVal}" and read its .designDoc field (absent or empty means no design doc is recorded for this story — report that, do not search further). Return your findings as EXACTLY one line of compact JSON, nothing else: {"files":[...],"designDoc":"<path relative to the worktree root, or empty string if none recorded>"}`
+}
+
+function acceptanceProductReviewPrompt(fields) {
+  const { ctxBlock, note, storyWorktreePath, files, designDoc, contract } =
+    requireFields(fields, ['ctxBlock', 'note', 'storyWorktreePath', 'files', 'designDoc', 'contract'], 'acceptanceProductReviewPrompt')
+  const docLine = designDoc
+    ? `Design doc: ${storyWorktreePath}/${designDoc}.`
+    : `No design doc is recorded for this story — review the implementation against PRODUCT.md and the story's acceptance criteria above instead.`
+  return `${ctxBlock}\n\n${note} This is a post-implementation product acceptance review. Review the implementation in ${storyWorktreePath}. Changeset file list, already resolved — you have no Bash, so treat this as your scope; never bounce back for scope or improvise it from Glob/Grep: ${JSON.stringify(files)}. ${docLine} Read PRODUCT.md at ${storyWorktreePath}/PRODUCT.md.\n\n${requireContract(contract)}`
+}
+
+function acceptanceWalkthroughPrompt(fields) {
+  const { ctxBlock, note, storyWorktreePath, base, contract } =
+    requireFields(fields, ['ctxBlock', 'note', 'storyWorktreePath', 'base', 'contract'], 'acceptanceWalkthroughPrompt')
+  return `${ctxBlock}\n\n${note} Walk through every user-facing change in the story worktree ${storyWorktreePath} (diff base ${base}) yourself, using @agent-product-reviewer's "When reviewing an IMPLEMENTATION" checklist (agents/product-reviewer.md from the plugin root) as the lens — a separate reviewer already ran that checklist as a subagent in parallel with you; don't re-derive the questions, just apply them directly as you walk the branch. Write concisely: 1-2 sentences per checklist item, bullets when listing multiple issues, no preamble.\n\nClose with two gate-specific questions the checklist doesn't ask:\n\n- One complaint — what's the single thing a real user would complain about if we shipped this as-is? Be specific. There's always something.\n- Operability — does the branch deliver what the design doc's Operational readiness section committed to (the migration and its rollback, the rollout strategy, the working/failing signals)? If the section said "N/A — no operational surface", confirm that still holds. If there's no design doc for this story, or it predates the Operational readiness section, note that and assess operability from the changeset directly.\n\nReturn your findings as structured text.\n\n${requireContract(contract)}`
+}
+
+function acceptanceFanIn(story, productBlock, walkthroughBlock, base, dir, nextPhase) {
+  return `You are compiling Studious's acceptance gate verdict for this story. Read commands/gate-acceptance.md's Part 4 from the plugin root (gate-ledger is on PATH; plugin root is dirname of it, up one) and apply ITS verdict rubric to the two reports below — you judge compilation only, you do not re-review. A lane marked UNREVIEWED (its agent died, or the mechanical scope-check that resolves its file list and design doc died or returned unparseable output) means you cannot certify a SHIP: the verdict is at best HOLD.\n\nChangeset: ${dir}, diff base ${base}.\n\nProduct review:\n${productBlock}\n\nImplementation walkthrough:\n${walkthroughBlock}\n\nRecord the verdict from inside ${dir}: cd "${dir}" && gate-ledger record --gate acceptance --verdict "<TOKEN>" && gate-ledger work-log --slug "${workSlug(story)}" --step acceptance --outcome "<TOKEN>" --phase "${nextPhase}"\n\nReturn: verdict (SHIP | FIX AND RE-CHECK | HOLD), sha, summary (for non-SHIP verdicts, the findings a fixer needs — specific enough to go directly into the engineering chain as fix tasks).`
+}
+
+// Orchestrates the three-dispatch fan-out above: a mechanical scope-check, then
+// product-review and the walkthrough concurrently (parallel(), not Promise.all, so
+// ONE dying degrades that lane to UNREVIEWED rather than crashing the whole round —
+// the same fault-isolation auditRound's own lane fan-out gets), then a compile step
+// that maps both into a single verdict. The compile dispatch is deliberately NOT
+// wrapped in try/catch, matching auditFanIn's own precedent: a died compiler
+// crashes the story via runStory's outer catch, exactly like a died gate agent
+// always has.
+async function acceptanceRound(story, note, nextPhase) {
+  const dir = storyWorktree(story)
+  const base = `epic/${slug}`
+  let scope = null
+  try {
+    scope = await agent(acceptanceScopeCheckPrompt(dir, base, workSlug(story)),
+      { label: `acceptance:scope:${story}`, phase: `story:${story}`, schema: REPORT, model: 'haiku', effort: 'low' })
+  } catch {
+    scope = null
+  }
+  let parsedScope = null
+  if (scope && scope.findings) {
+    try { parsedScope = JSON.parse(scope.findings) } catch { parsedScope = null }
+  }
+  const files = parsedScope && Array.isArray(parsedScope.files) ? parsedScope.files : null
+  const designDoc = parsedScope ? parsedScope.designDoc || '' : ''
+
+  const [productReport, walkthroughReport] = await parallel([
+    () => files === null
+      ? Promise.resolve(null)
+      : agent(acceptanceProductReviewPrompt({ ctxBlock: ctx(story), note, storyWorktreePath: dir, files, designDoc, contract: CONTRACT }),
+          { agentType: 'studious:product-reviewer', label: `acceptance:product-review:${story}`, phase: `story:${story}`, schema: REPORT }),
+    () => agent(acceptanceWalkthroughPrompt({ ctxBlock: ctx(story), note, storyWorktreePath: dir, base, contract: CONTRACT }),
+        { label: `acceptance:walkthrough:${story}`, phase: `story:${story}`, schema: REPORT }),
+  ])
+
+  const missing = []
+  let productBlock
+  if (productReport) {
+    productBlock = `--- product-reviewer ---\n${productReport.findings}`
+  } else {
+    missing.push('product-reviewer')
+    productBlock = '--- product-reviewer --- (AGENT DIED, or the scope-check died/returned unparseable output — no report; this lane is UNREVIEWED)'
+  }
+  let walkthroughBlock
+  if (walkthroughReport) {
+    walkthroughBlock = `--- walkthrough ---\n${walkthroughReport.findings}`
+  } else {
+    missing.push('walkthrough')
+    walkthroughBlock = '--- walkthrough --- (AGENT DIED — no report; this lane is UNREVIEWED)'
+  }
+
+  let result = await agent(acceptanceFanIn(story, productBlock, walkthroughBlock, base, dir, nextPhase),
+    { label: `acceptance:compile:${story}`, phase: `story:${story}`, schema: GATE_RESULT, model: 'opus' })
+  // Belt and braces, same posture as auditRound's own missing-lane guard: an
+  // UNREVIEWED lane can never compile into an earned SHIP, whatever the compiler
+  // said — never trust prompt compliance alone for a fail-closed guarantee.
+  if (result && missing.length && result.verdict === 'SHIP') {
+    result = { ...result, verdict: 'HOLD', summary: `unreviewed lane(s) — agent died: ${missing.join(', ')}. ${result.summary}` }
+  }
+  return result
 }
 
 const GATE_RESULT = {
@@ -652,7 +765,9 @@ async function runGate(story, gate, nextPhase) {
   }
   let result = gate === 'audit'
     ? await auditRound(story, initialNote, nextPhase, priorAuditResult, preMatchFlags)
-    : await agent(gatePrompt(story, gate, nextPhase), { label: `${gate}:${story}`, phase: `story:${story}`, schema: GATE_RESULT, model: 'opus' })
+    : gate === 'acceptance'
+      ? await acceptanceRound(story, initialNote, nextPhase)
+      : await agent(gatePrompt(story, gate, nextPhase), { label: `${gate}:${story}`, phase: `story:${story}`, schema: GATE_RESULT, model: 'opus' })
   if (!result) return { verdict: 'NEEDS DISCUSSION', summary: 'gate agent died; treating as judgment verdict', sha: '' }
 
   while (result.verdict === GATES[gate].retry && attempts < MAX_FIX_CYCLES) {
@@ -669,7 +784,9 @@ async function runGate(story, gate, nextPhase) {
     // never needs to round-trip through gate-ledger to decide scope.
     result = gate === 'audit'
       ? await auditRound(story, 'Re-audit with fresh eyes — a fix landed since the last audit.', nextPhase, result)
-      : await agent(gatePrompt(story, gate, nextPhase), { label: `${gate}:retry${attempts}:${story}`, phase: `story:${story}`, schema: GATE_RESULT, model: 'opus' })
+      : gate === 'acceptance'
+        ? await acceptanceRound(story, 'Re-check with fresh eyes — a fix landed since the last check.', nextPhase)
+        : await agent(gatePrompt(story, gate, nextPhase), { label: `${gate}:retry${attempts}:${story}`, phase: `story:${story}`, schema: GATE_RESULT, model: 'opus' })
     if (!result) return { verdict: 'NEEDS DISCUSSION', summary: 'gate agent died on re-run', sha: '' }
   }
   return result


### PR DESCRIPTION
## Summary

Two related fixes from the 2026-07-17 performance review (`~/Projects/brainstorming/studious-jig-performance-review-2026-07-17.md`, item 10) and issue #142's 117-minute-acceptance-gate case study.

- **Bound gate-acceptance's precedent-diff search (#142, finding 1).** Part 4's verdict rubric gave no guidance on calibrating severity against precedent, so an agent free-styled a "does this match a prior fix-cycle finding" check by reading full `git show` diffs of two prior commits — 96 of #142's 117 minutes. Precedent lookups now try `git log --oneline --grep` (commit messages) first, falling back to a full diff read only when the summary doesn't resolve it.
- **Fan out the story-level acceptance gate (item 10).** `epic-driver.js` dispatched one agent that read `commands/gate-acceptance.md` and self-performed every role serially — the shape behind #142's slow gate. Mirrors `auditRound`'s already-proven pattern: a haiku-pinned mechanical scope-check (product-reviewer has no Bash and can't compute the diff or find its own design doc, #89), then the real `product-reviewer` agentType and an implementation walkthrough dispatched concurrently, then a compile step mapping both into one verdict. A missing lane (died agent, or an unresolved scope so product-reviewer is never dispatched with nothing to review) forces an otherwise-SHIP compile down to HOLD, mirroring `auditRound`'s own missing-lane guard.

## Deliberately not included

- **#142 finding 2** (no visibility into the run's silent dispatch retry — the other ~75 minutes) is a separate, larger change to `gate-ledger`/`work-log` and stays open.
- **Finale-level acceptance** and **design-review** are unchanged — both are more complex shapes (the finale has no single design doc to scope against; design-review's pre-mortem enumeration has a different sequential dependency) and are clean follow-ups, not part of this PR.

## Test plan

- [x] `uv run --no-project --with pytest pytest tests/python -q` — 236 passed (includes a new `test_acceptance_fanout.py` covering the fan-out's dispatch shape, prompt content, and the missing-lane fail-closed guarantee end-to-end)
- [x] `node --check workflows/epic-driver.js`
- [x] `npx -y eslint@10.6.0 --report-unused-disable-directives workflows/` — clean
- [x] `bash tests/test_workflows_lint.sh` — all passed
- [x] `bash tests/test_evidence_capture.sh` — all passed
- [x] `bash tests/test_gate_ledger.sh` — all passed
- [x] `npx -y markdownlint-cli2` — 0 issues
- [x] `python3 scripts/check_references.py` — clean
- [x] `python3 scripts/validate_plugin.py` — clean