### PR TITLE
feat: front-load the epic interview so the driver can run unattended

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Run `/studious-doctor` any time after: right after install, after a marketplace 
 **From here, the fastest way in is to stop reading and run one command:**
 
 - Building one thing? `/work-on [idea or issue]`. It runs one step of the flow, tells you what's next, and hands back to you at the two steps Studious doesn't own (writing the design, writing the code). Run it again, or just say "next," when you're ready to keep going.
-- Driving a batch? `/work-through [milestone, epic issue, or label]`. It proposes a story plan for your approval, then dispatched agents design, build, and gate each story in parallel, gated exactly like anything else.
+- Driving a batch? `/work-through [milestone, epic issue, or label]`. It proposes a story plan and interviews you once for the whole epic, then dispatched agents design, build, and gate each story in parallel. Same gates as anywhere else — but you won't see the design docs, so read the trade below before you reach for it.
 
 Everything past this point is what those two commands are driving underneath — read on for the detail, or to run a piece by hand.
 
@@ -54,7 +54,9 @@ Studious wraps feature development in quality gates. Between them you build, and
 
 ### Let `/work-through` drive a whole milestone
 
-`/work-through [milestone, epic issue, or label]` scales the flow up a level. The first run reads the milestone's issues (read-only) and proposes a story plan: dependency order, acceptance criteria per story, which gates each story needs, an epic-level pre-mortem. Then it stops for your approval; nothing runs before it.
+`/work-through [milestone, epic issue, or label]` scales the flow up a level. The first run reads the milestone's issues (read-only) and proposes a story plan: dependency order, acceptance criteria per story, which gates each story needs, an epic-level pre-mortem. It also interviews you once for the whole epic — 10–12 questions, capped, covering only the product forks a worker can't decide alone — because every phase after this runs in a subagent with no human in its loop. Then it stops for your approval; nothing runs before it.
+
+**Know what you're trading.** At this scale you approve the story plan and answer the interview, and the next thing you see is the epic PR. You don't approve the design docs: `/gate-design-review` reviews every one of them, but that's an agent reviewing, not you signing off. A subagent can't open a browser, and the driver is barred from routing to `/design` by the same rule that keeps gates executor-agnostic. If you want the design in front of you story by story, that's what `/work-on` is for.
 
 Every run after that drives execution: agents design, build, and gate stories in parallel worktrees (3 at once by default). Stories that pass their gates merge into an `epic/<name>` integration branch, and fix-it verdicts get at most 2 repair cycles with a fresh auditor each time. Judgment verdicts (RETHINK, NEEDS DISCUSSION, HOLD) never retry: that story parks for you while independent stories keep moving.
 

--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -592,7 +592,7 @@ cmd_epic_get() {
 }
 
 cmd_epic_story_set() {
-  local epic="" slug="" title="" src="" criteria="" deps="" gates_csv="" status="" reason="" worktree="" bump="" reset=""
+  local epic="" slug="" title="" src="" criteria="" decisions="" deps="" gates_csv="" status="" reason="" worktree="" bump="" reset=""
   while [ $# -gt 0 ]; do
     case "$1" in
       --epic)        epic="$2"; shift 2 ;;
@@ -600,6 +600,7 @@ cmd_epic_story_set() {
       --title)       title="$2"; shift 2 ;;
       --source)      src="$2"; shift 2 ;;
       --criteria)    criteria="$2"; shift 2 ;;
+      --decisions)   decisions="$2"; shift 2 ;;
       --deps)        deps="$2"; shift 2 ;;
       --gates)       gates_csv="$2"; shift 2 ;;
       --status)      status="$2"; shift 2 ;;
