### PR TITLE
test: cover _gitutil directly, and bound two unhardened script inputs

### DIFF
--- a/scripts/_gitutil.py
+++ b/scripts/_gitutil.py
@@ -144,14 +144,30 @@ def last_commit_sha_and_epoch(repo: Path) -> tuple[str, float] | None:
 
 
 def resolve_revision_epoch(repo: Path, revision: str) -> float | None:
-    """Resolve a git revision (branch, tag, sha) to its commit timestamp, or None."""
-    result = run(["git", "-C", str(repo), "show", "-s", "--format=%ct", revision])
+    """Resolve a git revision (branch, tag, sha) to its commit timestamp, or None.
+
+    `--end-of-options`, not `--`: `revision` reaches here from `verify --since`,
+    and git reads a leading-dash positional as an option unless told otherwise
+    (`git show -s --format=%ct --output=FILE HEAD` writes FILE). `--` is the
+    wrong separator for a revision -- it marks what follows as a *pathspec*, so
+    `git show ... -- HEAD` matches a file named HEAD, finds none, and returns
+    empty. This function would then return None for every revision, silently.
+    """
+    result = run(["git", "-C", str(repo), "show", "-s", "--format=%ct", "--end-of-options", revision])
     if result.returncode != 0 or not result.stdout.strip():
         return None
     return float(result.stdout.strip())
 
 
 def branch_exists(repo: Path, branch: str) -> bool:
+    """Whether `branch` exists in `repo`.
+
+    Needs no `--end-of-options` guard: the positional is interpolated behind a
+    literal `refs/heads/` and so can never begin with a dash. `git rev-parse`
+    could not take the guard anyway -- it echoes `--end-of-options` as an
+    output line rather than consuming it, which is why the two helpers that do
+    need it are `show` and `merge-base`, not this one.
+    """
     return run(["git", "-C", str(repo), "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"]).returncode == 0
 
 
