### PR TITLE
fix: drain the design-doc citations that outlive the docs they name

### DIFF
--- a/scripts/_gitutil.py
+++ b/scripts/_gitutil.py
@@ -19,7 +19,7 @@ dependency-free import.
 Not a package, not importable from outside `scripts/` — each script adds
 its own directory to `sys.path` before importing this (see any script's
 top for the pattern). Deliberately dependency-free (standard library only)
-so each script stays a standalone CLI tool per `docs/design/build-scripts.md`.
+so each script stays a standalone CLI tool.
 """
 from __future__ import annotations
 

--- a/scripts/_planparse.py
+++ b/scripts/_planparse.py
@@ -13,7 +13,7 @@ apart on where a task block ends or what a tier parenthetical means.
 Not a package, not importable from outside `scripts/` — each script adds
 its own directory to `sys.path` before importing this (see any script's
 top for the pattern). Deliberately dependency-free (standard library only)
-so each script stays a standalone CLI tool per `docs/design/build-scripts.md`.
+so each script stays a standalone CLI tool.
 """
 from __future__ import annotations
 

--- a/scripts/build-report
+++ b/scripts/build-report
@@ -5,8 +5,7 @@
 `docs/jig/reports/YYYY-MM-DD-<story-slug>-build-report.md` -- same class
 and naming shape as studious's own dated review reports
 (`docs/studious/<kind>-reviews/YYYY-MM-DD-<kind>-review.md`), reusing an
-established convention rather than inventing a new report shape (see
-docs/design/finish-skill.md, Step 5).
+established convention rather than inventing a new report shape.
 
 This script only performs the mechanical write of already-assembled
 content -- it does not draft, summarize, or judge the report body itself;

