### PR TITLE
fix: declare and enforce the runtime version floor for shipped scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,15 @@ jobs:
       # a surprise red build.
       - name: Ruff
         run: uv run --no-project --with ruff==0.16.0 ruff check scripts tests/jig
+      # scripts/ ships to consuming projects and the skills invoke it bare
+      # (`scripts/design-lint --doc ...`), so it runs on whatever python3 that
+      # project has — not on CI's uv-managed interpreter and not on the 3.11+
+      # CLAUDE.md targets for development. 3.9 is the floor because that is what
+      # stock macOS provides. #250: design-lint imported itertools.pairwise (3.10)
+      # and the traceback read as a malformed design doc rather than a wrong
+      # interpreter. Pinned for the same reason every other linter here is.
+      - name: Runtime version floor for shipped scripts
+        run: uv run --no-project --with vermin==1.8.0 vermin --no-tips -t=3.9- scripts/
       - name: Unit tests
         run: uv run --no-project python3 -m unittest discover -s tests/jig
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,9 @@ node --test tests/js/*.js
 # Build-script lint and tests (ruff pinned; stdlib unittest, not pytest)
 uv run --no-project --with ruff==0.16.0 ruff check scripts tests/jig
 uv run --no-project python3 -m unittest discover -s tests/jig -v
+
+# Runtime version floor for the shipped scripts (vermin pinned; scripts/ only)
+uv run --no-project --with vermin==1.8.0 vermin --no-tips -t=3.9- scripts/
 ```
 
 Releases are automated via semantic-release (`pyproject.toml`); the version lives in `.claude-plugin/plugin.json` and is bumped by CI on merge to `main` — never edit it by hand.
@@ -147,9 +150,18 @@ gone when the finding was written.
 Applies to `scripts/` and both test trees. These override Studious's built-in idiom
 rubric for this repo.
 
-- **Target 3.11+.** `uv` for all tooling. Type hints required. Prefer comprehensions,
-  generator expressions, and stdlib (`functools`, `itertools`, `collections`) over
-  explicit loops.
+- **Target 3.11+ for development and CI.** `uv` for all tooling. Type hints required.
+  Prefer comprehensions, generator expressions, and stdlib (`functools`, `itertools`,
+  `collections`) over explicit loops.
+- **`scripts/` has a lower floor: 3.9, enforced by vermin in CI.** Those scripts ship to
+  consuming projects and the build skills invoke them bare — `skills/design/SKILL.md`
+  Step 5 runs `scripts/design-lint --doc <path> --repo <worktree>`, naming no interpreter
+  — so they execute on whatever `python3` that project has, which on stock macOS is 3.9.6.
+  This is the one place the 3.11+ target does not reach; `tests/`, `workflows/`, and
+  everything else keeps it. #250 is why the floor is declared rather than assumed:
+  `design-lint` imported `itertools.pairwise` (3.10) and the traceback read as a
+  malformed design doc rather than a wrong interpreter. Raise the floor deliberately if
+  a consuming-project baseline moves — don't drift into it one import at a time.
 - **Ruff, pinned** in `.github/workflows/ci.yml`. `pyproject.toml`'s `[tool.ruff.lint]`
   extends the pinned version's defaults with `B`, `C4`, `PERF`, `PIE`, `RUF`, `SIM`.
   The default set grows between releases — bump the pin deliberately and fix what the

--- a/scripts/design-lint
+++ b/scripts/design-lint
@@ -61,7 +61,6 @@ import argparse
 import re
 import sys
 from dataclasses import dataclass
-from itertools import pairwise
 from pathlib import Path
 
 # Mirrors reference/design-doc-contract.md's "Required sections" table, in
@@ -288,7 +287,10 @@ def _has_markdown_table(body: str) -> bool:
     lines = [ln.strip() for ln in body.splitlines() if ln.strip()]
     return any(
         a.startswith("|") and "-" in b and _TABLE_DELIM_RE.match(b)
-        for a, b in pairwise(lines)
+        # zip over the offset slice, not itertools.pairwise: the skills invoke
+        # these scripts bare (`scripts/design-lint ...`), so they run on whatever
+        # python3 a consuming project has, and pairwise needs 3.10 (#250).
+        for a, b in zip(lines, lines[1:])
     )
 
 


### PR DESCRIPTION
Closes #250.

`scripts/design-lint` imported `itertools.pairwise` (Python 3.10). `skills/design/SKILL.md` Step 5 invokes it bare — `scripts/design-lint --doc <path> --repo <worktree>`, naming no interpreter — so it runs on whatever `python3` the consuming project has. On stock macOS that is 3.9.6:

```
ImportError: cannot import name 'pairwise' from 'itertools' (unknown location)
```

The traceback reads as a malformed design doc rather than a wrong interpreter, which is the expensive part. Hit live on 2026-07-26 drafting `docs/design/close-epic.md` (#247).

## Change

`zip(lines, lines[1:])` in place of the one `pairwise` call. All 11 shipped scripts now run under 3.9.6, verified by `--help` on each.

## The contract half

The issue asked for a declared floor across all 11 scripts, not a patch to one. The other 10 were 3.9-compatible **by accident, not by contract** — nothing declared or enforced a minimum, so the next 3.10+ construct added to any of them fails identically.

A pinned `vermin==1.8.0` step over `scripts/` now enforces it. That covers all 11 at once and is a stronger regression test than a unit test on this call site would be: it exits 1 on the pre-fix file and 0 on the fixed tree, both verified.

CLAUDE.md now separates the two contracts explicitly, because they genuinely differ:

| Surface | Floor | Why |
|---|---|---|
| development, CI, `tests/`, `workflows/` | 3.11+ | runs under this repo's uv-managed interpreter |
| `scripts/` | **3.9** | ships to consuming projects, invoked bare by the build skills |

`scripts/` is the only code in this repo that executes outside a uv-managed interpreter, which is what makes it the one place the 3.11+ target cannot reach.

Raising that floor is a deliberate decision if a consuming-project baseline moves — the point of declaring it is to stop drifting into it one import at a time.