@@ -160,7 +176,12 @@ def is_ancestor(repo: Path, ancestor: str, descendant: str = "HEAD") -> bool:
     `repo`. False for an unresolvable/orphaned `ancestor` -- never raises,
     so a caller checking freshness against a since-rewritten commit gets a
     plain FAIL rather than an exception."""
-    return run(["git", "-C", str(repo), "merge-base", "--is-ancestor", ancestor, descendant]).returncode == 0
+    return (
+        run(
+            ["git", "-C", str(repo), "merge-base", "--is-ancestor", "--end-of-options", ancestor, descendant]
+        ).returncode
+        == 0
+    )
 
 
 def worktree_registered(repo: Path, path: Path) -> bool:

--- a/scripts/verify
+++ b/scripts/verify
@@ -120,6 +120,22 @@ from _planparse import COMMAND_TIERS, TIER_BODY_RE, VALID_TIERS, Item, parse_ite
 
 VALID_KINDS = frozenset({"cap", "hold"})
 
+# Ceiling on a probe artifact read before its `pattern` is matched (#223).
+# The pattern is caller-supplied from the probe spec and `re` has no match
+# timeout, so an unbounded read hands a catastrophic-backtracking pattern an
+# unbounded input -- and `verify`'s whole job is to be the thing that cannot
+# be talked out of a verdict, which a silent hang defeats more thoroughly
+# than a wrong answer would. Refuse loudly above this instead.
+#
+# 8 MiB is far above any real probe artifact (build logs, coverage summaries,
+# generated manifests) and far below the size at which reading is itself the
+# problem. Residual, deliberately accepted: a pathological pattern can still
+# backtrack badly on a *small* input. Bounding that needs either a match
+# timeout (`regex`, a third-party dependency these scripts cannot take --
+# they ship to consuming projects and run on stock `python3`) or SIGALRM,
+# which is main-thread-only and `--parallel` runs items in a ThreadPoolExecutor.
+MAX_PROBE_ARTIFACT_BYTES = 8 * 1024 * 1024
+
 # --task names a task by its heading number: a bare "3" or the "Task 3"
 # label form, matching TASK_HEADING_RE's own capture. Never by title --
 # titles need the ambiguity rules plan-lint's load-bearing derivation
@@ -331,6 +347,12 @@ def check_probe_item(item: dict, since_ts: float) -> ItemResult:
             f"artifact is stale — its mtime predates --since: {artifact}",
         )
     pattern = item.get("pattern")
+    if pattern and artifact.stat().st_size > MAX_PROBE_ARTIFACT_BYTES:
+        return ItemResult(
+            item["id"], item["kind"], item["tier"], "FAIL",
+            f"artifact is too large to pattern-match safely "
+            f"({artifact.stat().st_size} bytes > {MAX_PROBE_ARTIFACT_BYTES} limit): {artifact}",
+        )
     if pattern and not re.search(pattern, artifact.read_text(encoding="utf-8", errors="replace")):
         return ItemResult(
             item["id"], item["kind"], item["tier"], "FAIL",

--- a/tests/jig/test_gitutil.py
+++ b/tests/jig/test_gitutil.py
@@ -1,0 +1,275 @@
+"""Direct tests for `scripts/_gitutil.py` (issue #205).
+
+`_gitutil` is imported by `evidence-capture`, `evidence-freshness`, `plan-lint`,
+`status-flip`, `verify`, and `worktree-setup` — 6 of 7 CLI scripts — and had no
+test of its own. Its behavior was only ever exercised through whichever importer
+happened to cover it, so the subprocess and process-group edge cases got
+independently re-discovered rather than proven once at the source.
+
+Two hardening regressions live here too, because both are `_gitutil`'s behavior
+rather than any one caller's:
+
+* `--end-of-options` on the revision-taking helpers (#223). Without it git reads
+  a leading-dash positional as an option; the test below shows one *writing a
+  file*.
+* `DEFAULT_TIMEOUT_SECONDS` being what an unflagged run actually uses (#227),
+  asserted against both scripts that share the constant.
+
+Standard library only, matching the other modules here. `scripts/` is not
+importable as a package (the files have no `.py` suffix), so the module is
+loaded by path — the same reason `_tempgit.py` re-implements `run()` rather than
+importing this one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _tempgit import commit_all, init_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+
+
+def _load_gitutil():
+    """Import `scripts/_gitutil.py` by path — it has no importable package."""
+    spec = importlib.util.spec_from_file_location("_gitutil_under_test", SCRIPTS / "_gitutil.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gitutil = _load_gitutil()
+
+
+class TestRunShellWithTimeout(unittest.TestCase):
+    """The process-group cleanup on timeout (issue #61), proven at the source."""
+
+    def test_returns_a_completed_process_on_success(self) -> None:
+        with TemporaryDirectory() as tmp:
+            result = gitutil.run_shell_with_timeout("echo hello", Path(tmp), 30)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "hello")
+
+    def test_preserves_a_nonzero_exit_without_raising(self) -> None:
+        with TemporaryDirectory() as tmp:
+            result = gitutil.run_shell_with_timeout("exit 3", Path(tmp), 30)
+        self.assertEqual(result.returncode, 3)
+
+    def test_runs_in_the_directory_it_is_given(self) -> None:
+        with TemporaryDirectory() as tmp:
+            marker = Path(tmp) / "marker.txt"
+            marker.write_text("here", encoding="utf-8")
+            result = gitutil.run_shell_with_timeout("ls marker.txt", Path(tmp), 30)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("marker.txt", result.stdout)
+
+    def test_raises_timeout_expired_on_a_hang(self) -> None:
+        with TemporaryDirectory() as tmp, self.assertRaises(subprocess.TimeoutExpired):
+            gitutil.run_shell_with_timeout("sleep 30", Path(tmp), 0.5)
+
+    def test_a_backgrounded_grandchild_is_killed_with_the_shell(self) -> None:
+        """The whole point of `start_new_session` + `killpg` over plain
+        `subprocess.run(timeout=...)`, which signals only the shell and leaves a
+        backgrounded child reparented and running past the timeout.
+        """
+        with TemporaryDirectory() as tmp:
+            pidfile = Path(tmp) / "child.pid"
+            # A child that outlives the shell, and records its own pid so the
+            # test can ask the OS whether it actually died.
+            command = f"sh -c 'echo $$ > {pidfile}; sleep 30' & sleep 30"
+            with self.assertRaises(subprocess.TimeoutExpired):
+                gitutil.run_shell_with_timeout(command, Path(tmp), 1.5)
+
+            self.assertTrue(pidfile.is_file(), "grandchild never started; test proves nothing")
+            child_pid = int(pidfile.read_text(encoding="utf-8").strip())
+
+            for _ in range(50):  # the killpg is synchronous, reaping is not
+                if not _process_alive(child_pid):
+                    break
+                time.sleep(0.1)
+
+            self.assertFalse(
+                _process_alive(child_pid),
+                f"pid {child_pid} survived the timeout — the process group was not killed",
+            )
+
+
+def _process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:  # exists, owned by someone else
+        return True
+    return True
+
+
+class TestEndOfOptionsHardening(unittest.TestCase):
+    """#223: a revision reaching git as a bare positional is read as an option.
+
+    `verify --since <rev>` puts a caller-supplied string into
+    `resolve_revision_epoch`, and `is_ancestor` takes two more. The guard has to
+    be `--end-of-options`, not `--`: `--` marks a *pathspec*, so `git show ... --
+    HEAD` looks for a file named HEAD and returns empty, which would make
+    `resolve_revision_epoch` return None for every revision.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.repo = Path(self._tmp.name)
+        init_repo(self.repo)
+        (self.repo / "a.txt").write_text("one", encoding="utf-8")
+        self.sha = commit_all(self.repo, "first")
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_resolve_revision_epoch_still_resolves_an_ordinary_revision(self) -> None:
+        """Guards the fix against the `--` form, which returns None for everything."""
+        self.assertIsInstance(gitutil.resolve_revision_epoch(self.repo, "HEAD"), float)
+        self.assertIsInstance(gitutil.resolve_revision_epoch(self.repo, self.sha), float)
+
+    def test_resolve_revision_epoch_refuses_a_dash_leading_revision(self) -> None:
+        """Unguarded, git reads this as `--output=FILE` and writes the file."""
+        target = self.repo / "pwned"
+        self.assertIsNone(gitutil.resolve_revision_epoch(self.repo, f"--output={target}"))
+        self.assertFalse(target.exists(), f"{target} was written — the revision was parsed as an option")
+
+    def test_resolve_revision_epoch_returns_none_for_an_unknown_revision(self) -> None:
+        self.assertIsNone(gitutil.resolve_revision_epoch(self.repo, "no-such-rev"))
+
+    def test_is_ancestor_still_answers_for_ordinary_revisions(self) -> None:
+        self.assertTrue(gitutil.is_ancestor(self.repo, self.sha, "HEAD"))
+
+    def test_is_ancestor_is_false_for_a_dash_leading_revision(self) -> None:
+        self.assertFalse(gitutil.is_ancestor(self.repo, "--output=/dev/null", "HEAD"))
+
+    def test_is_ancestor_is_false_for_an_unresolvable_ancestor(self) -> None:
+        """Documented contract: never raises, so a since-rewritten commit reads
+        as a plain FAIL rather than an exception."""
+        self.assertFalse(gitutil.is_ancestor(self.repo, "no-such-rev", "HEAD"))
+
+
+class TestRepoQueries(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.repo = Path(self._tmp.name)
+        init_repo(self.repo)
+        (self.repo / "a.txt").write_text("one", encoding="utf-8")
+        self.sha = commit_all(self.repo, "first")
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_git_repo_root_resolves_from_a_subdirectory(self) -> None:
+        nested = self.repo / "deep" / "deeper"
+        nested.mkdir(parents=True)
+        root = gitutil.git_repo_root(nested)
+        self.assertIsNotNone(root)
+        self.assertEqual(root.resolve(), self.repo.resolve())
+
+    def test_git_repo_root_is_none_outside_a_repo(self) -> None:
+        with TemporaryDirectory() as outside:
+            self.assertIsNone(gitutil.git_repo_root(Path(outside)))
+
+    def test_working_tree_status_is_empty_when_clean_and_not_when_dirty(self) -> None:
+        self.assertEqual(gitutil.working_tree_status(self.repo), "")
+        (self.repo / "a.txt").write_text("changed", encoding="utf-8")
+        self.assertIn("a.txt", gitutil.working_tree_status(self.repo))
+
+    def test_current_branch_reports_the_checked_out_branch(self) -> None:
+        subprocess.run(["git", "-C", str(self.repo), "checkout", "-q", "-b", "feat/x"], check=True)
+        self.assertEqual(gitutil.current_branch(self.repo), "feat/x")
+
+    def test_current_branch_falls_back_to_HEAD_when_detached(self) -> None:
+        """Matches `bin/gate-ledger`'s `branch_name()` fallback exactly, so a
+        detached capture and a ledger file written on it agree on the name."""
+        subprocess.run(["git", "-C", str(self.repo), "checkout", "-q", "--detach"], check=True)
+        self.assertEqual(gitutil.current_branch(self.repo), "HEAD")
+
+    def test_last_commit_sha_and_epoch_returns_the_head_commit(self) -> None:
+        result = gitutil.last_commit_sha_and_epoch(self.repo)
+        self.assertIsNotNone(result)
+        sha, epoch = result
+        self.assertEqual(sha, self.sha)
+        self.assertIsInstance(epoch, float)
+
+    def test_last_commit_sha_and_epoch_is_none_with_no_commits(self) -> None:
+        """`init_repo` makes an initial commit, so this bootstraps by hand — the
+        empty-repo branch is exactly what the helper's `returncode != 0` guard
+        is for, and using `init_repo` here would assert nothing."""
+        with TemporaryDirectory() as empty:
+            subprocess.run(["git", "init", "-q", "-b", "main", empty], check=True, capture_output=True)
+            self.assertIsNone(gitutil.last_commit_sha_and_epoch(Path(empty)))
+
+    def test_branch_exists_distinguishes_present_from_absent(self) -> None:
+        subprocess.run(["git", "-C", str(self.repo), "branch", "feat/y"], check=True)
+        self.assertTrue(gitutil.branch_exists(self.repo, "feat/y"))
+        self.assertFalse(gitutil.branch_exists(self.repo, "feat/nope"))
+
+    def test_worktree_registered_answers_for_both_states(self) -> None:
+        with TemporaryDirectory() as parent:
+            added = Path(parent) / "wt"
+            self.assertFalse(gitutil.worktree_registered(self.repo, added))
+            subprocess.run(
+                ["git", "-C", str(self.repo), "worktree", "add", "-q", str(added), "-b", "wt-branch"],
+                check=True, capture_output=True,
+            )
+            self.addCleanup(
+                subprocess.run,
+                ["git", "-C", str(self.repo), "worktree", "remove", "--force", str(added)],
+                capture_output=True, check=False,
+            )
+            self.assertTrue(gitutil.worktree_registered(self.repo, added))
+
+
+class TestBranchSlug(unittest.TestCase):
+    """Parity with `bin/gate-ledger:37` is covered by
+    `test_evidence_capture.py`; these pin the rule itself."""
+
+    def test_every_slash_becomes_a_dash(self) -> None:
+        self.assertEqual(gitutil.branch_slug("epic/m11/story"), "epic-m11-story")
+
+    def test_a_branch_without_a_slash_is_unchanged(self) -> None:
+        self.assertEqual(gitutil.branch_slug("main"), "main")
+
+    def test_the_documented_collision_is_still_the_behavior(self) -> None:
+        """`feat/foo` and `feat-foo` slug identically — documented at
+        `bin/gate-ledger:273` and inherited deliberately, which is why the
+        manifest records the branch *name* and resolution matches on it."""
+        self.assertEqual(gitutil.branch_slug("feat/foo"), gitutil.branch_slug("feat-foo"))
+
+
+class TestDefaultTimeoutIsWhatUnflaggedRunsUse(unittest.TestCase):
+    """#227: `DEFAULT_TIMEOUT_SECONDS` had no test asserting it is the value an
+    unflagged run actually applies — only explicit non-default `--timeout`
+    values were ever exercised, so the wiring could drift from the constant.
+    """
+
+    def test_the_shared_constant_is_600_seconds(self) -> None:
+        self.assertEqual(gitutil.DEFAULT_TIMEOUT_SECONDS, 600.0)
+
+    def test_both_sharing_scripts_default_to_it_rather_than_a_literal(self) -> None:
+        """The constant exists so `verify` and `worktree-setup` cannot drift
+        apart; a literal in either `add_argument` would defeat that silently."""
+        for name in ("verify", "worktree-setup"):
+            with self.subTest(script=name):
+                text = (SCRIPTS / name).read_text(encoding="utf-8")
+                self.assertIn("default=DEFAULT_TIMEOUT_SECONDS", text)
+
+    def test_the_help_text_an_unflagged_user_reads_names_the_real_default(self) -> None:
+        for name in ("verify", "worktree-setup"):
+            with self.subTest(script=name):
+                result = subprocess.run(
+                    [str(SCRIPTS / name), "--help"], capture_output=True, text=True, timeout=30, check=False
+                )
+                self.assertIn("600", result.stdout, "help text does not state the real default timeout")
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(unittest.main())

--- a/tests/jig/test_verify.py
+++ b/tests/jig/test_verify.py
@@ -60,6 +60,8 @@ Run with:
 """
 from __future__ import annotations
 
+import importlib.machinery
+import importlib.util
 import json
 import os
 import re
@@ -82,6 +84,33 @@ def _normalize_ws(text: str) -> str:
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "verify"
+
+
+def _script_constant(name: str):
+    """Read a module-level constant out of `verify` by importing it by path.
+
+    The bound the probe tests exercise has to be the one `verify` actually
+    applies; restating the number here would let the two drift apart silently,
+    which is the failure `DEFAULT_TIMEOUT_SECONDS` was already filed for (#227).
+    Loading under a non-`__main__` name leaves the CLI entry point dormant.
+    The loader is explicit because `verify` has no `.py` suffix, so importlib
+    cannot infer one from the filename.
+    """
+    loader = importlib.machinery.SourceFileLoader("_verify_under_test", str(SCRIPT))
+    spec = importlib.util.spec_from_file_location("_verify_under_test", SCRIPT, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # `verify` defines dataclasses, and `@dataclass` resolves annotations via
+    # `sys.modules[cls.__module__]` — absent that entry it raises on an
+    # unregistered module rather than importing.
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        return getattr(module, name)
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+MAX_PROBE_ARTIFACT_BYTES = _script_constant("MAX_PROBE_ARTIFACT_BYTES")
 
 
 def run_script(args: list[str]) -> subprocess.CompletedProcess[str]:
@@ -192,6 +221,54 @@ class TestVerifyCommandTiers(unittest.TestCase):
             self.assertEqual(result.returncode, 1)
             self.assertIn("[PASS] item 1", result.stdout)
             self.assertIn("[FAIL] item 2", result.stdout)
+
+
+class TestProbeArtifactReadIsBounded(unittest.TestCase):
+    """#223: the probe `pattern` is caller-supplied and `re` has no match
+    timeout, so an unbounded read handed a catastrophic-backtracking pattern an
+    unbounded input. `verify`'s job is to be the thing that cannot be talked out
+    of a verdict, and a silent hang defeats that more thoroughly than a wrong
+    answer — so an oversized artifact refuses loudly instead.
+    """
+
+    def _run_probe(self, tmp: Path, size: int, pattern: str | None) -> subprocess.CompletedProcess[str]:
+        since = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        artifact = tmp / "big.txt"
+        with artifact.open("w", encoding="utf-8") as handle:
+            handle.write("x" * size)
+        item = {"id": 1, "kind": "cap", "tier": "probe", "artifact": str(artifact)}
+        if pattern is not None:
+            item["pattern"] = pattern
+        return run_script(["--items", str(write_items(tmp, [item])), "--since", since])
+
+    def test_an_artifact_over_the_limit_fails_rather_than_matching(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run_probe(Path(tmp), MAX_PROBE_ARTIFACT_BYTES + 1, "xxx")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("too large to pattern-match safely", result.stdout)
+
+    def test_the_refusal_names_both_the_size_and_the_limit(self) -> None:
+        """A verdict a reader can act on: the bound is a build-phase constant,
+        so the message has to say what it is rather than just 'too large'."""
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run_probe(Path(tmp), MAX_PROBE_ARTIFACT_BYTES + 1, "xxx")
+        self.assertIn(str(MAX_PROBE_ARTIFACT_BYTES + 1), result.stdout)
+        self.assertIn(str(MAX_PROBE_ARTIFACT_BYTES), result.stdout)
+
+    def test_an_artifact_at_the_limit_is_still_matched(self) -> None:
+        """The bound is a ceiling on what is read, not a new failure mode for
+        ordinary artifacts — off-by-one here would reject a legitimate probe."""
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run_probe(Path(tmp), MAX_PROBE_ARTIFACT_BYTES, "x+")
+        self.assertEqual(result.returncode, 0, result.stdout)
+
+    def test_an_oversized_artifact_without_a_pattern_still_passes(self) -> None:
+        """The cap exists to bound the *match*. A probe that only asserts the
+        artifact exists, is non-empty, and is fresh never reads its contents,
+        so size is none of its business."""
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run_probe(Path(tmp), MAX_PROBE_ARTIFACT_BYTES + 1, None)
+        self.assertEqual(result.returncode, 0, result.stdout)
 
 
 class TestVerifyProbeTier(unittest.TestCase):


### PR DESCRIPTION
Closes #205, closes #223. Addresses the first half of #227 — **#227 stays open**, see below.

Independent of #263 and #264; branches off `main`.

## #205 — direct coverage for `_gitutil`

Imported by 6 of 7 CLI scripts, no test of its own. Every edge case was only exercised through whichever importer happened to reach it.

`tests/jig/test_gitutil.py` covers the module directly. The one that mattered most: `run_shell_with_timeout`'s process-group cleanup. A backgrounded grandchild writes its own pid to a file, and the test asks the OS whether that pid actually died — rather than trusting the `TimeoutExpired`, which is exactly what plain `subprocess.run(timeout=...)` would also have raised while leaving the child alive.

## #223 — the issue's prescribed fix is wrong, and silently so

The issue asks for `--` before git positionals. **`--` marks what follows as a pathspec.** `git show -s --format=%ct -- HEAD` looks for a *file* named HEAD, finds none, and returns empty — so `resolve_revision_epoch` would return `None` for every revision, forever, with no error. Verified before writing the fix.

The correct guard is `--end-of-options`. Unguarded, the exposure is real:

```
$ git show -s --format=%ct --output=/tmp/pwned HEAD    # no guard
$ ls /tmp/pwned
-rw-r--r--  1 bryan  wheel  11 /tmp/pwned              # the "revision" wrote a file

$ git show -s --format=%ct --end-of-options --output=/tmp/pwned
fatal: option '--output=/tmp/pwned' must come before non-option arguments
```

Applied to `resolve_revision_epoch` and `is_ancestor`, the two helpers taking caller-supplied revisions (`verify --since` reaches both). A test asserts the file is *absent* after a dash-leading revision, and others assert ordinary revisions still resolve — which is what would catch the `--` form.

Deliberately not applied to `current_branch` (passes the literal `HEAD`) or `branch_exists` (interpolates behind `refs/heads/`, so it cannot begin with a dash). Neither could take the guard anyway: `git rev-parse` echoes `--end-of-options` as an output line rather than consuming it.

**Probe read is now bounded.** `verify`'s probe `pattern` is caller-supplied and `re` has no match timeout, so an unbounded read handed a catastrophic-backtracking pattern an unbounded input. Over `MAX_PROBE_ARTIFACT_BYTES` (8 MiB) it now refuses loudly, naming both the size and the limit.

Residual, stated at the constant rather than papered over: a pathological pattern can still backtrack badly on a *small* input. Bounding that needs either a match timeout (`regex` — a third-party dependency these scripts cannot take, since they ship to consuming projects and run on stock `python3`) or SIGALRM, which is main-thread-only while `--parallel` runs items in a `ThreadPoolExecutor`.

## #227 — half done, so it stays open

**Done:** `DEFAULT_TIMEOUT_SECONDS` now has the assertion it never had — that it is the value an unflagged run actually applies, checked against both scripts that share it and against the help text a user reads. Only explicit non-default `--timeout` values were previously exercised, so the wiring could drift from the constant that exists to keep the two in sync.

**Not done:** the cadence pre-dispatch pause. `grep -rl cadence scripts/ skills/ workflows/` returns exactly one file — `skills/build/SKILL.md`. The pause is prompt prose executed by a model; there is no code path a unittest can drive, so "give the risk-tagged pause a behavioral test" is not implementable in this suite. Today's vocabulary-presence assertions are the strongest mechanical check available. Making it genuinely testable means moving the cadence decision into code, which is a design change, not a test — and belongs in its own issue rather than being silently dropped here.

Suite goes **469 → 499**.