### PR TITLE
feat: wire jig as a first-class executor across the build seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Every command Studious ships, for quick reference:
 ## Works well with
 
 - [Superpowers](https://github.com/obra/superpowers): an optional executor for the build step — brainstorming, planning, TDD, debugging. Studious owns the gates and the worker contract; any executor that satisfies the contract works, Superpowers included.
+- [jig](https://github.com/jacquardlabs/jig): a purpose-built executor for the build step — `/design`, `/plan`, `/build`, `/finish` satisfy the worker contract directly and report back into the same flow state.
 - GitHub Issues: `/backlog-priorities` and `/backlog-hygiene` work with your tracker via the `gh` CLI.
 
 ## Contributing

--- a/commands/work-on.md
+++ b/commands/work-on.md
@@ -51,6 +51,7 @@ The work file's `phase` names the next piece, but verify it against evidence bef
 - **Design doc** — the `designDoc` path in the work file, else discover a candidate the way `/gate-design-review` does. When found, record it: `work-set --design-doc "<path>"`.
 - **Pre-mortem register** — `docs/studious/premortems/<doc-slug>.md`, where `<doc-slug>` is the recorded `designDoc`'s filename without its extension — `/gate-design-review` names the register after the design doc, not the feature slug, so don't reuse this flow's `<slug>` here. A register found at that path with a `Branch:` header matching the current branch is evidence design-review already returned **PROCEED TO PLAN**.
 - **Build progress** — implementation commits since the design-review sha. If the phase says `build` and there are none, the build piece isn't done: say so rather than advancing (re-offering the handoff is fine).
+- **Executor-reported build status** — an executor satisfying `reference/worker-contract.md` may log its own terminal status for the build piece without setting `--phase` itself (phase judgment stays this command's call). Read it with `gate-ledger work-get --slug "<slug>"`'s `.history`, most recent `step: "build"` entry. Trust it only when its `sha` is still HEAD — commits since mean the report is stale and the commit-evidence check above wins instead. If current: `BUILT` corroborates the commit check; `PAUSED` — stay at phase `build`, and say so using the reported status rather than a generic "no commits yet"; `ESCALATED` — regress phase to `design` and surface the reported reason, the same shape as design-review's `RETHINK` → `design` below.
 
 ## Run exactly one piece
 
@@ -76,6 +77,7 @@ Studious doesn't author design docs (`reference/design-doc-contract.md` — auth
 
 - Hand over the decide verdict, the (possibly scoped-down) title, and the contract's required sections; point at `templates/design-doc.md` as the scaffold.
 - If Superpowers is installed, note that its brainstorming and planning workflow produces a doc satisfying the contract; otherwise any hand-written spec does.
+- If jig is installed, note that its `/design` workflow (batch interview → drafted doc → viva sign-off) produces a doc satisfying the contract; otherwise any hand-written spec does.
 - Do not draft the doc yourself. It may well get written right here in the session — that work belongs to the user and their workflow, not to this command.
 
 Log the handoff: `work-log --step design --outcome HANDED-OFF` (phase stays `design`; the evidence check advances the flow once the doc exists).
@@ -97,6 +99,7 @@ Studious steps back here (README: build with your own workflow). Hand over the w
 - The design doc path, the pre-mortem register path (its items are what `/gate-audit` and `/gate-acceptance` verify at the end), the scoped title, and the source issue if any.
 - Once a feature branch exists, record it — the gate ledger is per-branch, so later pieces need it: `work-set --branch "<branch>"`.
 - If Superpowers is installed, its plan/execute workflow picks up from the design doc; otherwise the user builds however they like.
+- If jig is installed, its `/plan` + `/build` workflow picks up from the design doc and reports `BUILT | PAUSED | ESCALATED` back into this work file (see "Find the next piece — evidence first" below) — the next `/work-on` invocation resumes from that without asking.
 
 Log `work-log --step build --outcome HANDED-OFF`. Phase stays `build`; the evidence check advances it when implementation commits exist.
 

--- a/docs/superpowers/specs/2026-07-20-jig-executor-seam-design.md
+++ b/docs/superpowers/specs/2026-07-20-jig-executor-seam-design.md
@@ -1,0 +1,171 @@
+# Design: Wire jig as a first-class executor across the build seam
+
+**Date:** 2026-07-20
+**Status:** Design, pre-implementation
+**Story:** jig-executor-seam
+**Source:** [#143](https://github.com/jacquardlabs/studious/issues/143)
+
+## Problem & persona
+
+The persona is PRODUCT.md's primary user: a developer building features with Claude
+Code who wants product judgment and quality gates woven into the build. `/work-on`'s
+build handoff (`commands/work-on.md:95`) hands the how-layer away with "build with your
+own workflow" and names Superpowers as the one example. jig ships `/design`, `/plan`,
+`/build`, `/finish` — built to fill exactly that slot — but `grep -ri jig commands/
+agents/ skills/ reference/` returns zero hits. The arrow is one-directional today: jig
+already detects studious and hands off to `/gate-design-review` / `/gate-audit`,
+degrading explicitly when studious is absent (`skills/coach/SKILL.md`, `skills/design/
+SKILL.md`); studious never hands in. A user with both installed gets no signal from
+studious that jig exists, so jig goes unused even when present — the live pain behind
+this issue.
+
+The job-to-be-done: at the two points `/work-on` steps back (design, build), tell the
+user jig satisfies the contract, exactly as it already does for Superpowers; and when
+jig is what actually built the story, get its terminal status back into `/work-on`'s
+flow state without asking the user to relay it by hand.
+
+## Proposed design
+
+Two repos, two PRs. No `bin/gate-ledger` changes in either — `work-log`'s `--outcome`
+is already free text, and every call already appends to a `.history` array carrying
+`{step, outcome, sha, at}`, which is everything the read side below needs.
+
+### 1 · studious — recommend jig at the two handoffs (`commands/work-on.md`)
+
+Add one bullet at piece 2 (design, after the existing Superpowers bullet at line 78)
+and one at piece 4 (build, after line 99), same tone and placement as the existing
+Superpowers mentions, additive only:
+
+- **Design handoff:** "If jig is installed, note that its `/design` workflow (batch
+  interview → drafted doc → viva sign-off) produces a doc satisfying the contract;
+  otherwise any hand-written spec does."
+- **Build handoff:** "If jig is installed, its `/plan` + `/build` workflow picks up
+  from the design doc and reports `BUILT | PAUSED | ESCALATED` back into this work
+  file (see 'Find the next piece — evidence first') — the next `/work-on` invocation
+  resumes from that without asking; otherwise the user builds however they like."
+
+No new detection mechanism: the existing Superpowers bullet has never had a mechanical
+`command -v` check behind it either — it's a prose recommendation the model makes from
+its own context, and jig gets the identical treatment. Superpowers detection is
+unaffected.
+
+### 2 · studious — read jig's self-reported build status (`commands/work-on.md`)
+
+New bullet in "Find the next piece — evidence first," after the existing "Build
+progress" bullet:
+
+> **Executor-reported build status** — an executor satisfying
+> `reference/worker-contract.md` may log its own terminal status for the build piece
+> without setting `--phase` itself (phase judgment stays this command's call). Read it
+> with `gate-ledger work-get --slug "<slug>"`'s `.history`, most recent `step: "build"`
+> entry. Trust it only when its `sha` is still HEAD — commits since mean the report is
+> stale and the commit-evidence check above wins instead (the same sha-anchoring
+> already used for gate verdicts elsewhere in this section). If current: `BUILT`
+> corroborates the commit check; `PAUSED` — stay at phase `build`, and say so using the
+> reported status rather than a generic "no commits yet"; `ESCALATED` — regress phase
+> to `design` and surface the reported reason, the same shape as design-review's
+> `RETHINK` → `design` above, mirroring jig's own documented "`/build` ESCALATED routes
+> back to `/design`."
+
+### 3 · studious — publish the reporting contract (`reference/worker-contract.md`)
+
+- Line 8-10 gets jig named alongside Superpowers: "a worker MAY use Superpowers'
+  plan/execute workflow when it's installed, or jig's `/plan` + `/build` workflow, but
+  a worker without either must still satisfy every row below."
+- New short section between "What a worker must return" and "Boundaries":
+
+  > ## Status reporting
+  >
+  > A worker MAY additionally report its own terminal status for the phase it just
+  > finished. First resolve which work file is this feature's the same way `/work-on`
+  > does it: `gate-ledger work-list`, match the current branch's row. Found → `gate-ledger
+  > work-log --slug "<that-slug>" --step <phase> --outcome "<status>"`, omitting
+  > `--phase` (the phase judgment stays `/work-on`'s call). No match, or `gate-ledger`
+  > not on `PATH` at all → skip silently; this is best-effort corroboration, not a
+  > required part of the contract. This is a first-person status report, not a gate
+  > verdict or a self-assessment against a rubric, and does not conflict with "workers
+  > never... record a verdict" above — jig's `/build` reports `BUILT | PAUSED |
+  > ESCALATED` this way when `gate-ledger` is present.
+
+`commands/work-through.md` needs no change — it already refers to workers and
+`reference/worker-contract.md` generically, with no Superpowers-specific mention to
+mirror.
+
+### 4 · studious — README
+
+One line added to "Works well with" (line 171-172 today), parallel to the existing
+Superpowers entry:
+
+> - [jig](https://github.com/jacquardlabs/jig): a purpose-built executor for the build
+>   step — `/design`, `/plan`, `/build`, `/finish` satisfy the worker contract directly
+>   and report back into the same flow state.
+
+### 5 · jig (separate repo, separate PR) — call the contract from `/build`
+
+Only `skills/build/SKILL.md` changes; `/finish`'s verdict vocabulary (`MERGE | PR |
+KEEP | DISCARD`) doesn't map onto any `/work-on` piece, so it's out of scope (narrower
+than this issue's original framing, which over-included it).
+
+Right before `/build` reports its final verdict to the user, guarded exactly the way
+jig already guards its own `command -v gate-ledger` checks elsewhere (`skills/coach/
+SKILL.md`, `skills/design/SKILL.md`):
+
+1. `command -v gate-ledger` — not found → skip silently, report the verdict as today.
+2. Found → `gate-ledger work-list`, match a row whose branch column equals the current
+   branch. No match → skip silently.
+3. Match → `gate-ledger work-log --slug "<slug>" --step build --outcome "<BUILT|PAUSED|ESCALATED>"`
+   (no `--phase`), then report the verdict as today.
+
+## Why this shape
+
+- **Recording originates where the fact is known.** Only jig's own `/build` session
+  knows its verdict at the moment it happens; `/work-on` runs later, in a different
+  turn. Asking `/work-on` to solicit the verdict from the user would satisfy the letter
+  of "resumes... instead of asking" by not literally asking about the *step*, but it
+  would still require the user to relay jig's output by hand — the issue's stated goal
+  is to remove that relay entirely.
+- **Phase judgment stays one place.** jig reports status, never phase. `/work-on`
+  already owns every other phase transition in the flow (including backward ones —
+  design-review's `RETHINK` → `design` is existing precedent); an executor setting its
+  own `--phase` would duplicate that judgment in two repos and let them drift.
+  ESCALATED regressing to `design` is new precedent this design adds, but it's the same
+  shape as the existing RETHINK case, not a novel one.
+- **No new gate-ledger surface.** Free-text `--outcome` and the existing `.history`
+  array already carry everything both sides need — the smallest change that closes the
+  loop, per this project's own bias against unnecessary schema growth.
+- **Branch-match discovery, not a threaded slug.** jig could instead be handed the
+  work-file slug explicitly in `/work-on`'s build-handoff bullet. Branch-match is
+  preferred because `/work-on` already uses the identical convention to resolve "do the
+  next piece" for an empty `$ARGUMENTS`, so jig reuses an existing idiom instead of
+  studious inventing a new one-off handoff field, and it keeps working even if a jig
+  session is invoked directly (without a fresh `/work-on` build handoff having just
+  run).
+
+## Out of scope
+
+- Any change to `#150`'s repo-merge proposal — this design assumes the current
+  two-repo topology and doesn't depend on that decision either way.
+- jig's own `/design` verdict vocabulary (`DESIGNED | NEEDS RESEARCH | REVISED`) is not
+  recorded back — the issue's scope names only the build step's verdicts, and the
+  design step's evidence check (does the doc file exist) already has what it needs.
+- `bin/gate-ledger` code changes — none needed (see above).
+- jig's `/finish` — its verdict vocabulary doesn't correspond to any `/work-on` piece.
+
+## Testing
+
+Doc/prompt-only change on both sides; no new executable code path. Verification is
+`scripts/check_references.py` and `markdownlint-cli2` on the studious side (existing CI
+lanes, unaffected file types, both pass clean), jig's own `pytest tests/` (418 passed,
+1 skipped — untouched by this change's scope), and a manual round-trip walkthrough of
+the mechanism the design depends on, run before this was called done:
+
+`work-set --branch` from a main checkout, then from a **separate linked git worktree**
+on that branch (`git worktree add`, the same primitive jig's own `worktree-setup`
+script uses for a `/build` session) — `gate-ledger work-list` found the row by branch
+match, `gate-ledger work-log --step build --outcome ESCALATED` (no `--phase`) logged
+against it, and `gate-ledger work-get` read back a sha-anchored `.history` entry. This
+confirms both load-bearing assumptions this design depends on and lint/tests can't see:
+`bin/gate-ledger`'s `.studious/` root-anchoring (`repo_root()` via `git rev-parse
+--git-common-dir`) already unifies state across linked worktrees of the same repo, and
+branch-match discovery resolves correctly from inside one. Test artifacts (worktree,
+branch, work file) were removed after.

--- a/reference/worker-contract.md
+++ b/reference/worker-contract.md
@@ -6,8 +6,9 @@ explicitly approved epic plan. This file names the interface between the driver 
 worker: what every dispatch brief must hand over, and what a worker must hand back
 before its phase counts as done. It is the build-side analogue of
 `reference/design-doc-contract.md`. The contract, not any particular executor, is
-normative — a worker MAY use Superpowers' plan/execute workflow when it's installed,
-but a worker without it must still satisfy every row below.
+normative — a worker MAY use Superpowers' plan/execute workflow when it's installed, or
+jig's `/plan` + `/build` workflow, but a worker without either must still satisfy every
+row below.
 
 Workers never gate. A worker must not run a gate command, record a verdict, or
 self-assess against a gate's rubric — the gates judge its output blind, from the diff
@@ -38,6 +39,19 @@ branch's and the finale's concern, not the worker's.
 | A summary | What changed and why, at the level the gates read — files touched, behavior added, deliberate deviations from the design doc called out rather than hidden. |
 | Evidence | Commands actually run with their captured output: the test suite passing, the new tests failing before / passing after, lint or build results. "Done" without artifacts is not done — an assertion of success with no output attached is treated as not run. |
 | Tests | New behavior arrives with tests per the project's conventions; bug fixes arrive with regression tests. |
+
+## Status reporting
+
+A worker MAY additionally report its own terminal status for the phase it just
+finished. First resolve which work file is this feature's the same way `/work-on` does
+it: `gate-ledger work-list`, match the current branch's row. Found → `gate-ledger
+work-log --slug "<that-slug>" --step <phase> --outcome "<status>"`, omitting `--phase`
+(the phase judgment stays `/work-on`'s call). No match, or `gate-ledger` not on `PATH`
+at all → skip silently; this is best-effort corroboration, not a required part of the
+contract. This is a first-person status report, not a gate verdict or a self-assessment
+against a rubric, and does not conflict with "workers never... record a verdict" below
+— jig's `/build` reports `BUILT | PAUSED | ESCALATED` this way when `gate-ledger` is
+present.
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

- Recommend jig alongside Superpowers at `/work-on`'s design and build handoffs — additive, no existing mention changed.
- Teach `/work-on`'s evidence check to read jig's self-reported build status (`BUILT | PAUSED | ESCALATED`) via `gate-ledger work-get`'s `.history`, sha-anchored the same way gate verdicts already are; `ESCALATED` regresses phase to `design`, mirroring jig's own documented routing and the existing `RETHINK` → `design` precedent.
- Publish the reporting contract in `reference/worker-contract.md`: a worker resolves its own work file by branch match (the same convention `/work-on` uses) and logs `gate-ledger work-log --step <phase> --outcome <status>`, never `--phase` — a status report, not a gate verdict.
- Add jig to README's "Works well with."
- Design doc: `docs/superpowers/specs/2026-07-20-jig-executor-seam-design.md`.

No `bin/gate-ledger` changes — `--outcome` was already free text and `.history` already an array; nothing to extend.

Reciprocal jig-side change (calls this contract from `/build`): jacquardlabs/jig#97.

Closes #143

## Test plan

- [x] `markdownlint-cli2` clean
- [x] `scripts/check_references.py` clean
- [x] Manual round-trip: `work-set --branch` from a main checkout, then from a separate `git worktree add` sibling on that branch (the same primitive jig's `worktree-setup` uses), `gate-ledger work-list` found the row by branch match, `work-log --step build --outcome ESCALATED` (no `--phase`) logged against it, `work-get` read back a sha-anchored `.history` entry. Confirms `.studious/` root-anchoring and branch-match discovery both hold across linked worktrees. Test artifacts removed after.