@@ -641,6 +642,7 @@ cmd_epic_story_set() {
        | (if $title    != "" then .title    = $title    else . end)
        | (if $src      != "" then .source   = $src      else . end)
        | (if $criteria != "" then .criteria = $criteria else . end)
+       | (if $decisions != "" then .decisions = $decisions else . end)
        | (if $deps     != "" then .deps     = ($deps  | csv_trim) else . end)
        | (if $gates    != "" then .gates    = ($gates | csv_trim) else . end)
        | (if $status   != "" then .status   = $status   else . end)
@@ -649,6 +651,7 @@ cmd_epic_story_set() {
        | (if $bump     != "" then .retries[$bump]  = ((.retries[$bump]  // 0) + 1) else . end)
        | (if $reset    != "" then .retries[$reset] = 0 else . end))' \
     --arg s "$slug" --arg title "$title" --arg src "$src" --arg criteria "$criteria" \
+    --arg decisions "$decisions" \
     --arg deps "$deps" --arg gates "$gates_csv" --arg status "$status" --arg reason "$reason" \
     --arg wt "$worktree" --arg bump "$bump" --arg reset "$reset" --arg t "$(now_iso)"
   rc=$?
@@ -938,5 +941,5 @@ case "${1:-}" in
   evidence-append) shift; cmd_evidence_append "$@" ;;
   evidence-list)   shift; cmd_evidence_list "$@" ;;
   gc)              shift; cmd_gc "$@" ;;
-  *) echo "usage: gate-ledger {record --gate G --verdict V [--blocking-lanes L1,L2] | status | gate-get [--branch B] | work-set --slug S [--title T] [--source SRC] [--branch B] [--design-doc P] [--phase PH] | work-log --slug S --step ST --outcome O [--phase PH] | work-get --slug S | work-list | epic-set --slug S [--title T] [--source SRC] [--goal G] [--branch B] [--premortem P] [--concurrency N] [--status ST] | epic-story-set --epic E --slug S [--title T] [--source SRC] [--criteria C] [--deps D] [--gates G] [--status ST] [--reason R] [--worktree P] [--bump-retry GATE] [--reset-retry GATE] | epic-get --slug S | epic-reconcile --slug S | epic-list | evidence-append --command C --exit-code N --output-digest D --origin interactive|subagent [--agent-type T] | evidence-list [--branch B] [--dedupe] | gc}" >&2; exit 2 ;;
+  *) echo "usage: gate-ledger {record --gate G --verdict V [--blocking-lanes L1,L2] | status | gate-get [--branch B] | work-set --slug S [--title T] [--source SRC] [--branch B] [--design-doc P] [--phase PH] | work-log --slug S --step ST --outcome O [--phase PH] | work-get --slug S | work-list | epic-set --slug S [--title T] [--source SRC] [--goal G] [--branch B] [--premortem P] [--concurrency N] [--status ST] | epic-story-set --epic E --slug S [--title T] [--source SRC] [--criteria C] [--decisions D] [--deps D] [--gates G] [--status ST] [--reason R] [--worktree P] [--bump-retry GATE] [--reset-retry GATE] | epic-get --slug S | epic-reconcile --slug S | epic-list | evidence-append --command C --exit-code N --output-digest D --origin interactive|subagent [--agent-type T] | evidence-list [--branch B] [--dedupe] | gc}" >&2; exit 2 ;;
 esac

--- a/commands/work-through.md
+++ b/commands/work-through.md
@@ -131,14 +131,32 @@ supervised, evidence-first flow instead.
 6. Close with the report block below. Driving starts on the next invocation — approval
    and execution never share one.
 
-**Sign-off at epic scale is the `design-review` gate, not a per-story viva round.**
+**No human approves a design doc on this path. State that plainly to the user at
+approval time — don't let them discover it at the epic PR.**
+
 The driver's default profile is `design → design-review → build → audit → acceptance`:
 a dispatched worker drafts the design doc and `/gate-design-review` reviews it against
