### PR TITLE
feat: put both navigators on one store, and state the boundary between them

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ Two steps in the gate flow above — the `design doc` and `implement` boxes — 
 
 `/design` and `/plan` require [viva](https://github.com/jacquardlabs/viva) for their sign-off rounds — a declared dependency, so it installs with Studious.
 
+**`/work-on` or `/coach`?** They navigate the same flow and share the same state file, so a feature tracked by one is visible to the other — you can switch mid-feature and neither loses the thread. Pick by what you want done, not by where you are:
+
+| | `/work-on` | `/coach` |
+|---|---|---|
+| Does | Runs the next gate and records its verdict | Reads, then recommends one action |
+| Hands off by | Stopping and telling you what's next | Dispatching a build skill, only on your explicit yes |
+| Writes | The work file | Nothing at all |
+| Reach for it when | You want to advance the feature | You're re-entering cold, or a `PAUSED`/`ESCALATED` build left you unsure what to do |
+
 **No gate requires any of this.** `scripts/check_gate_independence.py` fails CI if a gate command, agent, driver, hook, or the ledger so much as invokes a build skill or reads a build artifact. What a gate may rely on is `reference/evidence-format.md`, which any executor can satisfy.
 
 ## CI mode (optional)

--- a/commands/work-on.md
+++ b/commands/work-on.md
@@ -22,8 +22,13 @@ Read PRODUCT.md at the project root first.
 | 4 | build | handoff — Studious steps back | implementation commits exist on the feature branch |
 | 5 | audit | `/gate-audit` | **PASS** at HEAD |
 | 6 | acceptance | `/gate-acceptance` | **SHIP** at HEAD |
+| 7 | finish | handoff — Studious steps back | the branch is closed out: scaffolding removed, evidence assembled, PR opened or the work merged/parked |
 
-After piece 6 the flow is `done`: recap the verdict trail and remind the user the PR is theirs to open (`gh pr create` — the PR-time hook reads the same ledger). Never create the PR yourself.
+Piece 4 covers planning as well as building — the route it hands to (`/plan` then `/build`) is two skills but one handoff, so there is no separate plan piece to stop at.
+
+After piece 7 the flow is `done`. Never open the PR yourself: piece 7 hands over, and whether the user runs `/finish` or does it by hand, the PR is theirs (`gh pr create` — the PR-time hook reads the same ledger).
+
+**This flow and `/coach`'s are the same flow.** `/coach` names the build skills at a finer grain (`/design`, `/plan`, `/build`, `/finish` as separate dispatches) because dispatching them one at a time is its job; this command groups them into handoff pieces because running the gates is its job. They read and write the same work file, so a feature tracked here is visible there and vice versa. The difference is posture, not position: **`/work-on` runs the gate and records the verdict; `/coach` only reads and recommends, and dispatches a build skill on explicit confirmation.** Use `/work-on` to advance a feature; use `/coach` when you're re-entering cold and want to be told where you are.
 
 For the gate pieces, run that slash command's workflow now, with the flow's context as its input — each gate owns its own logic and records its own verdict; don't restate or reimplement it here.
 
@@ -117,11 +122,23 @@ Log with `work-log --step audit --outcome "<verdict>" --phase "<phase>"`.
 
 Run `/gate-acceptance`, then:
 
-- **SHIP** → phase `done` — recap the trail and hand the PR to the user
+- **SHIP** → phase `finish`
 - **FIX AND RE-CHECK** → phase stays `acceptance`
 - **HOLD** → phase stays `acceptance`; surface the product concerns
 
 Log with `work-log --step acceptance --outcome "<verdict>" --phase "<phase>"`.
+
+### 7 · finish
+
+Both gates have passed. Closing out is a handoff, not a gate — there is no verdict to record here.
+
+Hand over and stop:
+
+- The verdict trail (every gate, its token, and the sha it was recorded at), and the pre-mortem register path.
+- Name `/finish` as the route that ships with this plugin: it assembles the evidence table, removes the branch-local scaffolding (`docs/design/<slug>.md`, `PLAN.md`), and ends in one of `MERGE` / `PR` / `KEEP` / `DISCARD`. Doing it by hand is equally fine — no gate cares which, and nothing downstream reads a `/finish` artifact.
+- The PR is the user's to open either way.
+
+Log `work-log --step finish --outcome HANDED-OFF --phase done`.
 
 ## Skips
 
@@ -132,7 +149,7 @@ Gates are optional by judgment — but that judgment is the user's. Skip a piece
 After the piece finishes, end with exactly this shape and nothing after it:
 
 ```text
-Flow: <slug> — piece <k>/6 (<name>): <outcome>.
+Flow: <slug> — piece <k>/7 (<name>): <outcome>.
 Next piece: <name> — <one clause on what it involves>.
 Run /work-on when you're ready, or just say "next".
 ```

--- a/skills/coach/SKILL.md
+++ b/skills/coach/SKILL.md
@@ -139,6 +139,17 @@ shows no result from it, the honest recommendation is the same step again,
 named as a resume rather than a fresh start. When a row and the work file
 disagree, say both out loud and follow the row.
 
+**When no row matches at all, the work file is what keeps you honest.** The
+commonest cause is a design doc that is branch-local by rule and simply not
+on this checkout — so `docs/design/*.md` is empty while the work file records
+phase `design-review` or later. Do not fall through to the first row and
+recommend `/gate-should-we-build`: a recorded decide verdict already rules
+that out, and re-recommending a gate the flow passed is the exact
+two-navigators-two-answers failure this store-sharing exists to end. Instead
+say which signals are missing, name the phase the work file records, and
+recommend the step that phase implies — flagged as derived from the work file
+rather than from repo evidence, so the human can see which it rests on.
+
 **Rough cost** comes from this fixed vocabulary — order-of-magnitude,
 honest about human attention vs. wall clock, never a fabricated number:
 

--- a/skills/coach/SKILL.md
+++ b/skills/coach/SKILL.md
@@ -21,9 +21,17 @@ sitting unacted-on. You assess pipeline state from evidence, recommend
 exactly one next action, and dispatch one of the four build skills only on the
 human's explicit confirmation. You never do the work yourself.
 
+**`/work-on` is the other entrypoint to this same flow, and you share its
+store.** It navigates the gate pieces and records verdicts; you read,
+recommend, and dispatch a build skill on confirmation. Same feature, same
+`.studious/work/<slug>.json`, different posture — so read that file (Step 1's
+first ledger signal) rather than re-deriving position from scratch, and never
+contradict it silently. A user who ran `/work-on` and then opens a fresh
+session with `/coach` must be told the same thing about where they are; the
+two giving different answers was the defect this closes (#214).
+
 Invocation is `/coach` — the same "single verb, slash-prefixed" convention
-as `/design`, `/plan`, `/build`, and `/finish` (closing `DESIGN.md`'s
-former risk #4). The trigger is an explicit ask only: the user says
+as `/design`, `/plan`, `/build`, and `/finish`. The trigger is an explicit ask only: the user says
 `/coach`, asks where they are in the pipeline or what to do next, or asks
 for help recovering a stuck loop. Never self-trigger on the mere presence
 of a verdict token earlier in the conversation — auto-triggering is the
@@ -44,20 +52,28 @@ paraphrase:
 
 | Signal | Read from | Establishes |
 |---|---|---|
-| Design docs | `docs/design/*.md` (Glob) | Which stories have designs. A `## Revision History` heading means at least one completed viva sign-off — viva appends it the moment a review round finishes (per `skills/plan/SKILL.md` Step 6). A doc without one exists but is unconfirmed from the repo alone. |
+| Design docs | `docs/design/*.md` (Glob) | Which stories have designs. A `## Revision History` heading means at least one viva round *finished* — not that it was approved. viva appends the same heading on a `REVISED` round, so this signal cannot tell a signed-off doc from a revised one (#198). Treat it as "a round happened," never as sign-off, and see the note below. |
 | Plan | `PLAN.md` at the repo root — a filesystem read, never `git ls-files` (a project that treats `/PLAN.md` as disposable scaffolding gitignores it, so an index read misses a real plan) | A plan exists; its `### Task N — <title>` blocks. |
 | Task statuses | Heading suffixes ` [PASS]` / ` [REPLAN]` / ` [ESCALATE]` — `scripts/status-flip`'s own `SUFFIX_RE` grammar, written only by that script, never the model | Which tasks closed, which paused or escalated. No suffix means not yet terminal (`todo` / `in-progress`). |
 | Failure reasons | `git log` for the `status-flip: task <N> -> REPLAN\|ESCALATE` commit — the Foreman's `--reason` lives in that commit's body, not in `PLAN.md` | The finding `/design` revision mode (or the human's block revision) needs, quoted verbatim. |
 | Evidence & reports | `docs/jig/evidence/<date>-<task>/`, `docs/jig/reports/` | Which tasks captured evidence; whether a story already closed out via `/finish` (a dated build report). |
+| Flow position | `command -v gate-ledger`; if found, `gate-ledger work-list` and match the row whose branch equals the current branch, then `gate-ledger work-get --slug "<that-slug>"` | Whether `/work-on` is already tracking this feature, and where it thinks the flow is: `.phase`, and `.history`'s per-step outcomes. **Read this first among the ledger signals.** It is the same store `/work-on` writes — one flow, two entrypoints — so a feature in flight there is visible here, and skipping it is how the two navigators used to give different answers to the same question (#214). No matching row means this branch isn't under `/work-on`; that is ordinary, not an error. |
 | Gate verdicts | `command -v gate-ledger`; if found, `gate-ledger gate-get --branch <branch>` (recorded verdict history) and `gate-ledger status` | Which gates actually recorded verdicts. Not found: the *ledger* is unreadable, which says nothing about whether the gates exist — they ship in this same plugin. State "`gate-ledger` not on `PATH` — can't read recorded verdicts; run `/studious-doctor`" and treat gates per the degradation rules below. Never assume one passed, and never conclude a gate is unavailable. |
 | Conversation | Session verdicts stated earlier in this conversation (`BUILT`/`PAUSED`/`ESCALATED`, `DESIGNED`/`NEEDS RESEARCH`/`REVISED`, `PLAN READY`/`DESIGN GAP`/`TOO BIG`) | Fills only the gaps the repo cannot show — e.g. a `NEEDS RESEARCH` verdict that deliberately wrote nothing to disk. |
 
-Three hard rules govern the read:
+Four hard rules govern the read:
 
 - **Repo evidence outranks conversation claims.** A conflict — the
   conversation says `BUILT`, `PLAN.md` shows an unsuffixed task — is
   reported by name, never silently resolved in either direction, and the
   recommendation follows the repo. The claim is never papered over.
+- **Repo evidence outranks the work file too, and the same way.** The work
+  file records what a step *reported*; the repo shows what is *there*. When
+  they disagree — phase `build` with no implementation commits, phase `done`
+  with an unsuffixed task — say so by name and follow the repo, exactly as
+  `commands/work-on.md`'s own "evidence first" check does. Never silently
+  correct the file: `/work-on` owns writing it, and this skill writes
+  nothing.
 - **Vocabulary discipline.** Task-status `[PASS]` (a `PLAN.md` heading
   suffix, per task, script-written) and studious's gate verdict `PASS` (a
   gate-ledger record, per gate) are different concepts sharing a word.
@@ -68,6 +84,22 @@ Three hard rules govern the read:
   one plan-shaped file, an unclear story slug — **ask the human once, by
   name**, the same escalation shape `skills/plan/SKILL.md`'s Input step
   already uses. Never pick one silently.
+
+**`## Revision History` is a weak signal, and the routing is what makes that
+safe (#198).** viva appends the heading when a round *finishes*, whether the
+verdict was approve or revise, so a revised-but-not-signed-off doc looks
+identical to a signed-off one from the repo alone. There is no first-party
+sign-off signal to read; adding one is a viva contract change, not something
+this skill can do.
+
+What contains the ambiguity is the routing table below: a doc with the
+heading but no recorded design-review verdict routes to **recommending the
+human run `/gate-design-review`** — never to a blind `/plan` dispatch. So the
+worst case of misreading this signal is one human-run gate that was going to
+be recommended anyway. That is the deliberate guard, not an accident of
+ordering: never add a row that treats the heading as sufficient to skip the
+gate, and if viva ever publishes a real sign-off signal, read that instead
+and this note goes away.
 
 **The assessment prints before the recommendation**: the state, then the
 evidence line behind each claim — so a misread fails visibly, in front of
@@ -95,6 +127,17 @@ Routing, observed state → the one action:
 | Every task ` [PASS]`; audit/acceptance not yet recorded (or the ledger is unreadable) | Recommend the human run `/gate-audit` (then `/gate-acceptance`) | The branch name |
 | Every task ` [PASS]`; both gates recorded as passed | Dispatch `/finish` | Nothing beyond the invocation — `/finish` reads `PLAN.md` and the evidence folders itself |
 | Dated build report exists for this story / branch closed out | Nothing to dispatch — state it and stop | — |
+
+**What the work file adds to this table.** It never overrides a row — the
+rows key on repo evidence and that stays the authority. It supplies three
+things the repo can't: the feature's slug and title (use them, rather than
+inventing a name for the story); corroboration, so a row reached with the
+work file agreeing is worth stating as such; and the fact that a handoff
+already happened — a `HANDED-OFF` outcome on the `design`, `build`, or
+`finish` step means `/work-on` already handed that piece over, so if the repo
+shows no result from it, the honest recommendation is the same step again,
+named as a resume rather than a fresh start. When a row and the work file
+disagree, say both out loud and follow the row.
 
 **Rough cost** comes from this fixed vocabulary — order-of-magnitude,
 honest about human attention vs. wall clock, never a fabricated number:
@@ -154,10 +197,13 @@ after `BUILT`."
 ## Does no work itself
 
 The coach's tool use is read-only, always: Read/Glob/Grep, `git log`,
-`git status`, `gate-ledger gate-get`/`status`, `command -v`. It never
-writes or edits a file (no code, no docs, no state file of its own), never
-flips a status, never records a verdict, never runs a gate, a lint, a
-test, or a build script, and never commits. Anything that looks like work
+`git status`, `command -v`, and `gate-ledger`'s four *read* verbs —
+`gate-get`, `status`, `work-list`, `work-get`. Never `work-set`, never
+`work-log`, never `record`: sharing `/work-on`'s store means reading it, not
+writing it, and a coach that corrected the work file would be doing the work
+it exists not to do. It never writes or edits a file (no code, no docs, no
+state file of its own), never flips a status, never records a verdict, never
+runs a gate, a lint, a test, or a build script, and never commits. Anything that looks like work
 is the dispatched skill's job or the human's.
 
 The coach also has **no verdict enum of its own** — it is not a pipeline

--- a/tests/jig/test_coach_skill.py
+++ b/tests/jig/test_coach_skill.py
@@ -206,7 +206,21 @@ class TestCoachSkillBody(unittest.TestCase):
     def test_assessment_reads_the_repo_first(self) -> None:
         self.assertPhraseIn("Read the repo before you believe anything.")
         self.assertIn("`docs/design/*.md` (Glob)", self.body)
-        self.assertPhraseIn("`## Revision History` heading means at least one completed viva sign-off")
+
+    def test_revision_history_is_not_read_as_sign_off(self) -> None:
+        # #198: viva appends the same heading on a REVISED round, so the heading
+        # cannot distinguish signed-off from revised. This used to assert the
+        # opposite ("means at least one completed viva sign-off"), which is the
+        # false-positive the issue names. The heading is now a weak signal, and
+        # what makes that safe is the routing, which is asserted below.
+        self.assertPhraseIn("means at least one viva round *finished* — not that it was approved")
+        self.assertPhraseIn('Treat it as "a round happened," never as sign-off')
+
+    def test_the_weak_sign_off_signal_is_contained_by_routing(self) -> None:
+        # The guard is that a heading-present/verdict-absent doc routes to a
+        # human-run gate, never a blind /plan dispatch — so the worst case of
+        # misreading it is a gate that was going to be recommended anyway.
+        self.assertPhraseIn("never add a row that treats the heading as sufficient to skip the gate")
 
     def test_plan_read_is_filesystem_never_git_ls_files(self) -> None:
         # jig's own .gitignore excludes /PLAN.md, so an index read misses
@@ -358,10 +372,15 @@ class TestCoachSkillBody(unittest.TestCase):
         )
 
     def test_coach_does_no_work_itself(self) -> None:
+        # The tool list grew the work-file read verbs when the two navigators were
+        # put on one store (#214). It must stay read-only in the same breath: the
+        # four reads named, the three writes explicitly refused.
         self.assertPhraseIn(
-            "read-only, always: Read/Glob/Grep, `git log`, `git status`, "
-            "`gate-ledger gate-get`/`status`, `command -v`"
+            "read-only, always: Read/Glob/Grep, `git log`, `git status`, `command -v`, "
+            "and `gate-ledger`'s four *read* verbs — `gate-get`, `status`, `work-list`, "
+            "`work-get`"
         )
+        self.assertPhraseIn("Never `work-set`, never `work-log`, never `record`")
         self.assertPhraseIn("never writes or edits a file")
         self.assertPhraseIn(
             "never flips a status, never records a verdict, never runs a gate, "

--- a/tests/python/test_navigator_shared_store.py
+++ b/tests/python/test_navigator_shared_store.py
@@ -1,0 +1,100 @@
+"""Two navigators, one store (issue #214).
+
+The merge shipped `/work-on` and `/coach` into one plugin. Both answer "what's next";
+neither read the other's state. `/work-on` wrote `work-set`/`work-log` and read gate
+verdicts; `/coach` re-derived position from `PLAN.md` suffixes, `git log`, and design
+docs, and its signal table never called `work-get` — so a feature actively tracked in a
+work file was invisible to the coach, which could recommend a step `/work-on` had
+already logged. Their flows also differed in shape: `/work-on` had no finish piece and
+ended at "the PR is yours"; `/coach` ended at `/finish`.
+
+Ratified: keep both entrypoints — the postures are genuinely different, one runs the
+gate and writes, the other only reads and dispatches on confirmation — and share the
+store. These tests pin the parts of that which are checkable from the prose: that the
+coach reads the store, that it still writes nothing, and that both files state the
+boundary rather than leaving a user to infer it.
+
+Static text checks — no live model, no subprocess.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+WORK_ON = REPO_ROOT / "commands" / "work-on.md"
+COACH = REPO_ROOT / "skills" / "coach" / "SKILL.md"
+README = REPO_ROOT / "README.md"
+
+#: gate-ledger's mutating verbs, matched only as a backtick-opened command span. The
+#: coach's prose legitimately uses "record" as a noun ("a gate-ledger record, per gate"),
+#: so a bare word match would fire on the vocabulary-discipline rule it must keep.
+LEDGER_WRITE_RE = re.compile(r"`(?:gate-ledger )?(work-set|work-log|record)\b")
+
+
+def test_coach_reads_the_work_file() -> None:
+    """The defect itself: the coach's evidence read never touched the store `/work-on`
+    writes."""
+    text = COACH.read_text(encoding="utf-8")
+    assert "work-get" in text, "the coach still does not read the work file"
+    assert "work-list" in text, "the coach cannot resolve which work file is this branch's"
+
+
+def test_coach_reads_the_store_before_the_other_ledger_signals() -> None:
+    """Ordering matters for a table declared 'cheapest first' whose reader stops at the
+    first sufficient answer: flow position has to come before gate verdicts, or the
+    coach re-derives what the file already knows."""
+    text = COACH.read_text(encoding="utf-8")
+    assert text.index("work-list") < text.index("gate-get")
+
+
+def test_coach_still_writes_nothing() -> None:
+    """Sharing the store means reading it. A coach that corrected the work file would
+    be doing the work it exists not to do — and `/work-on` owns that file."""
+    body = COACH.read_text(encoding="utf-8")
+    prohibition = re.search(r"Never `work-set`, never\n`work-log`, never `record`", body)
+    assert prohibition, "the coach's read-only ledger boundary is no longer stated"
+
+    # Every invocation-shaped mention must sit inside the prohibition, never read as an
+    # instruction to run one. Asserting a match count first, so a regex that stops
+    # matching can't turn the loop below into a silent pass.
+    matches = list(LEDGER_WRITE_RE.finditer(body))
+    assert len(matches) == 3, f"expected the three write verbs named once each, got {len(matches)}"
+    for match in matches:
+        window = body[max(0, match.start() - 120) : match.end() + 40]
+        assert "never" in window.lower(), (
+            f"the coach names `{match.group(1)}` outside its prohibition: ...{window}..."
+        )
+
+
+def test_both_navigators_model_the_same_flow_end() -> None:
+    """`/work-on` stopped at acceptance and called the flow done; `/coach` continued to
+    `/finish`. Same flow, two different shapes."""
+    work_on = WORK_ON.read_text(encoding="utf-8")
+    assert "| 7 | finish |" in work_on, "/work-on has no finish piece"
+    assert "/finish" in work_on, "/work-on never names the route that closes a branch"
+    assert "piece <k>/7" in work_on, "the closing block still counts the old six pieces"
+
+
+def test_work_on_explains_why_there_is_no_plan_piece() -> None:
+    """The other shape difference. `/coach` dispatches `/plan` and `/build` separately;
+    `/work-on` groups them into one handoff. That is a defensible difference in
+    granularity, but it has to be said, or it reads as an omission."""
+    work_on = WORK_ON.read_text(encoding="utf-8")
+    assert re.search(r"no separate plan piece", work_on)
+
+
+def test_the_posture_boundary_is_stated_in_all_three_places() -> None:
+    """A user meeting two commands that answer the same question needs the difference
+    written down where they'll meet it — in each prompt, and in the README."""
+    for path in (WORK_ON, COACH, README):
+        text = path.read_text(encoding="utf-8")
+        names_both = "/work-on" in text and "/coach" in text
+        assert names_both, f"{path.name} does not name both navigators"
+
+    work_on = WORK_ON.read_text(encoding="utf-8")
+    coach = COACH.read_text(encoding="utf-8")
+    assert "same flow" in work_on
+    assert "same" in coach and "store" in coach

--- a/tests/python/test_navigator_shared_store.py
+++ b/tests/python/test_navigator_shared_store.py
@@ -86,6 +86,19 @@ def test_work_on_explains_why_there_is_no_plan_piece() -> None:
     assert re.search(r"no separate plan piece", work_on)
 
 
+def test_coach_handles_the_no_row_matches_case() -> None:
+    """The routing table keys on repo signals, and every row assumes at least one is
+    present. A design doc is branch-local by rule, so on a checkout without it the
+    work file can say `design-review` while no row matches — and falling through to
+    the first row would re-recommend `/gate-should-we-build` for a feature that
+    already passed it. That is precisely the two-navigators-two-answers failure this
+    change exists to end, so the fallthrough is named and forbidden."""
+    text = COACH.read_text(encoding="utf-8")
+    assert "When no row matches at all" in text
+    assert "Do not fall through to the first row" in text
+    assert "a recorded decide verdict already rules" in text
+
+
 def test_the_posture_boundary_is_stated_in_all_three_places() -> None:
     """A user meeting two commands that answer the same question needs the difference
     written down where they'll meet it — in each prompt, and in the README."""


### PR DESCRIPTION
The merge shipped two commands that answer "what's next" into one plugin, reading
different state and unaware of each other. `/work-on` wrote `work-set`/`work-log` and
read gate verdicts; `/coach` re-derived position from `PLAN.md` suffixes, `git log`,
and design docs — its signal table never called `work-get`, so a feature actively
tracked in a work file was invisible to it, and it could recommend a step `/work-on`
had already logged. Their flows also differed in shape: `/work-on` had no finish piece
and ended at "the PR is yours"; `/coach` ended at `/finish`.

Ratified: **two navigators, one store.** Keeping both is right — the postures are
genuinely different, and collapsing them would lose that. `/work-on` runs the gate and
records the verdict; `/coach` only reads, recommends one action, and dispatches a build
skill on explicit confirmation. What was wrong was the two of them disagreeing.

- `/coach`'s signal table reads `work-list` + `work-get` **first among the ledger
  signals**, before gate verdicts — a table declared "cheapest first" whose reader
  stops at the first sufficient answer has to see flow position before it re-derives
  it. A fourth hard rule governs conflicts, mirroring `/work-on`'s own evidence-first
  check: repo evidence outranks the work file, say so by name, follow the repo — and
  never silently correct the file, because `/work-on` owns writing it.
- Sharing the store means reading it. The tool list now names `gate-ledger`'s four
  read verbs and refuses the three writes in the same breath.
- `/work-on` gains piece 7, `finish`, so both model the same flow end. It states why
  there is no separate plan piece: piece 4 hands `/plan` and `/build` over together —
  two skills, one handoff — which is a real difference in granularity rather than an
  omission, and reads as one only when unsaid.
- The posture boundary is written where a user meets it: both prompts and the README,
  as a four-row table keyed on what you want done rather than where you are.

**Also closes #198.** `/coach` read a `## Revision History` heading as "at least one
completed viva sign-off". viva appends the same heading on a `REVISED` round, so a
revised-but-not-signed-off doc read as signed off. There is no first-party sign-off
signal to switch to — that is a viva contract change, not something this skill can do —
so the ratification is the other option the issue offers: the heading is documented as
a weak signal, and the routing is what makes it safe. A heading-present,
verdict-absent doc routes to recommending a human-run `/gate-design-review`, never a
blind `/plan` dispatch, so the worst case of misreading it is a gate that was going to
be recommended anyway. That is now stated as a deliberate guard with a standing
instruction never to add a row that treats the heading as sufficient to skip the gate.

`tests/python/test_navigator_shared_store.py` pins what is checkable from the prose:
the coach reads the store, reads it before the other ledger signals, still names no
write verb outside its own prohibition, and both files state the boundary. Two existing
`tests/jig/test_coach_skill.py` assertions pinned the old wording — the sign-off one
asserted exactly the false-positive #198 filed — and were updated to the corrected
semantics rather than deleted.

Closes #198
Closes #214