### PR TITLE
refactor: give tests/jig one normalize_ws and one vocabulary parsing path

### DIFF
--- a/tests/jig/_text.py
+++ b/tests/jig/_text.py
@@ -1,0 +1,26 @@
+"""Text helpers shared across `tests/jig/`.
+
+These tests assert on prose — `SKILL.md` bodies and Python docstrings — where a
+phrase's meaning does not depend on where the source happens to be hand-wrapped
+but a naive substring check does. Normalizing first is what lets a test pin a
+multi-word phrase without also pinning the line breaks around it.
+
+Kept separate from `_vocabulary.py`: the script-behavior tests
+(`test_verify.py`, `test_worktree_setup.py`) normalize docstrings without
+parsing any vocabulary, and should not import a vocabulary module to do it.
+"""
+
+from __future__ import annotations
+
+import re
+
+_WHITESPACE_RUN = re.compile(r"\s+")
+
+
+def normalize_ws(text: str) -> str:
+    """Collapse whitespace runs, including line-wrap newlines, to a single space.
+
+    So a multi-word phrase check doesn't break on where prose or a docstring
+    happens to be hand-wrapped.
+    """
+    return _WHITESPACE_RUN.sub(" ", text)

--- a/tests/jig/_vocabulary.py
+++ b/tests/jig/_vocabulary.py
@@ -18,6 +18,8 @@ discover`.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
+from itertools import chain
 
 _BACKTICK = re.compile(r"`([^`]+)`")
 _CELL_SPLIT = re.compile(r"(?<!\\)\|")
@@ -90,14 +92,14 @@ def _section(markdown: str, heading: str) -> str:
 def _table_rows(section: str) -> list[list[str]]:
     """Parse a GFM table's `| a | b |` lines into stripped cell lists,
     respecting `\\|` as an escaped literal pipe rather than a delimiter."""
-    rows = []
-    for line in section.splitlines():
-        line = line.strip()
-        if not line.startswith("|"):
-            continue
-        inner = line[1:-1] if line.endswith("|") else line[1:]
-        rows.append([cell.strip() for cell in _CELL_SPLIT.split(inner)])
-    return rows
+    return [
+        [
+            cell.strip()
+            for cell in _CELL_SPLIT.split(line[1:-1] if line.endswith("|") else line[1:])
+        ]
+        for line in (raw.strip() for raw in section.splitlines())
+        if line.startswith("|")
+    ]
 
 
 def _backtick_tokens(cell: str) -> list[str]:
@@ -142,6 +144,25 @@ def _executor_checkpoint_fields(design_md: str) -> list[str]:
     return tokens[tokens.index("Do") + 1 :]
 
 
+def _derive_vocabulary(
+    design_md: str, concepts: frozenset[str], extra: Iterable[str] = ()
+) -> tuple[str, ...]:
+    """Canonical-display tokens for `concepts`, in table order, deduplicated,
+    followed by `extra`.
+
+    The one parsing path behind every `derive_*_vocabulary` below; those differ
+    only in which Vocabulary rows they read, and `derive_jig_vocabulary` in
+    appending the checkpoint-block fields. Deriving from `design_md`'s text
+    rather than a hand-maintained tuple is what makes a token DESIGN.md renames
+    fail whichever SKILL.md was not updated to match, instead of silently
+    passing -- so the dedup has to preserve first-seen order, which is the order
+    the table declares.
+    """
+    return tuple(
+        dict.fromkeys(chain(_vocabulary_table_tokens(design_md, concepts), extra))
+    )
+
+
 def derive_jig_vocabulary(design_md: str) -> tuple[str, ...]:
     """jig's own checkpoint-block vocabulary (DESIGN.md: Vocabulary,
     Formatting), derived from `design_md`'s text rather than an
@@ -149,13 +170,11 @@ def derive_jig_vocabulary(design_md: str) -> tuple[str, ...]:
     changes what this returns, and a SKILL.md that wasn't updated to match
     fails the check instead of silently passing.
     """
-    seen: dict[str, None] = {}
-    for token in (
-        *_vocabulary_table_tokens(design_md),
-        *_executor_checkpoint_fields(design_md),
-    ):
-        seen.setdefault(token, None)
-    return tuple(seen)
+    return _derive_vocabulary(
+        design_md,
+        RELEVANT_VOCABULARY_CONCEPTS,
+        _executor_checkpoint_fields(design_md),
+    )
 
 
 def derive_build_vocabulary(design_md: str) -> tuple[str, ...]:
@@ -166,10 +185,7 @@ def derive_build_vocabulary(design_md: str) -> tuple[str, ...]:
     scoped to what `skills/build/SKILL.md` (not the executor-facing
     discipline skill) discusses.
     """
-    seen: dict[str, None] = {}
-    for token in _vocabulary_table_tokens(design_md, BUILD_VOCABULARY_CONCEPTS):
-        seen.setdefault(token, None)
-    return tuple(seen)
+    return _derive_vocabulary(design_md, BUILD_VOCABULARY_CONCEPTS)
 
 
 def derive_finish_vocabulary(design_md: str) -> tuple[str, ...]:
@@ -179,10 +195,7 @@ def derive_finish_vocabulary(design_md: str) -> tuple[str, ...]:
     tuple -- same rationale as `derive_jig_vocabulary`, scoped to what
     `skills/finish/SKILL.md` discusses.
     """
-    seen: dict[str, None] = {}
-    for token in _vocabulary_table_tokens(design_md, FINISH_VOCABULARY_CONCEPTS):
-        seen.setdefault(token, None)
-    return tuple(seen)
+    return _derive_vocabulary(design_md, FINISH_VOCABULARY_CONCEPTS)
 
 
 def derive_plan_vocabulary(design_md: str) -> tuple[str, ...]:
@@ -194,10 +207,7 @@ def derive_plan_vocabulary(design_md: str) -> tuple[str, ...]:
     hand-maintained tuple -- same rationale as `derive_jig_vocabulary`,
     scoped to what `skills/plan/SKILL.md` discusses.
     """
-    seen: dict[str, None] = {}
-    for token in _vocabulary_table_tokens(design_md, PLAN_VOCABULARY_CONCEPTS):
-        seen.setdefault(token, None)
-    return tuple(seen)
+    return _derive_vocabulary(design_md, PLAN_VOCABULARY_CONCEPTS)
 
 
 def derive_design_vocabulary(design_md: str) -> tuple[str, ...]:
@@ -207,10 +217,7 @@ def derive_design_vocabulary(design_md: str) -> tuple[str, ...]:
     hand-maintained tuple -- same rationale as `derive_jig_vocabulary`,
     scoped to what `skills/design/SKILL.md` discusses.
     """
-    seen: dict[str, None] = {}
-    for token in _vocabulary_table_tokens(design_md, DESIGN_VOCABULARY_CONCEPTS):
-        seen.setdefault(token, None)
-    return tuple(seen)
+    return _derive_vocabulary(design_md, DESIGN_VOCABULARY_CONCEPTS)
 
 
 def derive_coach_vocabulary(design_md: str) -> tuple[str, ...]:
@@ -221,7 +228,4 @@ def derive_coach_vocabulary(design_md: str) -> tuple[str, ...]:
     same rationale as `derive_jig_vocabulary`, scoped to what
     `skills/coach/SKILL.md` discusses.
     """
-    seen: dict[str, None] = {}
-    for token in _vocabulary_table_tokens(design_md, COACH_VOCABULARY_CONCEPTS):
-        seen.setdefault(token, None)
-    return tuple(seen)
+    return _derive_vocabulary(design_md, COACH_VOCABULARY_CONCEPTS)

--- a/tests/jig/test_build_skill.py
+++ b/tests/jig/test_build_skill.py
@@ -83,6 +83,7 @@ import unittest
 from pathlib import Path
 
 from _frontmatter import FRONTMATTER
+from _text import normalize_ws
 from _vocabulary import derive_build_vocabulary
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -156,20 +157,15 @@ class TestBuildVocabularyDerivation(unittest.TestCase):
         )
 
 
-def _normalize_ws(text: str) -> str:
-    """Collapse whitespace runs (including line-wrap newlines) to a single
-    space, so a multi-word phrase check doesn't break on where prose
-    happens to be hand-wrapped."""
-    return re.sub(r"\s+", " ", text)
 
 
 class TestBuildSkillBody(unittest.TestCase):
     def setUp(self) -> None:
         self.body = SKILL_MD.read_text(encoding="utf-8")
-        self.flat_body = _normalize_ws(self.body)
+        self.flat_body = normalize_ws(self.body)
 
     def assertPhraseIn(self, phrase: str) -> None:
-        self.assertIn(_normalize_ws(phrase), self.flat_body, f"phrase not found (whitespace-normalized): {phrase!r}")
+        self.assertIn(normalize_ws(phrase), self.flat_body, f"phrase not found (whitespace-normalized): {phrase!r}")
 
     def test_body_uses_build_level_vocabulary(self) -> None:
         missing = [term for term in BUILD_VOCABULARY if term not in self.body]
@@ -271,8 +267,8 @@ class TestBuildSkillBody(unittest.TestCase):
 
         # Immediately beside the existing dispatch-timestamp capture -- not
         # merely present somewhere in the body.
-        flat_timestamp_phrase = _normalize_ws("Capture this attempt's dispatch timestamp")
-        flat_model_phrase = _normalize_ws("Name this attempt's dispatch model")
+        flat_timestamp_phrase = normalize_ws("Capture this attempt's dispatch timestamp")
+        flat_model_phrase = normalize_ws("Name this attempt's dispatch model")
         timestamp_idx = self.flat_body.index(flat_timestamp_phrase)
         model_idx = self.flat_body.index(flat_model_phrase)
         self.assertLess(
@@ -295,8 +291,8 @@ class TestBuildSkillBody(unittest.TestCase):
 
         # Immediately beside the existing inherited-case phrase -- not
         # merely present somewhere else in the body.
-        flat_inherited_phrase = _normalize_ws("state it plainly as `inherited: <model>`")
-        flat_unavailable_phrase = _normalize_ws(
+        flat_inherited_phrase = normalize_ws("state it plainly as `inherited: <model>`")
+        flat_unavailable_phrase = normalize_ws(
             "If the model genuinely can't be determined at all, state it "
             "plainly as `unavailable`"
         )
@@ -397,10 +393,10 @@ class TestBuildSkillBody(unittest.TestCase):
 
         # Assembled before the existing evidence-capture call, not after --
         # Done means item 1's "before the existing evidence-capture call".
-        flat_assemble_phrase = _normalize_ws(
+        flat_assemble_phrase = normalize_ws(
             "Assemble the replay bundle at a scratch path"
         )
-        flat_evidence_call_phrase = _normalize_ws(
+        flat_evidence_call_phrase = normalize_ws(
             "Call `scripts/evidence-capture --task <id> --repo <worktree> "
             "--artifact verify:results=<scratch-path>/results.json"
         )

--- a/tests/jig/test_coach_skill.py
+++ b/tests/jig/test_coach_skill.py
@@ -48,6 +48,7 @@ import unittest
 from pathlib import Path
 
 from _frontmatter import FRONTMATTER
+from _text import normalize_ws
 from _vocabulary import derive_coach_vocabulary
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -166,21 +167,16 @@ class TestCoachVocabularyDerivation(unittest.TestCase):
         )
 
 
-def _normalize_ws(text: str) -> str:
-    """Collapse whitespace runs (including line-wrap newlines) to a single
-    space, so a multi-word phrase check doesn't break on where prose
-    happens to be hand-wrapped."""
-    return re.sub(r"\s+", " ", text)
 
 
 class TestCoachSkillBody(unittest.TestCase):
     def setUp(self) -> None:
         self.body = SKILL_MD.read_text(encoding="utf-8")
-        self.flat_body = _normalize_ws(self.body)
+        self.flat_body = normalize_ws(self.body)
 
     def assertPhraseIn(self, phrase: str) -> None:
         self.assertIn(
-            _normalize_ws(phrase),
+            normalize_ws(phrase),
             self.flat_body,
             f"phrase not found (whitespace-normalized): {phrase!r}",
         )

--- a/tests/jig/test_design_skill.py
+++ b/tests/jig/test_design_skill.py
@@ -46,6 +46,7 @@ import unittest
 from pathlib import Path
 
 from _frontmatter import FRONTMATTER
+from _text import normalize_ws
 from _vocabulary import derive_design_vocabulary
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -139,20 +140,15 @@ class TestDesignVocabularyDerivation(unittest.TestCase):
         )
 
 
-def _normalize_ws(text: str) -> str:
-    """Collapse whitespace runs (including line-wrap newlines) to a single
-    space, so a multi-word phrase check doesn't break on where prose
-    happens to be hand-wrapped."""
-    return re.sub(r"\s+", " ", text)
 
 
 class TestDesignSkillBody(unittest.TestCase):
     def setUp(self) -> None:
         self.body = SKILL_MD.read_text(encoding="utf-8")
-        self.flat_body = _normalize_ws(self.body)
+        self.flat_body = normalize_ws(self.body)
 
     def assertPhraseIn(self, phrase: str) -> None:
-        self.assertIn(_normalize_ws(phrase), self.flat_body, f"phrase not found (whitespace-normalized): {phrase!r}")
+        self.assertIn(normalize_ws(phrase), self.flat_body, f"phrase not found (whitespace-normalized): {phrase!r}")
 
     def test_body_uses_design_level_vocabulary(self) -> None:
         missing = [term for term in DESIGN_VOCABULARY if term not in self.body]

--- a/tests/jig/test_finish_skill.py
+++ b/tests/jig/test_finish_skill.py
@@ -41,6 +41,7 @@ import unittest
 from pathlib import Path
 
 from _frontmatter import FRONTMATTER
+from _text import normalize_ws
 from _vocabulary import derive_finish_vocabulary
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -113,20 +114,15 @@ class TestFinishVocabularyDerivation(unittest.TestCase):
         )
 
 
-def _normalize_ws(text: str) -> str:
-    """Collapse whitespace runs (including line-wrap newlines) to a single
-    space, so a multi-word phrase check doesn't break on where prose
-    happens to be hand-wrapped."""
-    return re.sub(r"\s+", " ", text)
 
 
 class TestFinishSkillBody(unittest.TestCase):
     def setUp(self) -> None:
         self.body = SKILL_MD.read_text(encoding="utf-8")
-        self.flat_body = _normalize_ws(self.body)
+        self.flat_body = normalize_ws(self.body)
 
     def assertPhraseIn(self, phrase: str) -> None:
-        self.assertIn(_normalize_ws(phrase), self.flat_body, f"phrase not found (whitespace-normalized): {phrase!r}")
+        self.assertIn(normalize_ws(phrase), self.flat_body, f"phrase not found (whitespace-normalized): {phrase!r}")
 
     def test_body_uses_finish_level_vocabulary(self) -> None:
         missing = [term for term in FINISH_VOCABULARY if term not in self.body]
@@ -295,11 +291,11 @@ class TestFinishResolvesTheEvidenceFolderByAsking(unittest.TestCase):
 
     def setUp(self) -> None:
         self.body = SKILL_MD.read_text(encoding="utf-8")
-        self.flat_body = _normalize_ws(self.body)
+        self.flat_body = normalize_ws(self.body)
 
     def assertPhraseIn(self, phrase: str) -> None:
         self.assertIn(
-            _normalize_ws(phrase),
+            normalize_ws(phrase),
             self.flat_body,
             f"phrase not found (whitespace-normalized): {phrase!r}",
         )
@@ -334,7 +330,7 @@ class TestFinishResolvesTheEvidenceFolderByAsking(unittest.TestCase):
         # `--repo`. An unjoined path exits 2 and stops /finish outright.
         self.assertIn(
             "scripts/evidence-freshness --repo <worktree> --evidence <worktree>/<folder>",
-            _normalize_ws(self.body),
+            normalize_ws(self.body),
         )
         self.assertPhraseIn("**joined onto `<worktree>/`**")
         self.assertPhraseIn("resolves `--evidence` against the process's own cwd")
@@ -348,7 +344,7 @@ class TestFinishResolvesTheEvidenceFolderByAsking(unittest.TestCase):
 
     def test_the_manifest_sentence_describes_the_folder_resolve_printed(self) -> None:
         # Its antecedent is the exit-0 resolved folder, and it has one home.
-        contents = _normalize_ws("carries a `manifest.json` (`commit_sha`, `commit_timestamp`, `branch`")
+        contents = normalize_ws("carries a `manifest.json` (`commit_sha`, `commit_timestamp`, `branch`")
         self.assertEqual(self.flat_body.count(contents), 1, "the manifest description has one home")
-        exit_zero_at = self.flat_body.index(_normalize_ws("It prints one folder path, repo-relative, on exit 0."))
+        exit_zero_at = self.flat_body.index(normalize_ws("It prints one folder path, repo-relative, on exit 0."))
         self.assertLess(exit_zero_at, self.flat_body.index(contents))

--- a/tests/jig/test_plan_skill.py
+++ b/tests/jig/test_plan_skill.py
@@ -50,6 +50,7 @@ import unittest
 from pathlib import Path
 
 from _frontmatter import FRONTMATTER
+from _text import normalize_ws
 from _vocabulary import derive_plan_vocabulary
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -62,11 +63,6 @@ FINISH_SKILL_MD = REPO_ROOT / "skills" / "finish" / "SKILL.md"
 PLAN_VOCABULARY = derive_plan_vocabulary(DESIGN_MD.read_text(encoding="utf-8"))
 
 
-def _normalize_ws(text: str) -> str:
-    """Collapse whitespace runs (including line-wrap newlines) to a single
-    space, so a multi-word phrase check doesn't break on where prose
-    happens to be hand-wrapped."""
-    return re.sub(r"\s+", " ", text)
 
 
 class TestPlanSkillFile(unittest.TestCase):
@@ -135,10 +131,10 @@ class TestPlanVocabularyDerivation(unittest.TestCase):
 class TestPlanSkillBody(unittest.TestCase):
     def setUp(self) -> None:
         self.body = SKILL_MD.read_text(encoding="utf-8")
-        self.flat_body = _normalize_ws(self.body)
+        self.flat_body = normalize_ws(self.body)
 
     def assertPhraseIn(self, phrase: str) -> None:
-        self.assertIn(_normalize_ws(phrase), self.flat_body, f"phrase not found (whitespace-normalized): {phrase!r}")
+        self.assertIn(normalize_ws(phrase), self.flat_body, f"phrase not found (whitespace-normalized): {phrase!r}")
 
     def test_body_uses_plan_level_vocabulary(self) -> None:
         missing = [term for term in PLAN_VOCABULARY if term not in self.body]

--- a/tests/jig/test_verify.py
+++ b/tests/jig/test_verify.py
@@ -62,7 +62,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import subprocess
 import sys
 import tempfile
@@ -72,13 +71,7 @@ from pathlib import Path
 
 from _orphancheck import orphan_spawning_command, process_is_gone, wait_for_marker
 from _tempgit import commit_all, init_repo
-
-
-def _normalize_ws(text: str) -> str:
-    """Collapse whitespace runs (including line-wrap newlines) to a single
-    space, so a multi-word phrase check doesn't break on where a docstring
-    happens to be hand-wrapped."""
-    return re.sub(r"\s+", " ", text)
+from _text import normalize_ws
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "verify"
@@ -476,7 +469,7 @@ class TestVerifyTrustBoundaryDocumented(unittest.TestCase):
         self.assertIn(
             "Commands in a plan are executed verbatim via the shell; only "
             "run /build on plans you would run by hand",
-            _normalize_ws(text),
+            normalize_ws(text),
         )
         self.assertIn("shell=True", text)
         self.assertIn("issue #48", text)

--- a/tests/jig/test_vocabulary_derivation.py
+++ b/tests/jig/test_vocabulary_derivation.py
@@ -31,6 +31,7 @@ import unittest
 from pathlib import Path
 
 from _vocabulary import (
+    _derive_vocabulary,
     derive_build_vocabulary,
     derive_coach_vocabulary,
     derive_design_vocabulary,
@@ -410,6 +411,65 @@ class TestDeriveCoachVocabulary(unittest.TestCase):
             missing,
             "a deliberate DESIGN.md token rename should have been caught "
             "as a missing term once SKILL.md wasn't updated to match",
+        )
+
+
+# A synthetic table, not the real DESIGN.md: order and dedup are properties of
+# the parsing path, and pinning them against live prose would make this fail on
+# an unrelated Vocabulary edit. `mid` is deliberately in two rows.
+_ORDERING_FIXTURE = """## Vocabulary
+
+| Concept | Canonical display |
+| --- | --- |
+| alpha | `zeta`, `mid` |
+| beta | `mid`, `aardvark` |
+| gamma | `excluded` |
+"""
+
+
+class TestDeriveVocabularySharedPath(unittest.TestCase):
+    """The one parsing path the six `derive_*_vocabulary` functions share (#197).
+
+    The per-skill tests above all assert membership, so nothing held the two
+    properties the shared helper actually promises: that tokens come back in the
+    order `DESIGN.md`'s table declares them, and that a token appearing in two
+    selected rows collapses to its first position. Both were previously carried
+    by six copies of a `seen.setdefault` loop; a membership-only suite would not
+    have noticed them changing.
+    """
+
+    DESIGN = _ORDERING_FIXTURE
+
+    def test_tokens_come_back_in_table_order_not_sorted(self) -> None:
+        self.assertEqual(
+            _derive_vocabulary(self.DESIGN, frozenset({"alpha"})),
+            ("zeta", "mid"),
+        )
+
+    def test_a_token_in_two_selected_rows_collapses_to_its_first_position(self) -> None:
+        self.assertEqual(
+            _derive_vocabulary(self.DESIGN, frozenset({"alpha", "beta"})),
+            ("zeta", "mid", "aardvark"),
+        )
+
+    def test_unselected_concepts_contribute_nothing(self) -> None:
+        self.assertNotIn(
+            "excluded", _derive_vocabulary(self.DESIGN, frozenset({"alpha", "beta"}))
+        )
+
+    def test_extra_is_appended_after_the_table_tokens(self) -> None:
+        self.assertEqual(
+            _derive_vocabulary(self.DESIGN, frozenset({"alpha"}), ("tail",)),
+            ("zeta", "mid", "tail"),
+        )
+
+    def test_extra_dedupes_against_the_table_tokens_it_follows(self) -> None:
+        """`derive_jig_vocabulary` passes checkpoint fields that can also appear
+        in the Vocabulary table; the old chained-tuple loop collapsed those, so
+        the shared path has to as well."""
+        self.assertEqual(
+            _derive_vocabulary(self.DESIGN, frozenset({"alpha"}), ("mid", "tail")),
+            ("zeta", "mid", "tail"),
         )
 
 

--- a/tests/jig/test_worktree_setup.py
+++ b/tests/jig/test_worktree_setup.py
@@ -35,7 +35,6 @@ Run with:
 """
 from __future__ import annotations
 
-import re
 import subprocess
 import sys
 import tempfile
@@ -44,13 +43,7 @@ from pathlib import Path
 
 from _orphancheck import orphan_spawning_command, process_is_gone, wait_for_marker
 from _tempgit import init_repo
-
-
-def _normalize_ws(text: str) -> str:
-    """Collapse whitespace runs (including line-wrap newlines) to a single
-    space, so a multi-word phrase check doesn't break on where a docstring
-    happens to be hand-wrapped."""
-    return re.sub(r"\s+", " ", text)
+from _text import normalize_ws
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "worktree-setup"
@@ -247,7 +240,7 @@ class TestWorktreeSetupTrustBoundaryDocumented(unittest.TestCase):
         self.assertIn(
             "Commands in a plan are executed verbatim via the shell; only "
             "run /build on plans you would run by hand",
-            _normalize_ws(text),
+            normalize_ws(text),
         )
         self.assertIn("shell=True", text)
         self.assertIn("issue #48", text)


### PR DESCRIPTION
Closes #197, closes #226.

Both issues describe the same shape on the same surface, and #226 explicitly asks for its vocabulary items to be folded into #197's consolidation rather than done twice.

## Note on the issue text

Both issues name paths from jig's own repo — `tests/_vocabulary.py`, `tests/test_vocabulary_derivation.py`. The jig merge (#150) moved everything under `tests/jig/`. #197's stated baseline of "390 passed / 1 skipped" is likewise pre-merge; the suite is 469 before this change.

## `_normalize_ws` → `tests/jig/_text.py`

Defined in **7** test modules, in two wordings that differed only in whether the docstring said "prose" or "a docstring". The implementation was `re.sub(r"\s+", " ", text)` in all seven.

A new module rather than a function on `_vocabulary.py`: `test_verify.py` and `test_worktree_setup.py` normalize docstrings without parsing any vocabulary, and shouldn't import a vocabulary module to do it. They import `_orphancheck`/`_tempgit`, not `_vocabulary`, today.

## Six `derive_*_vocabulary` → one `_derive_vocabulary`

Each carried its own `seen.setdefault` ordered-dedup loop. Five differed only in which concept rows they read; `derive_jig_vocabulary` also appends the checkpoint-block fields. All six now call:

```python
def _derive_vocabulary(design_md, concepts, extra=()):
    return tuple(dict.fromkeys(chain(_vocabulary_table_tokens(design_md, concepts), extra)))
```

Every next skill adds a call, not a seventh clone — which is the growth #197 was filed to stop. `_table_rows` becomes a filtered comprehension, #226's third item.

## The gap this surfaced

**The order and dedup being preserved here were untested.** All 24 existing tests assert membership — `pulls_known_terms`, `excludes_other_vocabularies`, `every_derived_term_present`, `token_change_is_caught`. Swapping the ordered dedup for `sorted(set(...))` would have passed every one of them, silently reordering what six SKILL.md checks compare against.

Five tests now pin the shared path directly: table order, first-position collapse for a token in two selected rows, exclusion of unselected concepts, and `extra` appended and deduped against what precedes it. Against a synthetic table, not live `DESIGN.md`, so an unrelated Vocabulary edit can't fail them.

Verified by mutation: 4 of the 5 fail against `sorted(set(...))`, all 5 pass against the real implementation.

Suite goes **469 → 474**, no existing test modified.

## Left alone deliberately

`run()` stays duplicated between `scripts/_gitutil.py` and `tests/jig/_tempgit.py`. `scripts/` is not importable from `tests/`, which is the documented reason for the split, and it still holds — as #226 itself says. Nothing here crosses the `tests/jig` (unittest) / `tests/python` (pytest) runner boundary.