-`reference/design-doc-contract.md` on every story. A per-story browser sign-off would
-be a second reviewer of the same artifact, and a subagent cannot open one anyway. What
-front-loading moves is the **interview**, which has no substitute; the **sign-off**
-already has one. Story-scale work through `/work-on` keeps its full per-story rounds —
-that flow has the human present throughout.
+`reference/design-doc-contract.md` on every story. Two constraints force this, and
+neither is a preference:
+
+- **A subagent cannot open a browser.** viva's sign-off is a human at a keyboard, and
+  there isn't one inside a dispatched phase running three-at-a-time in parallel
+  worktrees.
+- **The driver may not name a build skill.** `workflows/epic-driver.js` is on the gate
+  surface `scripts/check_gate_independence.py` guards, so it dispatches a worker
+  against `reference/worker-contract.md` rather than routing to `/design`. That rule is
+  what keeps a gate from caring who built the branch; it also means the epic path can't
+  inherit `/design`'s sign-off loop even if a human were available.
+
+So the human turns at epic scale are: the story-plan approval, this interview, and the
+PR. `/gate-design-review` reviews every design doc, but an agent reviewing is not a
+human approving — do not describe it to the user as an equivalent substitute. What
+front-loading moves is the **interview**, which has no substitute at all; the sign-off
+is genuinely reduced, not relocated.
+
+Story-scale work through `/work-on` keeps the human in every round — a design doc there
+gets both a viva sign-off and the gate. The inconsistency between the two scales is
+known and tracked (issue #210); it is not a licence to improvise a third behaviour here.
 
 ## Driver — every later invocation
 

--- a/commands/work-through.md
+++ b/commands/work-through.md
@@ -57,16 +57,64 @@ supervised, evidence-first flow instead.
    plan — the user can only approve what they can see.
 3. Stop and iterate. The user trims, reorders, re-scopes, drops. Nothing is recorded
    and nothing runs until they explicitly approve.
-4. On approval, record exactly what was approved. Derive `<slug>` from the epic title:
+
+4. **Settle the open forks in one interview — the epic's only scheduled human turn.**
+
+   Every dispatched phase runs in a subagent with no human in its loop. A worker that
+   meets an unanswered product fork can only guess or park, and a guess is worse. So
+   the forks get answered here, once, for the whole epic.
+
+   Collect the questions across all stories, then admit only those that are **both**:
+
+   - **product or scope level** — which surface, which persona, what's in and out,
+     which of two behaviours is correct; *not* which abstraction or library, which
+     gets discovered mid-build and depends on what the earlier stories produced; and
+   - **answerable now** — nothing in an unbuilt story's output changes the answer.
+
+   **Cap the session at 10–12 questions for the entire epic**, prioritised by how much
+   rework a wrong assumption causes. That is roughly two per story on a five-story
+   epic — deliberately far below what a per-story interview would ask, because this
+   session buys unattended execution, not exhaustive specification. Everything cut
+   stays available: a worker that hits it parks, and the story surfaces in "Needs you".
+
+   Skip the session outright when nothing qualifies; say so rather than manufacturing
+   questions to fill a quota.
+
+   If viva is installed, run it as one batch. `QAInput` is a flat question list with a
+   single `context` string and no grouping field, so **the story slug goes in each
+   question's `id`** (`<story-slug>-<n>`) and opens its `text` — no viva change is
+   needed. Give every fork 2–3 `choices` and, where you have a defensible view, one
+   `recommended_choice` (it must match a choice exactly; it renders as advice and is
+   never preselected).
+
+   ```bash
+   # .viva/qa-input.json — see viva's docs/headless-contract.md §3 for the shape
+   jq -n --arg ctx "Epic <slug> — settling <n> forks before the driver runs" \
+     '{mode: "qa", context: $ctx, questions: $qs}' --argjson qs "$QUESTIONS" \
+     > .viva/qa-input.json
+   ```
+
+   Then invoke `/viva-qa` and read `.viva/answers.json`. If viva is **not** installed,
+   ask the same questions in the conversation — the point is that a human answers them
+   before dispatch, not that viva mediates it.
+
+5. On approval, record exactly what was approved. Derive `<slug>` from the epic title:
 
    ```bash
    gate-ledger epic-set --slug "<slug>" --title "<title>" --source "<milestone M | issue #N | label L>" \
      --goal "<goal statement>" --branch "epic/<slug>" --concurrency <cap> --status approved
    gate-ledger epic-story-set --epic "<slug>" --slug "<story>" --title "<story title>" \
-     --source "issue #N" --criteria "<criteria>" --deps "<dep-a,dep-b>" --gates "<profile>"
+     --source "issue #N" --criteria "<criteria>" --decisions "<answered forks>" \
+     --deps "<dep-a,dep-b>" --gates "<profile>"
    ```
 
-   (one `epic-story-set` per story), then:
+   `--decisions` carries that story's answers as one line — `fork: answer; fork: answer`
+   — distilled from `.viva/answers.json` (`choice`, plus `note` when the human added
+   one). It reaches every dispatch prompt through the driver's shared context block,
+   marked settled and not to be re-litigated. Omit the flag for a story with no
+   answered forks; keep acceptance criteria in `--criteria`, where they belong.
+
+   One `epic-story-set` per story, then:
 
    - Write the epic pre-mortem register to `docs/studious/premortems/<slug>-epic.md`
      and record it: `gate-ledger epic-set --slug "<slug>" --premortem "<path>"`.
@@ -80,8 +128,17 @@ supervised, evidence-first flow instead.
      git worktree add ".studious/worktrees/<slug>/__epic" "epic/<slug>"
      ```
 
-5. Close with the report block below. Driving starts on the next invocation — approval
+6. Close with the report block below. Driving starts on the next invocation — approval
    and execution never share one.
+
+**Sign-off at epic scale is the `design-review` gate, not a per-story viva round.**
+The driver's default profile is `design → design-review → build → audit → acceptance`:
+a dispatched worker drafts the design doc and `/gate-design-review` reviews it against
+`reference/design-doc-contract.md` on every story. A per-story browser sign-off would
+be a second reviewer of the same artifact, and a subagent cannot open one anyway. What
+front-loading moves is the **interview**, which has no substitute; the **sign-off**
+already has one. Story-scale work through `/work-on` keeps its full per-story rounds —
+that flow has the human present throughout.
 
 ## Driver — every later invocation
 

--- a/reference/epic-plan-contract.md
+++ b/reference/epic-plan-contract.md
@@ -13,6 +13,7 @@ or unjudgeable story later.
 | Epic goal statement | One sentence. The epic-finale `/gate-acceptance` judges the integrated result against it, not against any single story. |
 | Stories | Each: a short slug, a title, and its source issue(s). Splitting or merging GitHub issues is proposed here, never applied to GitHub. |
 | Acceptance criteria per story | What the story's `/gate-acceptance` run must be able to verify — concrete and observable. "Works" is not a criterion. |
+| Settled forks per story | The product/scope questions answered at the plan piece's one interview, recorded per story as `decisions`. Every phase is dispatched to a subagent with no human in its loop, so an unanswered fork can only be guessed or parked — this is where the human answers instead. Distinct from acceptance criteria: criteria say what "done" means, decisions say which of two defensible designs was chosen. Absent for a story whose forks were all obvious. |
 | Dependency edges | The DAG the scheduler runs. Only real sequencing dependencies: an edge claims the downstream story cannot be designed or built until the upstream one lands. |
 | Gate profile per story | Which of design → design-review → build → audit → acceptance run for this story. Default is all five. Audit is never trimmed. Trimming is proposed by the planner, decided by the user at approval. |
 | Epic pre-mortem | Cross-story failure modes — integration seams, shared-schema drift, sequencing risk — written to `docs/studious/premortems/<epic-slug>-epic.md` and verified at the epic finale by `agents/premortem-auditor.md`. |
@@ -26,3 +27,23 @@ recorded: if they trim, reorder, or drop stories, record the edited version. App
 the plan is the batched should-we-build for every story in it — no per-story decide
 gate runs later. A story added mid-flight gets its own scoped decide pass and explicit
 approval of its DAG placement before it joins the schedule.
+
+The fork interview runs before approval, not after: the user is approving a plan whose
+open product questions are already answered, not one that will discover them mid-run.
+Cap the interview at 10–12 questions for the whole epic, admitting only forks that are
+both product/scope level and answerable before any story is built. Implementation forks
+surface mid-build and depend on earlier stories' output — those park, and the story
+appears in "Needs you". Approval is the interview's deadline, so a fork raised after it
+follows the mid-flight-story rule above.
+
+## Consumers that must stay in sync
+
+- `commands/work-through.md` — the only writer. Its plan piece runs the interview and
+  records each element through `gate-ledger epic-set` / `epic-story-set`; the field
+  names in its `--criteria` / `--decisions` / `--deps` / `--gates` flags are this
+  table's elements.
+- `bin/gate-ledger` — `epic-story-set` stores them; a new required element here needs a
+  flag there, or the plan piece has nowhere to put it.
+- `workflows/epic-driver.js` — reads them back. `ctx()` threads `criteria` and
+  `decisions` into every dispatch prompt; `deps` and `gates` drive the scheduler. An
+  element the driver never reads is a documentation-only element, and should say so.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -45,6 +45,27 @@ else to resolve here.
 
 ## Step 2 -- Batch interview (viva-qa)
 
+**Skip this step when the forks arrive already answered.** A dispatched run —
+studious's `/work-through` driver, or any orchestrator that settled its forks
+up front — passes them in its brief as a `Decisions already made by the human`
+line. You have no human in your loop to interview, so a fresh round here would
+either stall or, worse, invent answers.
+
+When that line is present:
+
+- Treat each decision as settled. Carry it into the draft exactly as given, and
+  do not re-open it — not as an "Open question", not as an alternative weighed
+  in the prose.
+- Skip straight to Step 3. Steps 5 and 6 are unaffected: `design-lint` still
+  runs, and the sign-off still belongs to whoever the caller says it belongs to.
+- A fork the brief does **not** answer is not yours to decide. Return `NEEDS
+  RESEARCH` naming it, so the orchestrator parks the story and it reaches a
+  human through the escalation path — never guess to keep the run moving.
+
+This is the same distinction studious's `/work-through` documents: the interview
+front-loads, the sign-off does not. Interactive `/design` — a human at the
+keyboard, no decisions in the brief — runs the full round below unchanged.
+
 Write `.viva/qa-input.json`:
 
 ```json

--- a/tests/python/test_frontloaded_decisions.py
+++ b/tests/python/test_frontloaded_decisions.py
@@ -1,0 +1,133 @@
+"""Tests for front-loading the epic interview (studious #150 follow-on).
+
+A dispatched phase runs in a subagent with no human in its loop, so jig's
+`/design` cannot hold its viva-qa interview there. `/work-through`'s Plan piece
+runs one interview for the whole epic instead, records each story's answers via
+`gate-ledger epic-story-set --decisions`, and the driver threads them into every
+dispatch prompt through its shared `ctx()` block.
+
+The ledger half is covered by `tests/test_gate_ledger.sh`. Here:
+
+- an **executed** fixture runs the driver's real, unmodified `ctx()` — extracted
+  verbatim by balanced-brace scan, never reimplemented, following
+  `test_contract_injection.py`'s precedent — and asserts the decisions line
+  appears when the field is set and is absent when it is not;
+- structural checks that the two prompts documenting the split (studious's
+  Plan piece, jig's `/design` Step 2) actually say what the driver relies on.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DRIVER = REPO_ROOT / "workflows" / "epic-driver.js"
+WORK_THROUGH = REPO_ROOT / "commands" / "work-through.md"
+JIG_DESIGN = REPO_ROOT / "plugins" / "jig" / "skills" / "design" / "SKILL.md"
+
+
+def _extract_function(source: str, name: str) -> str:
+    """Extract a top-level ``function <name>(...) { ... }`` declaration verbatim."""
+    marker = f"function {name}("
+    start = source.index(marker)
+    brace_open = source.index("{", start)
+    depth = 0
+    i = brace_open
+    while True:
+        ch = source[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        i += 1
+    return source[start : i + 1]
+
+
+def _run_ctx(story_fields: dict) -> str:
+    """Execute the driver's real ctx() against one story record."""
+    ctx_src = _extract_function(DRIVER.read_text(), "ctx")
+    harness = f"""
+      const repoRoot = '/repo'
+      const slug = 'demo-epic'
+      const epic = {{ title: 'Demo Epic', goal: 'ship the thing' }}
+      const stories = {{ 'story-a': {json.dumps(story_fields)} }}
+      const storyBranch = s => `story/${{s}}`
+      const storyWorktree = s => `/repo/.studious/worktrees/${{s}}`
+      const workSlug = s => s
+      const shellSafe = s => s
+      {ctx_src}
+      process.stdout.write(ctx('story-a'))
+    """
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", harness],
+        capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+DECISIONS = "surface: CLI not TUI; guest carts: out of scope"
+
+
+def test_decisions_reach_the_dispatch_context() -> None:
+    out = _run_ctx({"title": "A", "criteria": "does X", "decisions": DECISIONS})
+    assert DECISIONS in out
+
+
+def test_decisions_are_marked_settled_not_advisory() -> None:
+    """A worker that treats them as suggestions would re-open a closed fork."""
+    out = _run_ctx({"title": "A", "criteria": "does X", "decisions": DECISIONS})
+    line = next(ln for ln in out.splitlines() if DECISIONS in ln)
+    assert "settled" in line.lower()
+    assert "re-litigate" in line.lower()
+
+
+def test_no_decisions_line_when_the_story_has_none() -> None:
+    """Most stories answer no forks; they must not carry an empty placeholder."""
+    out = _run_ctx({"title": "A", "criteria": "does X"})
+    assert "Decisions already made" not in out
+    assert "undefined" not in out
+
+
+def test_decisions_do_not_displace_acceptance_criteria() -> None:
+    out = _run_ctx({"title": "A", "criteria": "does X", "decisions": DECISIONS})
+    assert "Acceptance criteria: does X" in out
+
+
+def test_plan_piece_caps_the_interview_and_names_both_admission_rules() -> None:
+    text = WORK_THROUGH.read_text()
+    assert "10–12 questions" in text, "the question cap must be a number, not 'a few'"
+    assert "answerable now" in text
+    assert "--decisions" in text
+
+
+def test_plan_piece_records_why_sign_off_is_not_front_loaded() -> None:
+    """The interview moves; the sign-off already has a substitute at epic scale."""
+    text = WORK_THROUGH.read_text()
+    assert "design-review" in text
+    assert "front-loading moves is the **interview**" in text
+
+
+def test_jig_design_skips_its_own_interview_when_forks_arrive_answered() -> None:
+    text = JIG_DESIGN.read_text()
+    step2 = text.split("## Step 2")[1].split("## Step 3")[0]
+    assert "Skip this step" in step2
+    assert "Decisions already made by the human" in step2, (
+        "jig must key off the exact phrase the driver's ctx() emits"
+    )
+
+
+def test_jig_design_escalates_an_unanswered_fork_instead_of_guessing() -> None:
+    text = JIG_DESIGN.read_text()
+    step2 = text.split("## Step 2")[1].split("## Step 3")[0]
+    assert "NEEDS\nRESEARCH" in step2 or "NEEDS RESEARCH" in step2
+
+
+def test_the_driver_phrase_and_the_jig_trigger_phrase_are_the_same_string() -> None:
+    """The contract between the two halves is one literal; drift breaks it silently."""
+    phrase = "Decisions already made by the human"
+    assert phrase in DRIVER.read_text()
+    assert phrase in JIG_DESIGN.read_text()

--- a/tests/python/test_frontloaded_decisions.py
+++ b/tests/python/test_frontloaded_decisions.py
@@ -1,7 +1,7 @@
 """Tests for front-loading the epic interview (studious #150 follow-on).
 
-A dispatched phase runs in a subagent with no human in its loop, so jig's
-`/design` cannot hold its viva-qa interview there. `/work-through`'s Plan piece
+A dispatched phase runs in a subagent with no human in its loop, so `/design`
+cannot hold its viva-qa interview there. `/work-through`'s Plan piece
 runs one interview for the whole epic instead, records each story's answers via
 `gate-ledger epic-story-set --decisions`, and the driver threads them into every
 dispatch prompt through its shared `ctx()` block.
@@ -13,7 +13,7 @@ The ledger half is covered by `tests/test_gate_ledger.sh`. Here:
   `test_contract_injection.py`'s precedent — and asserts the decisions line
   appears when the field is set and is absent when it is not;
 - structural checks that the two prompts documenting the split (studious's
-  Plan piece, jig's `/design` Step 2) actually say what the driver relies on.
+  Plan piece, `/design` Step 2) actually say what the driver relies on.
 """
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DRIVER = REPO_ROOT / "workflows" / "epic-driver.js"
 WORK_THROUGH = REPO_ROOT / "commands" / "work-through.md"
-JIG_DESIGN = REPO_ROOT / "plugins" / "jig" / "skills" / "design" / "SKILL.md"
+DESIGN_SKILL = REPO_ROOT / "skills" / "design" / "SKILL.md"
 
 
 def _extract_function(source: str, name: str) -> str:
@@ -111,23 +111,23 @@ def test_plan_piece_records_why_sign_off_is_not_front_loaded() -> None:
     assert "front-loading moves is the **interview**" in text
 
 
-def test_jig_design_skips_its_own_interview_when_forks_arrive_answered() -> None:
-    text = JIG_DESIGN.read_text()
+def test_design_skips_its_own_interview_when_forks_arrive_answered() -> None:
+    text = DESIGN_SKILL.read_text()
     step2 = text.split("## Step 2")[1].split("## Step 3")[0]
     assert "Skip this step" in step2
     assert "Decisions already made by the human" in step2, (
-        "jig must key off the exact phrase the driver's ctx() emits"
+        "/design must key off the exact phrase the driver's ctx() emits"
     )
 
 
-def test_jig_design_escalates_an_unanswered_fork_instead_of_guessing() -> None:
-    text = JIG_DESIGN.read_text()
+def test_design_escalates_an_unanswered_fork_instead_of_guessing() -> None:
+    text = DESIGN_SKILL.read_text()
     step2 = text.split("## Step 2")[1].split("## Step 3")[0]
     assert "NEEDS\nRESEARCH" in step2 or "NEEDS RESEARCH" in step2
 
 
-def test_the_driver_phrase_and_the_jig_trigger_phrase_are_the_same_string() -> None:
+def test_the_driver_phrase_and_the_design_trigger_phrase_are_the_same_string() -> None:
     """The contract between the two halves is one literal; drift breaks it silently."""
     phrase = "Decisions already made by the human"
     assert phrase in DRIVER.read_text()
-    assert phrase in JIG_DESIGN.read_text()
+    assert phrase in DESIGN_SKILL.read_text()

--- a/tests/test_gate_ledger.sh
+++ b/tests/test_gate_ledger.sh
@@ -376,6 +376,23 @@ check "story gates split to an array" "5" "$(jq '.stories["cart-api"].gates | le
     --deps "cart-api, payment-svc" )
 check "deps split to a trimmed array" '["cart-api","payment-svc"]' "$(jq -c '.stories["checkout-ui"].deps' "$ef15")"
 