--- a/scripts/check_references.py
+++ b/scripts/check_references.py
@@ -28,6 +28,49 @@ SKILL_RES = (
 # Curated rubric paths agents cite, e.g. `reference/security-checklist.md` or the
 # template `reference/idioms/<language>.md`. Angle-bracket placeholders are allowed.
 REFERENCE_RE = re.compile(r"reference/[A-Za-z0-9_./<>-]+\.md")
+#: Directories holding files that outlive any branch. A file here may not cite a
+#: *specific* design doc, because design docs are branch-local and deleted at
+#: closeout (#219) — the citation is dangling the moment the branch merges. The
+#: bare directory (`docs/design/`, `docs/design/<slug>.md` as a template) is fine
+#: and common: that is the producer's output path, not a reference to one doc.
+DURABLE_DIRS = ("scripts", "skills", "commands", "agents", "reference", "bin", "workflows", "tests")
+#: A concrete filename under a disposable doc tree, as opposed to the bare
+#: directory or the `<slug>` placeholder form, both of which are legitimate.
+DISPOSABLE_CITATION = re.compile(r"docs/design/(?!<)([A-Za-z0-9_-]+\.md)")
+
+
+def find_disposable_citations(root: Path) -> list[str]:
+    """Durable files citing a design doc that cannot survive its branch (#233).
+
+    Thirty-three of these accumulated before anyone noticed, every one reading as
+    load-bearing rationale ("per the build-scripts design doc") that a reader
+    following it would find missing — unable to tell whether the claim was ever
+    true. `check_references.py` did not catch them because it validates only
+    `@agent-*`, skill names, and `reference/*.md`, and scans only three
+    directories.
+    """
+    errors: list[str] = []
+    for sub in DURABLE_DIRS:
+        base = root / sub
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*")):
+            if not path.is_file() or path.suffix in {".png", ".jpg", ".gif"}:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            rel = path.relative_to(root)
+            errors.extend(
+                f"{rel} cites docs/design/{name}, a branch-local design doc that is "
+                f"deleted at closeout — attribute the claim to the issue, the "
+                f"pre-mortem register, or state it inline (#233)"
+                for name in sorted(set(DISPOSABLE_CITATION.findall(text)))
+            )
+    return errors
+
+
 def _declared_dependencies() -> set[str]:
     """Plugins this one declares a dependency on. Their skills are legitimately
     referenced by name and legitimately absent from `skills/` — derived from the
@@ -87,13 +130,16 @@ def find_broken(root: Path) -> list[str]:
 
 
 def main() -> int:
-    errors = find_broken(REPO)
+    errors = find_broken(REPO) + find_disposable_citations(REPO)
     if errors:
         print("Reference check FAILED:")
         for e in errors:
             print(f"  - {e}")
         return 1
-    print("Reference check passed: all @agent-*, skill, and reference/ paths resolve.")
+    print(
+        "Reference check passed: all @agent-*, skill, and reference/ paths resolve, "
+        "and no durable file cites a disposable design doc."
+    )
     return 0
 
 

--- a/scripts/evidence-capture
+++ b/scripts/evidence-capture
@@ -5,8 +5,7 @@ Writes a task's verification artifacts (from `verify` and/or
 `worktree-setup`) to `docs/jig/evidence/<date>-<task>/`, alongside a
 manifest recording a timestamp, the commit SHA the evidence was checked
 against, and which script produced each artifact — the paper trail
-`/gate-audit` and a human read afterward (docs/design/build-scripts.md,
-"Proposed design").
+`/gate-audit` and a human read afterward.
 
 Freshness rule (this story's acceptance criteria: "timestamp >= last code
 commit"): an evidence folder can only exist if it was provably produced

--- a/scripts/evidence-freshness
+++ b/scripts/evidence-freshness
@@ -8,7 +8,7 @@ evidence folder (`docs/jig/evidence/<date>-<task>/`, written by
 reproduce issue #44's bug shape one layer up (a producing step that commits
 *after* writing the artifact it's timestamping against makes a "must be >=
 current HEAD" check structurally unpassable for every folder but the most
-recent). See docs/design/finish-skill.md, Step 1.
+recent).
 
 Two checks per folder, both floored on the manifest's own `commit_sha` /
 `commit_timestamp`, never a moving target:

--- a/scripts/plan-lint
+++ b/scripts/plan-lint
@@ -64,7 +64,7 @@ a git repository (paths can't be resolved), or it has zero `### Task`
 headings at all (nothing to lint -- a fail-closed stance, never a vacuous
 PASS, matching `verify`'s own refusal on an empty items list).
 
-Out of scope (see docs/design/plan-lint.md "Out of scope"): the `/plan`
+Out of scope: the `/plan`
 skill itself; issue #23 (the Not-here-follow-ups heading-*level* fix) and
 issue #13 (UI-probe mechanization); any semantic/quality judgment; CI
 wiring; auto-fixing anything found; validating `/build`'s own status-suffix

--- a/scripts/status-flip
+++ b/scripts/status-flip
@@ -3,8 +3,7 @@
 
 Writes a task's terminal status back onto its own `### Task <label>` heading
 in a `PLAN.md`-shaped file, and commits that annotation — the mechanical
-write `docs/design/build-skill.md`'s "Status-flip persistence" section calls
-for so `DESIGN.md`'s Vocabulary table ("flipped by scripts only, never the
+write that makes `DESIGN.md`'s Vocabulary table ("flipped by scripts only, never the
 model") and `PRODUCT.md`'s "Judgment in the model, mechanics in scripts"
 principle are true in fact, not just in spirit. The Foreman decides *what*
 status a task reaches (PASS is derived here from `verify`'s own

--- a/scripts/verify
+++ b/scripts/verify
@@ -3,8 +3,8 @@
 
 Independently re-runs a task's Done-means items — one PASS/FAIL per item,
 never a single suite-level boolean — instead of trusting the executor's
-claim that they're satisfied (docs/design/build-scripts.md, "Proposed
-design"; PRODUCT.md's "Nothing signs off on itself" principle). Takes its
+claim that they're satisfied (PRODUCT.md's "Nothing signs off on itself"
+principle). Takes its
 item list from exactly one of two sources:
 
 - `--items <json>`: an already-extracted item list (a small JSON document

--- a/scripts/worktree-setup
+++ b/scripts/worktree-setup
@@ -7,9 +7,7 @@ task is dispatched. A non-zero baseline is a **dirty baseline**: this script
 surfaces the failure, frames it explicitly as pre-existing (not caused by
 this build session), leaves the worktree in place for inspection, and exits
 non-zero — `/build` must stop before task 1 rather than let a fresh
-executor start against an ambiguous starting point
-(docs/design/build-scripts.md, "Proposed design" / this story's acceptance
-criteria).
+executor start against an ambiguous starting point.
 
 Colliding with an existing branch or worktree at the given path fails loudly
 with the exact remediation command, rather than silently reusing stale

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -144,7 +144,7 @@ may appear anywhere in the block. No `Risk:` line means `LOW` — see Cadence.
    that trailing section into the preceding task card (a real bug the
    project's own M0 dogfood surfaced); read for meaning and don't reproduce
    it. The `##` level itself is not the bug and stays as-is (story
-   `plan-skill`, issue #23): `docs/design/plan-skill.md`'s Step 6 verified,
+   `plan-skill`, issue #23): that story verified,
    against the actually-installed viva, that a `####` level would be
    *coarser* than this rule's own level 1–3 boundary and nest inside the
    preceding task instead — this parsing rule, and `scripts/plan-lint`'s
@@ -238,8 +238,8 @@ For each task block, in order:
    model — the same model named in your own system prompt — so state it
    plainly as `inherited: <model>`. If the model genuinely can't be
    determined at all, state it plainly as `unavailable` — a third case
-   beside `override`/`inherited`, per the design's own documented
-   degradation path (`docs/design/replay-bundle.md`). Name this before you
+   beside `override`/`inherited` — a documented degradation path, not an
+   improvisation at capture time. Name this before you
    launch the subagent, the same plain-statement discipline step 1's
    load-bearing-set computation already uses ("state the computed set
    plainly before proceeding").
@@ -426,8 +426,8 @@ For each task block, in order:
      recorded `unavailable` for this attempt, the bundle is still
      assembled and written the same way — `model` recorded as
      `unavailable`, never a reason for this call to refuse the whole
-     `evidence-capture` capture (the design's own Failure path,
-     `docs/design/replay-bundle.md`). The replay
+     `evidence-capture` capture — a documented failure path, not a
+     judgment call made here. The replay
      harness itself (issue #41) and issue #33's richer identity fields
      (`run_id`/`step_id`/`parent_step_id`/`skill`/`role`/`routing_reason`)
      stay out of scope here — none of those exist in this session model

--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -130,7 +130,7 @@ until now:
 - **Not-here follow-ups** — `PLAN.md`'s own `## Not-here follow-ups`
   section (bulleted, one line each). Read it directly. The `##` level is
   confirmed safe, not just carried forward (story `plan-skill`, issue #23):
-  `docs/design/plan-skill.md`'s Step 6 re-verified this against the
+  that story re-verified this against the
   actually-installed viva, including the `Revision History`-collision case
   a bare heading-level read would miss — `/plan`'s own viva invocation
   passes an explicit `--split-on` rather than relying on auto-detect alone.

--- a/tests/jig/_vocabulary.py
+++ b/tests/jig/_vocabulary.py
@@ -70,8 +70,8 @@ DESIGN_VOCABULARY_CONCEPTS = frozenset({"/design verdict"})
 # /finish's verdict enum (the coach dispatches /finish but never consumes
 # its MERGE/PR/KEEP/DISCARD outcome), the inspector's, or the risk tags
 # (a /plan-to-/build contract the coach never inspects). The coach has no
-# verdict enum of its own by design (docs/design/coach-skill.md, Out of
-# scope) -- there is no coach-owned row to derive.
+# verdict enum of its own by design (`skills/coach/SKILL.md` states it: "no
+# verdict enum of its own") -- there is no coach-owned row to derive.
 COACH_VOCABULARY_CONCEPTS = frozenset(
     {"/design verdict", "/plan verdict", "/build task status", "/build session verdict"}
 )

--- a/tests/jig/fixtures/plan-lint/broken-plan.md
+++ b/tests/jig/fixtures/plan-lint/broken-plan.md
@@ -1,6 +1,6 @@
 # Plan: plan-lint broken fixture
 
-Deliberately broken, per docs/design/plan-lint.md's "Required demonstration"
+Deliberately broken, per the plan-lint story's "Required demonstration"
 -- one distinct violation category per task, so a single `scripts/plan-lint`
 run against this file demonstrates all eight in one pass. Not a real build
 plan; never run through `/build`. Task 8 exists only to make Task 7

--- a/tests/jig/fixtures/plan-lint/clean-plan.md
+++ b/tests/jig/fixtures/plan-lint/clean-plan.md
@@ -1,7 +1,7 @@
 # Plan: plan-lint clean fixture
 
 This is a structural fixture for `scripts/plan-lint`'s own regression tests
-and this story's required demonstration (docs/design/plan-lint.md,
+and this story's required demonstration (
 "Operational readiness") -- not a real build plan, and never run through
 `/build`. Its `Read first:` and tier-method paths resolve against files
 that actually exist in this repo, so plan-lint's checks run for real

--- a/tests/jig/test_build_report.py
+++ b/tests/jig/test_build_report.py
@@ -1,7 +1,7 @@
 """Regression tests for scripts/build-report (story finish-skill, issue #20).
 
 Checks this story's acceptance criteria mechanically
-(`docs/design/finish-skill.md`, Step 5):
+(the finish-skill story, Step 5):
 
 1. Happy path: writes `docs/jig/reports/YYYY-MM-DD-<slug>-build-report.md`
    with the caller-supplied content copied in verbatim -- this script is a

--- a/tests/jig/test_build_skill.py
+++ b/tests/jig/test_build_skill.py
@@ -284,7 +284,7 @@ class TestBuildSkillBody(unittest.TestCase):
 
     def test_dispatch_model_names_unavailable_case_beside_override_and_inherited(self) -> None:
         # Task 3 (issue #34 follow-up, /gate-acceptance SHOULD FIX): the
-        # design doc's own Failure path (docs/design/replay-bundle.md) names
+        # design's own documented Failure path names
         # a third dispatch-model case -- when the model genuinely can't be
         # determined at all, the Foreman states it plainly as `unavailable`,
         # immediately beside the existing `override`/`inherited` cases.
@@ -428,8 +428,8 @@ class TestBuildSkillBody(unittest.TestCase):
         # Task 3: step 7's bundle-assembly instruction must reference the
         # unavailable case so a Foreman hitting it still assembles and
         # writes the bundle -- model recorded as `unavailable`, never a
-        # reason to refuse the whole evidence-capture call (the design
-        # doc's own Failure path, docs/design/replay-bundle.md).
+        # reason to refuse the whole evidence-capture call (a
+        # documented Failure path, not a judgment call made there).
         self.assertPhraseIn(
             "If step 2.2 recorded `unavailable` for this attempt, the "
             "bundle is still assembled and written the same way"

--- a/tests/jig/test_coach_skill.py
+++ b/tests/jig/test_coach_skill.py
@@ -4,8 +4,8 @@ Standard library only, matching test_build_skill.py's convention. Run with:
 
     uv run --no-project python3 -m unittest discover -s tests -v
 
-Checks this story's acceptance criteria and docs/design/coach-skill.md's
-commitments mechanically, by inspecting the prose a `/coach` session
+Checks this story's acceptance criteria and its design commitments
+mechanically, by inspecting the prose a `/coach` session
 actually reads (the same approach the other four skills' test modules
 already take):
 
@@ -192,7 +192,7 @@ class TestCoachSkillBody(unittest.TestCase):
         )
 
     def test_coach_owns_no_verdict_enum_of_its_own(self) -> None:
-        # docs/design/coach-skill.md, Out of scope: the coach is not a
+        # Out of scope by design: the coach is not a
         # pipeline judgment point; its closed vocabulary is the action set.
         self.assertPhraseIn("no verdict enum of its own")
         self.assertPhraseIn("It reads the other skills' verdicts; it never emits one.")

--- a/tests/jig/test_design_lint.py
+++ b/tests/jig/test_design_lint.py
@@ -1,7 +1,6 @@
 """Regression tests for scripts/design-lint (story design-lint, issue #9;
-section-name schema reconciled to studious's `reference/design-doc-
-contract.md` at story design-lint-reconcile,
-docs/design/design-lint-reconcile.md).
+section-name schema reconciled to `reference/design-doc-contract.md`,
+which is the sole authority for the section set -- see #211).
 
 Exercises the script as a black box (subprocess against the real
 executable), matching `test_verify.py`/`test_evidence_capture.py`'s own
@@ -9,8 +8,8 @@ convention, never importing its internals directly. Each violation fixture
 is `CLEAN_DOC` with exactly one targeted change, so a failure names the
 *specific* element this story's acceptance criteria require:
 
-1. Clean pass: a 7-section, fully-conformant doc (using
-   `design-doc-contract.md`'s seven names) exits 0.
+1. Clean pass: a fully-conformant doc carrying every section
+   `reference/design-doc-contract.md` requires exits 0.
 2. Each of Check 1's sub-cases (missing required section, wrong section
    count, unrecognized heading), Check 2 (prose-only Proposed design),
    Check 3 (Problem & persona's three grounding buckets, each direction),
@@ -63,8 +62,8 @@ PERSONA_BLOCKQUOTE = (
 # (bucket c) followed by a "problem today" paragraph that also carries a
 # real, tree-checkable path citation (`src/server.py`) — both grounding
 # shapes present at once, matching this repo's own real fixtures
-# (docs/design/design-lint.md's Problem & persona cites a real premortem
-# path *alongside* its persona blockquote).
+# (a real shipped doc's Problem & persona cites a real premortem path
+# *alongside* its persona blockquote).
 PERSONA_SECTION_BODY = (
     "Primary persona, verbatim from `PRODUCT.md`:\n\n"
     f"{PERSONA_BLOCKQUOTE}\n"
@@ -85,11 +84,10 @@ PROPOSED_DESIGN_CONCRETE_BLOCK = (
     "`src/server.py:5-8`.\n\n"
 )
 
-# A fully-conformant 7-section design-<slug>.md, using
-# design-doc-contract.md's seven required section names — the same seven
+# A fully-conformant design-<slug>.md carrying every section
+# `reference/design-doc-contract.md` requires, in its order -- the same set
 # every real, gate-design-reviewed doc this repo has produced actually
-# carries (docs/design/design-lint.md, docs/design/finish-skill.md,
-# docs/design/design-skill.md). Every check actually resolves clean against
+# carries. Every check actually resolves clean against
 # a throwaway fixture repo: `Problem & persona` carries a PRODUCT.md-
 # verbatim blockquote, `Proposed design` carries a fenced code block plus
 # artifact-shaped inline code and its own ruled `(q1)` fork, `User journey`
@@ -411,7 +409,7 @@ class TestDesignLintProposedDesignArtifactSpanThreshold(unittest.TestCase):
 class TestDesignLintCheck3PersonaCheckable(unittest.TestCase):
     """Check 3's three grounding buckets, remapped from the old schema's
     per-bullet `Assumptions` check onto `Problem & persona`'s single
-    section-level claim (docs/design/design-lint-reconcile.md)."""
+    section-level claim."""
 
     def test_blockquote_not_verbatim_in_product_is_named(self) -> None:
         fabricated = (

--- a/tests/jig/test_evidence_freshness.py
+++ b/tests/jig/test_evidence_freshness.py
@@ -3,7 +3,7 @@
 Exercises the script against a throwaway git repo (`tests/_tempgit.py`),
 never the real jig repo, checking this story's freshness-hold acceptance
 criteria (evidence timestamp >= last code commit) and
-`docs/design/finish-skill.md`'s Step 1 mechanically:
+the finish-skill story's Step 1 mechanically:
 
 1. Happy path: a folder whose manifest.json's commit_sha is an ancestor of
    the repo's current HEAD, and whose artifact mtimes are all >= the

--- a/tests/jig/test_plan_lint.py
+++ b/tests/jig/test_plan_lint.py
@@ -3,7 +3,7 @@
 Exercises the script against throwaway git repos (`tests/_tempgit.py`),
 never the real jig repo, plus the two committed fixtures under
 `tests/fixtures/plan-lint/` (this story's own required demonstration --
-docs/design/plan-lint.md, "Operational readiness"), checking the
+the plan-lint story's "Operational readiness"), checking the
 acceptance criteria mechanically:
 
 1. Every task needs >=1 [cap], >=1 [hold], <=5 items total.
@@ -67,7 +67,7 @@ def write(path: Path, text: str) -> Path:
 
 
 class TestPlanLintCommittedFixtures(unittest.TestCase):
-    """This story's own required demonstration (docs/design/plan-lint.md,
+    """This story's own required demonstration (
     'Operational readiness'): a clean fixture exits 0, and a deliberately
     broken one exits 1 naming one distinct violation per category, in a
     single run.
@@ -571,7 +571,7 @@ class TestPlanLintNotHereFollowups(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stdout)
 
     def test_heading_located_by_text_regardless_of_depth(self) -> None:
-        """Deliberate defensive property (docs/design/plan-lint.md,
+        """Deliberate defensive property (
         'Not-here follow-ups'): issue #23's heading-*level* fix is a sibling
         story's job; plan-lint matches the heading text at any # depth."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/jig/test_plan_skill.py
+++ b/tests/jig/test_plan_skill.py
@@ -315,20 +315,28 @@ class TestPlanSkillBody(unittest.TestCase):
 class TestStaleReferencesUpdated(unittest.TestCase):
     """Resolves issue #23's second half: the two already-shipped stale
     references now cite this story's own verified round-trip, and neither
-    changed the heading level itself (docs/design/plan-skill.md, Step 6)."""
+    changed the heading level itself (issue #23, Step 6)."""
+
+    # Both assertions used to also require the literal path of this story's own
+    # design doc. That pinned the attribution to a branch-local file which, by the rule ratified in #219, is deleted at closeout --
+    # so the assertion guaranteed a permanently dangling pointer (#233). The
+    # issue number is the durable half and is what these check now: the claim
+    # still has to be attributed, just not to a file that cannot exist.
+    #
+    # The negative is deliberately the whole directory rather than one filename.
+    # Naming a file here would put the very string this rule forbids back into a
+    # permanent file, and the point is that *no* design-doc path belongs in one.
 
     def test_build_skill_cites_the_verified_round_trip(self) -> None:
         body = BUILD_SKILL_MD.read_text(encoding="utf-8")
         self.assertIn("## Not-here follow-ups", body)
         self.assertIn("issue #23", body)
-        self.assertIn("docs/design/plan-skill.md", body)
         self.assertNotIn("#### Not-here follow-ups", body)
 
     def test_finish_skill_cites_the_verified_round_trip(self) -> None:
         body = FINISH_SKILL_MD.read_text(encoding="utf-8")
         self.assertIn("## Not-here follow-ups", body)
         self.assertIn("issue #23", body)
-        self.assertIn("docs/design/plan-skill.md", body)
         self.assertNotIn("#### Not-here follow-ups", body)
 
 

--- a/tests/jig/test_status_flip.py
+++ b/tests/jig/test_status_flip.py
@@ -2,7 +2,7 @@
 
 Exercises the script against a throwaway git repo (`tests/_tempgit.py`),
 never the real jig repo, checking this story's acceptance criteria and
-`docs/design/build-skill.md`'s "Status-flip persistence" section
+`skills/build/SKILL.md`'s status-flip contract
 mechanically:
 
 1. The PASS path derives its token solely from `verify`'s own `results.json`

--- a/tests/python/test_check_references.py
+++ b/tests/python/test_check_references.py
@@ -155,3 +155,59 @@ def test_an_undeclared_external_skill_is_still_broken(tmp_path: Path) -> None:
     _write(tmp_path / "commands" / "x.md", "the `not-a-dependency` skill handles it")
     errors = find_broken(tmp_path)
     assert any("skills/not-a-dependency/ missing" in e for e in errors)
+
+
+# The guard forbids a literal `docs/design/<file>.md` in any durable file — and this
+# file is one. The fixtures below therefore assemble the path at runtime: the regex
+# needs the filename immediately after the slash, so a concatenation never matches in
+# source while still producing the exact string under test. That keeps the invariant
+# absolute, with no self-exemption list to go stale (#233).
+_DIR = "docs/design/"
+
+
+def _cite(name: str) -> str:
+    return _DIR + name
+
+
+def test_a_durable_file_may_not_cite_a_specific_design_doc(tmp_path: Path) -> None:
+    """#233: 33 citations accumulated pointing at design docs that are deleted at
+    closeout by the rule ratified in #219. Each read as load-bearing rationale, so a
+    reader following one found nothing and could not tell whether the claim was ever
+    true."""
+    from check_references import find_disposable_citations
+
+    _write(tmp_path / "scripts" / "verify", f"per {_cite('build-scripts.md')}, step 2")
+    errors = find_disposable_citations(tmp_path)
+    assert len(errors) == 1
+    assert "build-scripts.md" in errors[0]
+    assert "#233" in errors[0]
+
+
+def test_the_design_doc_directory_itself_is_not_a_citation(tmp_path: Path) -> None:
+    """The bare directory and the `<slug>` placeholder are the producer's output
+    path, named legitimately by /design, /plan, /coach, and gate-design-review. Only
+    a concrete filename is a pointer that can dangle."""
+    from check_references import find_disposable_citations
+
+    _write(tmp_path / "skills" / "design" / "SKILL.md", f"Written to `{_DIR}<slug>.md`")
+    _write(tmp_path / "commands" / "work-on.md", f"discover a candidate under {_DIR}")
+    assert find_disposable_citations(tmp_path) == []
+
+
+def test_the_guard_covers_the_directories_the_old_check_missed() -> None:
+    """`find_broken` scans only commands/agents/skills/reference, which is why none
+    of the 33 were caught: most were in scripts/ and tests/."""
+    from check_references import DURABLE_DIRS
+
+    for missed in ("scripts", "tests", "bin", "workflows"):
+        assert missed in DURABLE_DIRS
+
+
+def test_the_guard_reads_non_markdown_files(tmp_path: Path) -> None:
+    """Most of the 33 were in Python and in extensionless script files, not .md —
+    the old check only ever globbed `*.md`."""
+    from check_references import find_disposable_citations
+
+    _write(tmp_path / "scripts" / "_gitutil.py", f"# per {_cite('build-scripts.md')}")
+    _write(tmp_path / "tests" / "jig" / "test_x.py", f"# {_cite('plan-lint.md')} says")
+    assert len(find_disposable_citations(tmp_path)) == 2


### PR DESCRIPTION
Thirty-three citations across 20 files pointed at seven `docs/design/*.md` docs
that do not exist. Every one of them died at `/finish` closeout, exactly as the
rule ratified in #219 prescribes — the defect is that permanent files cited them
anyway, and `CLAUDE.md` now states the constraint they violate: a durable file
must not cite a disposable one.

They read as load-bearing rationale — "per `docs/design/build-scripts.md`", "the
design doc's own Failure path" — so a reader following one finds nothing and
cannot tell whether the claim was ever true. That is worse than no citation.

Each was resolved on its own merits, per the scope in #233:

- **The claim stands on its own** → dropped the pointer, kept the sentence.
  `scripts/verify` still says it re-runs items rather than trusting the executor,
  and still cites PRODUCT.md's "Nothing signs off on itself", which is durable.
- **The rationale is a story's decision** → cited the issue. `skills/build` and
  `skills/finish` already named issue #23 beside the path; the issue is the half
  that survives.
- **A live authority exists** → named it instead. `scripts/status-flip` cited a
  deleted doc's "Status-flip persistence" section for a contract
  `skills/build/SKILL.md` states directly.

Two tests *asserted* a dangling path. `test_plan_skill.py` required the literal
`docs/design/plan-skill.md` in both skill bodies — guaranteeing a permanently
broken pointer, in a test named for checking the citation was correct. They now
check the issue number, and the negative assertion is the whole directory rather
than one filename: naming a file there would reintroduce the string the rule
forbids.

`scripts/check_references.py` gains the guard #233 asks for. It never caught these
because it validates only `@agent-*`, skill names, and `reference/*.md`, and scans
only `commands/`, `agents/`, `skills/`, `reference/` — while most of the 33 were in
`scripts/` and `tests/`, in Python and extensionless files it never globbed. The new
check covers eight directories and every file type, and distinguishes a concrete
filename (a pointer that can dangle) from the bare `docs/design/` directory and the
`<slug>` placeholder, both of which are the producer's output path and legitimate.

The guard caught three instances of my own prose on its first run, including its
own docstring's examples. Its tests assemble the forbidden path at runtime, so the
invariant stays absolute with no self-exemption list to go stale.

Also fixes a leftover from #211: `tests/jig/test_design_lint.py` still described
its fixture as "a fully-conformant 7-section doc" using "seven required section
names". The cross-surface pin added in that PR checks five surfaces and not the
test file, so the stale claim survived the reconciliation that removed it
everywhere else.

Closes #233