### PR TITLE
fix: cover the build half in /studious-doctor, and refresh the stale ground truth

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -103,6 +103,11 @@ this section is your voice, not the extractor's.
   why `scripts/check_gate_independence.py` enforces it in CI rather than trusting it.
 - **Anti-cleverness tripwire** — a sequential for-loop is the default. No sprint
   ceremony, no resident coordinating roles, no agent persona that outlives its dispatch.
+  The test is residency, not vocabulary: the Foreman, Executor, and Inspector that one
+  `/build` loop dispatches one at a time are stage labels on a for-loop — ephemeral,
+  stateless across tasks, each one a fresh subagent that ends when its task does. What
+  this rules out is the BMAD-style standing cast: an agent that persists between
+  dispatches, accrues state, or has to be consulted.
 - **Propose, don't apply** — reviews surface findings and propose updates to context
   docs, but never write them. "They never apply them. You review and approve." The
   human stays the decision-maker.
@@ -126,14 +131,17 @@ Issue tracker: [GitHub Issues](https://github.com/jacquardlabs/studious/issues)
 
 The tracker owns individual features. PRODUCT.md owns strategic context only.
 
-The open issues encode a tiered roadmap with a pre-recorded gate verdict on each:
-- **A-tier (Horizon 1)** — foundational: A1 self-verification harness (#24, the
-  "keystone"), A2 non-web product support (#25, resolved this cycle), A3 idiom
-  feedback loop (#26).
-- **M-tier (Horizon 2)** — gate ledger/statefulness (#27), metrics persistence (#28),
-  design-doc contract (#29), CI-mode audit (#30).
-- **X-tier (moonshot)** — spec traceability (#31), post-ship outcome gate (#32),
-  self-tuning corpus (#33), org portfolio health (#34, parked).
+**The roadmap lives in [milestones](https://github.com/jacquardlabs/studious/milestones), not here.** Restating it in this file is how it went stale
+before: the original A/M/X tiers were listed as the live roadmap long after every
+A-tier and M-tier issue had closed, and every gate reads this file as ground truth.
+Milestones are ordered by their own descriptions; the run order as of 2026-07-25 is
+M10 → M11 → M9 → M6 → M12 → M8 → M5.
+
+The one durable point: **X-tier is the strategic bet.** Spec traceability (#31), the
+post-ship outcome gate (#32), and the self-tuning corpus (#33) are what turn a set of
+gates into a loop that learns, and they stay last because each one needs shipped
+outcome data the earlier milestones produce. Cross-repo portfolio health (#34) is
+parked pending evidence anyone wants it.
 
 ## Critical user journeys
 
@@ -199,23 +207,30 @@ lanes still skip cleanly on non-web projects, by design.
 
 ## Current known problems
 
-The GitHub tracker is the authoritative source. Ordered here by likely user impact:
+The GitHub tracker is the authoritative source. Ordered here by likely user impact.
+Refreshed 2026-07-25 (#147) — the previous list named four problems that had all
+shipped: the self-verification harness (#24, CI now runs seven jobs), stateless gates
+(#27, the `.studious/` ledger and PR-time hook), metrics persistence (#28), and the
+undefined design-doc contract (#29). Every gate and review reads this file, so a stale
+entry here is not a documentation nit — it is the discipline running on bad fuel.
 
-1. **The quality tool has no quality gate on itself** (#24) — the entire system is
-   markdown prompts, but CI only cuts releases: no markdown lint, no plugin-schema
-   validation, no link-check that referenced agents/skills exist, no golden-fixture
-   behavioral tests. Gate-contract regressions are caught only by manual audit. The
-   maintainer calls this the "highest-leverage gap" and "keystone."
-2. **Gates are stateless** (#27) — nothing records that a gate ran or what it
-   returned, so the PR-time hook can only ask blindly instead of "acceptance never ran
-   on this branch."
-3. **No real trend tracking** (#28) — deep-review emits a metrics table but nothing
-   persists snapshots across runs, so trends are manual.
-4. **The design-doc contract is undefined** (#29) — `/gate-design-review` consumes a
-   design doc whose required shape isn't specified.
-5. **PRODUCT.md was empty until now** — the project did not fully dogfood its own
-   init; this file is the first evidence-based pass and still needs the human review
-   the workflow prescribes.
+1. **Cost is unbudgeted and grows with the auditor roster, not the diff** (#130, #144,
+   #142) — a gate's price scales O(auditors), so a one-line change pays for a full
+   fan-out. No per-gate latency or cost budget is stated anywhere, which means nothing
+   can be over budget. Cost is the UX for a tool a developer runs per feature.
+2. **The merge unified the repo, not the flow** (M10) — `/work-on` and `/coach` answer
+   "what's next" from two state stores neither reads (#214), and the design-review
+   model differs between the story and epic pipelines for reasons that accumulated
+   rather than being decided (#210).
+3. **Contracts are pinned by prose, not by tests** (M9) — vocabulary and roster facts
+   are restated across surfaces and re-derived by regex over that prose (#176, #116,
+   #115). #211 and #213 were both this failure class reaching production behavior.
+4. **Two evidence stores, and CI blesses the thinner one** (#148) — the committed,
+   freshness-verified per-task evidence is the store no gate may read; the ephemeral
+   JSONL is the sanctioned contract. Defensible, but written down nowhere as a
+   decision.
+5. **Nothing closes the loop after ship** (M5) — the gates judge intent and execution,
+   then stop. Whether a shipped feature worked is not read back into anything.
 
 ## Business model
 

--- a/commands/studious-doctor.md
+++ b/commands/studious-doctor.md
@@ -14,8 +14,10 @@ Run each check and classify the result:
 - **Git repo** — run `git rev-parse --is-inside-work-tree`. If it fails: **Critical** — "not a git repo: gate ledger, merge-base diffing, and every gate that scopes to 'this branch' cannot function."
 - **`jq` present** — run `command -v jq`. If it fails: **Critical** — "jq missing: `gate-ledger record` silently no-ops (see `bin/gate-ledger`'s own comment: 'Degrades silently when git or jq is unavailable') — no gate verdict, and no `/work-on` flow position, will ever be recorded."
 - **`gh` authenticated** — run `gh auth status`. If `gh` itself is missing, or the command exits non-zero: **Important** — "gh missing or unauthenticated: `/backlog-priorities`, `/backlog-hygiene`, and the PR-time gate reminder's context all depend on it."
+- **`python3` present** — run `command -v python3`. If it fails: **Critical** — "python3 missing: every build script (`plan-lint`, `design-lint`, `verify`, `status-flip`, `evidence-capture`, `evidence-freshness`, `build-report`, `worktree-setup`) is a Python CLI, so `/plan` cannot lint a plan and `/build` cannot verify a single task — it would report success off nothing but the executor's own claim."
+- **`viva` available** — the plugin manifest's only declared dependency. Check the way `skills/design/SKILL.md` already reasons about it: look for the `viva` skill in this session's registered skill listing. If absent: **Critical** — "viva missing: `/design` and `/plan` both end in a human sign-off round they cannot run, so neither completes."
 
-If all three succeed, report each as **OK**.
+Report each check as **OK** when it succeeds. These five are the tools; the first three are gate-side, the last two are build-side — a Studious install missing either half degrades silently in exactly the way this command exists to catch.
 
 ## 2. Plugin health
 

--- a/scripts/check_references.py
+++ b/scripts/check_references.py
@@ -6,11 +6,13 @@ command's @agent-* reference). Standard library only.
 """
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
+MANIFEST = REPO / ".claude-plugin" / "plugin.json"
 SCAN_DIRS = ("commands", "agents", "skills", "reference")
 AGENT_RE = re.compile(r"@agent-([a-z0-9-]+)")
 # Recognized phrasings for a skill reference, e.g. "the `<name>` skill" (also
@@ -26,8 +28,22 @@ SKILL_RES = (
 # Curated rubric paths agents cite, e.g. `reference/security-checklist.md` or the
 # template `reference/idioms/<language>.md`. Angle-bracket placeholders are allowed.
 REFERENCE_RE = re.compile(r"reference/[A-Za-z0-9_./<>-]+\.md")
+def _declared_dependencies() -> set[str]:
+    """Plugins this one declares a dependency on. Their skills are legitimately
+    referenced by name and legitimately absent from `skills/` — derived from the
+    manifest rather than restated here, so declaring a dependency is the single
+    action that makes its skill citable."""
+    try:
+        return set(json.loads(MANIFEST.read_text(encoding="utf-8")).get("dependencies", []))
+    except (OSError, json.JSONDecodeError):
+        return set()  # validate_plugin.py owns manifest validity; don't double-report
+
+
 # Skills referenced by name but legitimately shipped elsewhere, not in this repo.
-EXTERNAL_SKILLS = {"web-design-guidelines"}
+# `web-design-guidelines` ships with Claude Code itself; the rest come from the
+# manifest's declared dependencies (`viva`, which /design, /plan, and the doctor's
+# tooling check all name).
+EXTERNAL_SKILLS = {"web-design-guidelines"} | _declared_dependencies()
 
 
 def find_broken(root: Path) -> list[str]:

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -16,14 +16,13 @@ scripts" is the whole shape.
 ## Input
 
 One optional argument: a path to a design-doc-shaped markdown file. Read it
-**semantically**, not by parsing a fixed heading grammar -- a hand-authored
-doc, a Studious worker's `docs/design/<slug>.md` (Problem & persona /
-Proposed design / User journey / Out of scope / Alternatives considered /
-Operational readiness / Open questions), and a future `/design`-produced doc
-(Intent / Experience / Contracts / Approach / Assumptions / Not doing /
-Risks) are three inputs to one reading step, not three parsers. Extract by
+**semantically**, not by parsing a fixed heading grammar. A hand-authored
+doc, a dispatched worker's `docs/design/<slug>.md`, and a `/design`-produced
+doc are three inputs to one reading step, not three parsers. Extract by
 *content* -- problem, proposed approach, user-facing journey, explicit
-exclusions, risks -- under whatever labels the doc actually uses.
+exclusions, risks -- under whatever labels the doc actually uses. Section
+names are deliberately not listed here: `reference/design-doc-contract.md`
+owns that set, and this step does not depend on it (#203).
 
 **Name what you extracted.** Before drafting anything, state in your own
 output which doc section supplied the problem, the approach, and any

--- a/skills/task-execution-discipline/SKILL.md
+++ b/skills/task-execution-discipline/SKILL.md
@@ -91,8 +91,11 @@ front of you rather than a feeling.
 NO DONE-MEANS CLAIM WITHOUT FRESH EVIDENCE IN THIS TASK'S EVIDENCE FIELD
 ```
 
-A task's status moves `todo` → `in-progress` → `PASS`/`FIX`/`REPLAN`/
-`ESCALATE`. That flip belongs to a script, never the executor's
+A task's status moves `todo` → `in-progress` → `PASS`/`REPLAN`/`ESCALATE`.
+`FIX` is not in that set: it is the failure routine's own transient action
+between attempts, and `scripts/status-flip` never writes it as a heading
+suffix (`skills/build/SKILL.md`, DESIGN.md's Vocabulary table). That flip
+belongs to a script, never the executor's
 self-report — "Judgment in the model, mechanics in scripts," and "Nothing
 signs off on itself" (`PRODUCT.md`, Product principles). `scripts/verify`
 independently re-runs every item after you're done regardless — that

--- a/tests/python/test_check_references.py
+++ b/tests/python/test_check_references.py
@@ -131,3 +131,27 @@ def test_reference_dir_siblings_resolve(tmp_path: Path) -> None:
         "analogue of `reference/design-doc-contract.md`; @agent-product-reviewer judges",
     )
     assert find_broken(tmp_path) == []
+
+
+def test_a_declared_dependencys_skill_is_not_a_broken_reference() -> None:
+    """`viva` ships in its own plugin, so `skills/viva/` will never exist here — but
+    `/design`, `/plan`, and `/studious-doctor`'s tooling check all name it, and the
+    manifest declares the dependency. Deriving the exemption from `dependencies`
+    rather than hardcoding it means declaring a dependency is the one action that
+    makes its skill citable, and dropping one immediately makes citations broken
+    again."""
+    import check_gate_independence  # noqa: F401  (proves scripts/ is importable)
+    from check_references import EXTERNAL_SKILLS, _declared_dependencies
+
+    declared = _declared_dependencies()
+    assert declared, ".claude-plugin/plugin.json declares no dependencies to derive from"
+    assert declared <= EXTERNAL_SKILLS
+    assert "web-design-guidelines" in EXTERNAL_SKILLS
+
+
+def test_an_undeclared_external_skill_is_still_broken(tmp_path: Path) -> None:
+    """The exemption is scoped to declared dependencies — a typo or an undeclared
+    plugin's skill must still fail."""
+    _write(tmp_path / "commands" / "x.md", "the `not-a-dependency` skill handles it")
+    errors = find_broken(tmp_path)
+    assert any("skills/not-a-dependency/ missing" in e for e in errors)


### PR DESCRIPTION
Five drift fixes across the docs every gate reads.

**#215 — `/studious-doctor` checked only the gate half.** Its tooling section
covered git, `jq`, and `gh` — all gate-side — while half the product had moved
in-box. Adds `python3` (every build script is a Python CLI, so without it `/plan`
cannot lint a plan and `/build` cannot verify a task; it would report success off
nothing but the executor's own claim) and `viva` (the manifest's only declared
dependency — `/design` and `/plan` both end in a sign-off round they cannot run
without it). The roster check in §2 already scaled, since it globs `skills/*/SKILL.md`.

That change made `scripts/check_references.py` fail, correctly: it validates skill
names against `skills/`, and `viva` will never be there. Rather than hardcoding a
second exemption beside `web-design-guidelines`, the allowlist now derives from the
manifest's `dependencies` — so declaring a dependency is the single action that makes
its skill citable, and dropping one makes the citations broken again the same day.

**#202 — `FIX` was listed as a task status.** `task-execution-discipline/SKILL.md` is
the shared text every fresh `/build` executor reads before writing a status, and it
listed `PASS`/`FIX`/`REPLAN`/`ESCALATE` where `skills/build/SKILL.md` and DESIGN.md
both say `FIX` is the failure routine's transient action and never a suffix. Maximally
reachable contradiction, one line.

**#203 — `/plan` described `/design`'s output with superseded section names.** Dropped
the list rather than restating it: `/plan` reads design docs by content, not by heading
grammar, so it never depended on the names — and a fifth copy of a set that
`reference/design-doc-contract.md` owns is what #211 was about.

**#204 — the anti-cleverness principle read as contradicting `/build`.** The principle
now names the test explicitly: residency, not vocabulary. Foreman/Executor/Inspector
are stage labels on a for-loop, ephemeral and stateless across tasks; what is ruled out
is a standing cast that persists between dispatches and accrues state.

**#147 — the known-problems list was four shipped features.** It named the
self-verification harness (#24), stateless gates (#27), metrics persistence (#28), and
the undefined design-doc contract (#29) as current problems. All four are closed, and
so is every other A-tier and M-tier issue the roadmap section listed — verified against
the tracker, not assumed. Every gate and review reads this file as ground truth, so
this was the discipline running on bad fuel.

Replaced with this cycle's real top five, each traceable to open work: gate cost
(#130/#144/#142), the flow the merge left unreconciled (M10), prose-pinned contracts
(M9), the two evidence stores (#148), and the missing post-ship loop (M5). The A/M/X
roadmap tiers are replaced by a pointer to the live milestones, plus the one durable
strategic point — X-tier is last because each item needs outcome data the earlier
milestones produce. Restating the roadmap here is exactly how it went stale.

Closes #147
Closes #202
Closes #203
Closes #204
Closes #215