+# --- decisions: the Plan piece's front-loaded fork answers ride alongside criteria ---
+( cd "$d15" && "$LEDGER" epic-story-set --epic checkout-revamp --slug cart-api \
+    --decisions "surface: REST not GraphQL; guest carts: out of scope" )
+check "story stores decisions" "surface: REST not GraphQL; guest carts: out of scope" \
+  "$(jq -r '.stories["cart-api"].decisions' "$ef15")"
+check "decisions do not disturb criteria" "POST /cart returns 201 with a cart id" \
+  "$(jq -r '.stories["cart-api"].criteria' "$ef15")"
+
+# --- a later criteria-only write must not clobber decisions (they are separate fields) ---
+( cd "$d15" && "$LEDGER" epic-story-set --epic checkout-revamp --slug cart-api \
+    --criteria "POST /cart returns 201 and a Location header" )
+check "criteria update leaves decisions intact" "surface: REST not GraphQL; guest carts: out of scope" \
+  "$(jq -r '.stories["cart-api"].decisions' "$ef15")"
+
+# --- a story with no answered forks carries no decisions key at all ---
+check "decisions absent when never set" "null" "$(jq -r '.stories["checkout-ui"].decisions // "null"' "$ef15")"
+
 # --- story upsert: status/reason land, earlier fields survive ---
 ( cd "$d15" && "$LEDGER" epic-story-set --epic checkout-revamp --slug cart-api \
     --status parked --reason "audit: NEEDS DISCUSSION - auth model unclear" )

--- a/workflows/epic-driver.js
+++ b/workflows/epic-driver.js
@@ -768,6 +768,12 @@ function ctx(story) {
   return [
     `Repo (MAIN working tree): ${repoRoot}. Epic: "${epic.title}" (slug ${slug}); epic goal: ${epic.goal}.`,
     `Story: "${s.title}" (slug ${story}). Source: ${s.source || 'epic plan'}. Acceptance criteria: ${s.criteria || 'see epic plan'}.`,
+    // Answers the human gave at the Plan piece's one interview, before any story ran.
+    // A dispatched agent cannot hold its own interview — there is no human in its
+    // loop — so a fork that isn't answered here is parked, never guessed.
+    ...(s.decisions
+      ? [`Decisions already made by the human at epic planning — treat as settled, do not re-litigate: ${s.decisions}`]
+      : []),
     `Story branch: ${storyBranch(story)}. Story worktree: ${storyWorktree(story)} (the ONLY checkout you may touch).`,
     `Conventions: read PRODUCT.md and CLAUDE.md at the project root. The gate-ledger tool is on PATH; the Studious plugin root is dirname "$(command -v gate-ledger)")/.. — read referenced command/reference files from there.`,
     `If the worktree does not exist yet, create it first, from inside ${repoRoot}: git branch "${storyBranch(story)}" "epic/${slug}" 2>/dev/null; git worktree add "${storyWorktree(story)}" "${storyBranch(story)}" — then record it: gate-ledger work-set --slug "${workSlug(story)}" --title "${shellSafe(s.title)}" --source "epic:${slug}" --branch "${storyBranch(story)}"`,


### PR DESCRIPTION
**Stacked on #171** — base is `feat/absorb-jig`, not `main`. Review that first; this diff is four files.

This is the feature that motivated the merge: it touches `commands/work-through.md`, `workflows/epic-driver.js`, `bin/gate-ledger`, and `skills/design/SKILL.md`. One change, one diff, one review. Before #171 that was two repos.

## The problem

A dispatched phase runs in a subagent with no human in its loop, so `/design` cannot hold its viva-qa interview there. That is why #143's seam went into `/work-on` and never touched `/work-through` — the pairing only worked where the human was already present.

## The correction

"Move viva earlier" splits into two different things:

| | Front-loadable? |
|---|---|
| **viva-qa** — the interview, before the doc exists | **Yes.** No substitute; a subagent cannot ask. |
| **viva** — section-by-section sign-off on a drafted doc | **No,** and it doesn't need to be. |

You can't front-load approval of a document that doesn't exist yet. And at epic scale the sign-off already has a substitute: `FULL_PROFILE = ['design', 'design-review', 'build', 'audit', 'acceptance']`, so `/gate-design-review` reviews every story's design doc against `reference/design-doc-contract.md`. A per-story viva round would be a second reviewer of the same artifact.

`/work-on` keeps its full per-story rounds — that flow has the human present throughout.

## What ships

- **One viva-qa batch at the Plan piece**, which already ends at approval. Capped at **10–12 questions for the whole epic**, admitting only forks that are both product/scope level *and* answerable before anything is built — roughly two per story on a five-story epic. Implementation forks get discovered mid-build and depend on earlier stories' output; those still park into "Needs you".
- **`gate-ledger epic-story-set --decisions`** records each story's answers beside, not inside, its acceptance criteria.
- **`ctx()` threads them into every dispatch prompt**, marked settled.
- **`/design` Step 2 skips its own interview** when that line is present, and returns `NEEDS RESEARCH` for a fork the brief doesn't answer rather than guessing.
- **`reference/epic-plan-contract.md`** gains `decisions` as a required element and a "Consumers that must stay in sync" section — the command was writing more than its contract admitted.

## Zero viva changes

`QAInput` is a flat `questions` list with a single `context` string and no grouping field, so the story slug rides in each question's `id` (`<story-slug>-<n>`). That's criterion (e) in practice: crossing that boundary means calling a documented contract, so co-locating viva would buy nothing.

## Verification

9 new tests. The load-bearing one is an executed fixture running the driver's **real, unmodified `ctx()`**, extracted verbatim by balanced-brace scan following `test_contract_injection.py`'s precedent. Plus: a story with no forks emits no line and no `undefined`; decisions don't displace criteria; and the driver's emitted phrase and the skill's trigger phrase are asserted to be the same literal — that string is the contract between the two halves, and drift would break it silently. Ledger coverage in `tests/test_gate_ledger.sh`: `--decisions` round-trips, a later `--criteria`-only write doesn't clobber it, the key is absent when never set.

Full suite green: 304 pytest, 413 unittest, gate-ledger + evidence bash, markdownlint, link-check, gate independence, shellcheck, eslint, ruff.