### PR TITLE
fix: give the load-bearing surfaces one task-heading grammar

### DIFF
--- a/scripts/_planparse.py
+++ b/scripts/_planparse.py
@@ -33,6 +33,13 @@ TASK_HEADING_RE = re.compile(r"^### Task (\d+)\b.*$", re.MULTILINE)
 # (e.g. a closing `## Not-here follow-ups`), either one ends a task block.
 HEADING_LEVEL_1_TO_3_RE = re.compile(r"^(#{1,3})[ \t]", re.MULTILINE)
 
+# The heading's title half, and the suffix `status-flip` writes onto it.
+# Both moved here from `plan-lint` (#206) rather than left there: the
+# load-bearing derivation needs titles on two surfaces, and a second copy is
+# exactly how the task-heading grammar diverged in the first place.
+TASK_HEADING_TITLE_RE = re.compile(r"^### Task \d+(?:\s*—\s*(.*))?$", re.MULTILINE)
+STATUS_FLIP_SUFFIX_RE = re.compile(r"\s*\[(?:PASS|REPLAN|ESCALATE)\]\s*$")
+
 ITEM_RE = re.compile(
     r"^[ \t]*(\d+)\.[ \t]*\[(cap|hold)\][ \t]*(.*?)[ \t]*(?:\(tier:[ \t]*([^)]*)\))?[ \t]*$",
     re.MULTILINE,
@@ -65,6 +72,35 @@ def split_tasks(text: str, boundary_re: re.Pattern[str] | None = None) -> list[t
         end = next((b for b in boundary_starts if b > start), len(text))
         tasks.append((m.group(1), text[start:end]))
     return tasks
+
+
+def task_title(block: str) -> str:
+    """The task's own heading title (after the em-dash), with any status-flip
+    suffix stripped -- "" if the heading carries no title at all (a bare
+    `### Task N`)."""
+    first_line = block.splitlines()[0] if block else ""
+    m = TASK_HEADING_TITLE_RE.match(first_line)
+    if not m or not m.group(1):
+        return ""
+    return STATUS_FLIP_SUFFIX_RE.sub("", m.group(1)).strip()
+
+
+def split_tasks_with_titles(
+    text: str, boundary_re: re.Pattern[str] | None = None
+) -> list[tuple[str, str, str]]:
+    """`split_tasks`, plus each block's heading title: (number, title, block).
+
+    Exists so every surface deriving the load-bearing set reads the same task
+    boundaries and the same titles (#206). `scripts/plan-lint` and the
+    test-side reference in `tests/jig/_load_bearing.py` previously each carried
+    their own heading regex, and disagreed on three inputs: a non-numeric label
+    (`Task 2a`), a hyphen where the em-dash belongs, and -- worst -- a trailing
+    coarser-level section, which the reference absorbed into the last task's
+    block. That last one is the naive-parser bug `skills/build/SKILL.md` Step
+    1.4 explicitly warns about, reproduced by the very module written to
+    demonstrate the rule.
+    """
+    return [(num, task_title(block), block) for num, block in split_tasks(text, boundary_re)]
 
 
 def parse_items(block: str) -> list[Item]:

--- a/scripts/plan-lint
+++ b/scripts/plan-lint
@@ -96,27 +96,19 @@ from _gitutil import git_repo_root  # noqa: E402
 from _planparse import (  # noqa: E402
     COMMAND_TIERS,
     HEADING_LEVEL_1_TO_3_RE,
+    STATUS_FLIP_SUFFIX_RE,  # noqa: F401  (re-export for tests/jig/_load_bearing.py)
     TASK_HEADING_RE,  # noqa: F401  (re-export for tests/_task_split_boundary.py)
+    TASK_HEADING_TITLE_RE,  # noqa: F401  (re-export, same reason)
     TIER_BODY_RE,
     VALID_TIERS,
     Item,
     parse_items,
+    task_title,
 )
 from _planparse import split_tasks as _split_tasks  # noqa: E402
 
 MAX_ITEMS = 5
 PLACEHOLDER_FOLLOWUPS = frozenset({"", "todo", "tbd", "..."})
-
-# Captures a task heading's own title text (after the em-dash), for
-# compute_load_bearing's title-match path (issue #62's sibling gap: the
-# reference tests/_load_bearing.py already matches this way; this was the
-# still-number-only copy). No title (a bare "### Task N" with nothing
-# after it) is fine -- _task_title returns "" and title-match never fires.
-TASK_HEADING_TITLE_RE = re.compile(r"^### Task \d+(?:\s*—\s*(.*))?$", re.MULTILINE)
-# scripts/status-flip's own SUFFIX_RE, duplicated here (scripts are
-# self-contained, not a shared package) so a title comparison ignores the
-# suffix status-flip appends and compares the same text a human reads.
-STATUS_FLIP_SUFFIX_RE = re.compile(r"\s*\[(?:PASS|REPLAN|ESCALATE)\]\s*$")
 # Located by heading *text*, not depth -- issue #23's heading-level fix is
 # the sibling plan-skill story's job, not this linter's.
 NOT_HERE_FOLLOWUPS_HEADING_RE = re.compile(r"^(#{1,6})[ \t]*Not-here follow-ups[ \t]*$", re.IGNORECASE | re.MULTILINE)
@@ -162,14 +154,11 @@ def strip_line_locator(span: str) -> str:
 
 
 def _task_title(block: str) -> str:
-    """The task's own heading title (after the em-dash), with any
-    status-flip suffix stripped -- "" if the heading carries no title at
-    all (a bare `### Task N`)."""
-    first_line = block.splitlines()[0] if block else ""
-    m = TASK_HEADING_TITLE_RE.match(first_line)
-    if not m or not m.group(1):
-        return ""
-    return STATUS_FLIP_SUFFIX_RE.sub("", m.group(1)).strip()
+    """`_planparse.task_title`, kept as a local name so this module's own
+    call sites and tests read unchanged. The grammar moved to `_planparse`
+    (#206) so the test-side reference derives titles from the same source
+    rather than a second regex that drifted."""
+    return task_title(block)
 
 
 def _is_number_match(rests_on_text: str, task_num: str) -> bool:

--- a/tests/jig/_load_bearing.py
+++ b/tests/jig/_load_bearing.py
@@ -18,24 +18,58 @@ collected" convention already established in this repo.
 """
 from __future__ import annotations
 
+import importlib.util
 import re
+import sys
 from collections import Counter
+from pathlib import Path
 
-TASK_HEADING_RE = re.compile(r"^### Task (\S+) — (.*)$", re.MULTILINE)
 RESTS_ON_RE = re.compile(r"^Rests on:\s*(.*)$", re.MULTILINE)
+
+_PLANPARSE = Path(__file__).resolve().parents[2] / "scripts" / "_planparse.py"
+
+
+def _load_planparse():
+    """Load `scripts/_planparse.py` — the shared task grammar, not either
+    surface's own code (#206).
+
+    This module used to carry its own `^### Task (\\S+) — (.*)$` and split at
+    the next task heading. Both halves diverged from the grammar the scripts
+    actually use, on three inputs: a non-numeric label (`Task 2a`), a hyphen
+    where the em-dash belongs, and a trailing coarser-level section. The last
+    one is the naive-parser bug `skills/build/SKILL.md` Step 1.4 explicitly
+    names — this module absorbed a closing `## Not-here follow-ups` into the
+    preceding task's block, so a `Rests on:` line down there was read as that
+    task's. The cross-surface agreement test never caught any of it because no
+    fixture sat on those boundaries.
+
+    Sharing the *tokenizer* costs nothing this module was built to provide.
+    Its reason to exist is demonstrating step 1.5's derivation — number match,
+    unambiguous title match, never self-referential — and that stays written
+    out here, independently of `plan-lint`'s.
+    """
+    spec = importlib.util.spec_from_file_location("_planparse_for_reference", _PLANPARSE)
+    module = importlib.util.module_from_spec(spec)
+    # `_planparse` defines a dataclass, and `@dataclass` resolves annotations
+    # through `sys.modules[cls.__module__]` — absent that entry it raises.
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(spec.name, None)
+        raise
+    return module
+
+
+_planparse = _load_planparse()
 
 
 def _task_blocks(plan_text: str) -> list[tuple[str, str, str]]:
     """Split `plan_text` into `(label, title, block_text)` triples, one per
-    `### Task <label> — <title>` heading, in document order -- mirroring
-    step 1.4's own "stop at the next `### ` heading" rule."""
-    headings = list(TASK_HEADING_RE.finditer(plan_text))
-    blocks = []
-    for i, match in enumerate(headings):
-        start = match.start()
-        end = headings[i + 1].start() if i + 1 < len(headings) else len(plan_text)
-        blocks.append((match.group(1), match.group(2).strip(), plan_text[start:end]))
-    return blocks
+    task heading, in document order -- the shared grammar's split, so this
+    reference and `plan-lint` cannot disagree on where a task begins, what
+    counts as one, or where it ends."""
+    return _planparse.split_tasks_with_titles(plan_text)
 
 
 def _is_number_match(rests_on_text: str, label: str) -> bool:

--- a/tests/jig/fixtures/plan-lint/boundary-heading-variants.md
+++ b/tests/jig/fixtures/plan-lint/boundary-heading-variants.md
@@ -1,0 +1,79 @@
+# Plan: task-block boundary fixture — heading label and separator variants
+
+A structural fixture for `tests/jig/test_load_bearing_cross_surface.py`
+(issue #206) — not a real build plan, never run through `/build`.
+
+`skills/build/SKILL.md` documents the heading as `### Task N — <title>`.
+Two near-miss forms sat outside every existing fixture, and the two
+load-bearing surfaces answered them differently:
+
+* **A non-numeric label** (`### Task 2a`). The shared grammar matches
+  `Task (\d+)\b`, so `2a` is not a task heading. It is still a `### `
+  heading, so it ends the preceding block, and its own content belongs to
+  no task — its `Rests on:` line names nothing. The old test-side reference
+  matched `Task (\S+)`, counted it as a task, and let that line contribute.
+* **A hyphen where the em-dash belongs** (`### Task 3 - ...`). The shared
+  grammar accepts it — the title half is optional, which is what lets a
+  `status-flip`-written `[PASS]` suffix survive re-parsing. The old
+  reference required a literal ` — ` and skipped the heading entirely,
+  folding its block into the previous task's.
+
+Expected load-bearing set: **`{3}`** — Task 4 rests on Task 3 by number,
+and Task 3 is a real task despite its hyphen. Task 2a's `Rests on: Task 1`
+is outside every task block and contributes nothing, so `1` is absent.
+
+The old reference produced `{1}` here instead: it saw tasks `1`, `2a`, `4`,
+read Task 2a's line as a real dependency, and never saw Task 3 at all — so
+`3` could not be load-bearing and `1` wrongly was. Both wrong, in opposite
+directions, on one fixture.
+
+That a malformed label is silently skipped rather than reported is a
+separate question — a `plan-lint` validation gap, not a divergence — and is
+deliberately not what this fixture asserts.
+
+### Task 1 — Add a `quintuple` helper to `_gitutil.py`
+Why now:    the task only the out-of-grammar heading points at, so a wrong parse is visible.
+Read first: `scripts/_gitutil.py`
+Rests on:   n/a -- first task.
+Do:         add `quintuple(n)` to `scripts/_gitutil.py`.
+Not here:   no CLI flag, no other helpers.
+
+Done means:
+1. [cap]  `quintuple(n)` returns `5 * n` for any int n   (tier: script `scripts/_gitutil.py`)
+2. [hold] `scripts/_gitutil.py`'s existing helpers still import cleanly   (tier: script `scripts/_gitutil.py`)
+Evidence: n/a -- structural fixture only, not a real build.
+
+### Task 2a — Non-numeric label, outside the documented grammar
+Why now:    the label-format boundary this fixture exists for.
+Read first: `scripts/plan-lint`
+Rests on:   Task 1 -- named here, but this heading is not a task block, so it counts for nothing.
+Do:         nothing; this heading is the fixture.
+Not here:   no real work.
+
+Done means:
+1. [cap]  the shared grammar does not treat this heading as a task   (tier: probe)
+Evidence: n/a -- structural fixture only, not a real build.
+
+### Task 3 - Hyphen separator instead of an em-dash
+Why now:    the separator boundary this fixture exists for.
+Read first: `scripts/plan-lint`
+Rests on:   n/a -- depends on nothing. Deliberately names no other heading: a
+            number mentioned anywhere on this line would itself be read as a
+            dependency, which is the point of the number-match path.
+Do:         nothing; this heading is the fixture.
+Not here:   no real work.
+
+Done means:
+1. [cap]  the shared grammar still reads this as task 3   (tier: probe)
+Evidence: n/a -- structural fixture only, not a real build.
+
+### Task 4 — Depend on the hyphen-separated task by number
+Why now:    makes Task 3's task-hood observable in the load-bearing set.
+Read first: `scripts/plan-lint`
+Rests on:   Task 3 -- a real dependency, on a real task block.
+Do:         nothing; this heading is the fixture.
+Not here:   no real work.
+
+Done means:
+1. [cap]  task 3 is load-bearing because this task names it   (tier: probe)
+Evidence: n/a -- structural fixture only, not a real build.

--- a/tests/jig/fixtures/plan-lint/boundary-trailing-section.md
+++ b/tests/jig/fixtures/plan-lint/boundary-trailing-section.md
@@ -1,0 +1,55 @@
+# Plan: task-block boundary fixture — trailing coarser-level section
+
+A structural fixture for `tests/jig/test_load_bearing_cross_surface.py`
+(issue #206) — not a real build plan, never run through `/build`.
+
+`skills/build/SKILL.md` Step 1.4 requires a task block to stop at the next
+heading *and* to "explicitly exclude any trailing content at a coarser
+heading level (e.g. a closing `## Not-here follow-ups` section) from the
+last task's block — a naive parser silently absorbs that trailing section
+into the preceding task card (a real bug the project's own M0 dogfood
+surfaced)".
+
+`load-bearing-title-match.md` already carries such a trailing section, but
+nothing inside it looks like a `Rests on:` line, so a parser that wrongly
+absorbed it produced the same answer anyway. This fixture puts a
+`Rests on:` line down there — a deferred task sketched in the follow-ups,
+which is what that section is for.
+
+Neither task rests on the other, so the load-bearing set is **empty**. A
+parser that absorbs the trailing section into Task 2's block reads
+`Rests on: Task 1` as Task 2's own and reports `{1}` instead.
+
+### Task 1 — Add a `quadruple` helper to `_gitutil.py`
+Why now:    gives the trailing-section boundary two independent tasks to sit after.
+Read first: `scripts/_gitutil.py`
+Rests on:   n/a -- first task.
+Do:         add `quadruple(n)` to `scripts/_gitutil.py`.
+Not here:   no CLI flag, no other helpers.
+
+Done means:
+1. [cap]  `quadruple(n)` returns `4 * n` for any int n   (tier: script `scripts/_gitutil.py`)
+2. [hold] `scripts/_gitutil.py`'s existing helpers still import cleanly   (tier: script `scripts/_gitutil.py`)
+Evidence: n/a -- structural fixture only, not a real build.
+
+### Task 2 — Document the helper in the module docstring
+Why now:    deliberately independent of Task 1 so the expected set is empty.
+Read first: `scripts/_gitutil.py`
+Rests on:   n/a -- nothing in this plan.
+Do:         add one line to `scripts/_gitutil.py`'s module docstring.
+Not here:   no behavior change.
+
+Done means:
+1. [cap]  the module docstring names the new helper   (tier: script `scripts/_gitutil.py`)
+2. [hold] no callable in `scripts/_gitutil.py` changes behavior   (tier: script `scripts/_gitutil.py`)
+Evidence: n/a -- structural fixture only, not a real build.
+
+## Not-here follow-ups
+- Wire the helper into a real CLI flag once a caller actually needs one.
+
+A future task, deferred out of this plan rather than carded here. Its
+dependency line is written at column 0, the same shape a real task block
+uses, which is exactly what a parser that absorbed this section would
+mistake for the preceding task's own:
+
+Rests on:   Task 1 -- it would call `quadruple`, so it cannot start until that lands.

--- a/tests/jig/test_load_bearing_cross_surface.py
+++ b/tests/jig/test_load_bearing_cross_surface.py
@@ -35,7 +35,17 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURES = REPO_ROOT / "tests" / "jig" / "fixtures" / "plan-lint"
 BUILD_SKILL_MD = REPO_ROOT / "skills" / "build" / "SKILL.md"
 
-FIXTURE_NAMES = ("clean-plan.md", "broken-plan.md", "load-bearing-title-match.md")
+FIXTURE_NAMES = (
+    "clean-plan.md",
+    "broken-plan.md",
+    "load-bearing-title-match.md",
+    # Boundary fixtures (#206). The three above are all parsed identically by
+    # any reasonable task-heading grammar, which is why the agreement they
+    # proved was weaker than it read: the two surfaces carried different
+    # regexes and disagreed on all three inputs below.
+    "boundary-trailing-section.md",
+    "boundary-heading-variants.md",
+)
 
 
 class TestStep1_5DocumentsBothMatchPaths(unittest.TestCase):
@@ -61,7 +71,7 @@ class TestTwoSurfacesAgreeOnLoadBearingSets(unittest.TestCase):
     def setUp(self) -> None:
         self.plan_lint_module = load_plan_lint_module()
 
-    def test_all_three_fixtures_agree(self) -> None:
+    def test_every_fixture_agrees(self) -> None:
         for fixture_name in FIXTURE_NAMES:
             with self.subTest(fixture=fixture_name):
                 text = (FIXTURES / fixture_name).read_text(encoding="utf-8")
@@ -93,6 +103,30 @@ class TestTwoSurfacesAgreeOnLoadBearingSets(unittest.TestCase):
         )
         self.assertNotIn("Task 1", rests_on_line)
         self.assertEqual(surface_1_plan_lint(self.plan_lint_module, text), frozenset({"1"}))
+
+    def test_a_trailing_coarser_section_contributes_nothing(self) -> None:
+        """Step 1.4's explicit exclusion, which the old reference violated:
+        it split only at the next *task* heading, so a closing
+        `## Not-here follow-ups` was absorbed into the last task's block and
+        a `Rests on:` line down there was read as that task's own. Agreement
+        alone would not catch this -- both surfaces could agree on `{1}` --
+        so the expected set is asserted outright.
+        """
+        text = (FIXTURES / "boundary-trailing-section.md").read_text(encoding="utf-8")
+        # rsplit: the fixture's own header prose names the heading too, and the
+        # section that matters is the trailing one.
+        self.assertIn("Rests on:   Task 1", text.rsplit("## Not-here follow-ups", 1)[1])
+        self.assertEqual(surface_1_plan_lint(self.plan_lint_module, text), frozenset())
+        self.assertEqual(surface_2_reference(text), frozenset())
+
+    def test_only_the_documented_heading_form_contributes(self) -> None:
+        """`Task 2a` is outside the documented `### Task N` grammar, so it is
+        not a task block and its `Rests on:` line names nothing; `Task 3 -`
+        (hyphen, not em-dash) still is one. The old reference inverted both:
+        it accepted any `\\S+` label and required a literal em-dash."""
+        text = (FIXTURES / "boundary-heading-variants.md").read_text(encoding="utf-8")
+        self.assertEqual(surface_1_plan_lint(self.plan_lint_module, text), frozenset({"3"}))
+        self.assertEqual(surface_2_reference(text), frozenset({"3"}))
 
 
 class TestMutationIsCaughtAsMismatch(unittest.TestCase):


### PR DESCRIPTION
Closes #206.

## The divergence is real, and worse than filed

`scripts/plan-lint` and the test-side reference in `tests/jig/_load_bearing.py` each carried their own task-heading regex. Measured against the two surfaces directly, before any change:

| input | `plan-lint` | reference | correct |
|---|---|---|---|
| trailing `## Not-here follow-ups` with a `Rests on:` line | `{}` | `{1}` | `{}` |
| `### Task 2a — ...` (non-numeric label) | `{}` | `{1}` | `{}` |
| `### Task 3 - ...` (hyphen, not em-dash) | `{1}` | `{}` | `{1}` |

The issue names the label and separator cases. **The third one it doesn't name is the serious one**, and it isn't the heading regex at all — it's the block-end rule. The reference split only at the next *task* heading, so a closing `## Not-here follow-ups` section was absorbed into the last task's block, and a `Rests on:` line down there was read as that task's own dependency.

That is precisely the bug `skills/build/SKILL.md` Step 1.4 exists to warn about:

> **Explicitly exclude any trailing content at a coarser heading level** (e.g. a closing `## Not-here follow-ups` section) from the last task's block — a naive parser silently absorbs that trailing section into the preceding task card (a real bug the project's own M0 dogfood surfaced)

Reproduced by the module written to demonstrate the rule.

## Which surface was right

`plan-lint`'s, on all three. Step 1.4's documented rule is "stop at the next `### ` heading" *plus* the coarser-level exclusion — exactly `_planparse`'s `HEADING_LEVEL_1_TO_3_RE`. The documented heading form is `### Task N — <title>`, which is `Task (\d+)`, not `Task (\S+)`.

## The change

`_planparse` gains `split_tasks_with_titles`, plus `TASK_HEADING_TITLE_RE` and `STATUS_FLIP_SUFFIX_RE` moved out of `plan-lint`. Both surfaces read task boundaries, labels, and titles from that one place. `plan-lint`'s `_task_title` becomes a thin alias so its own call sites and tests read unchanged.

That also retires a duplicate the issue doesn't mention: `plan-lint` carried its own copy of `status-flip`'s `SUFFIX_RE`, commented as "duplicated here (scripts are self-contained, not a shared package)" — which stopped being true when `_planparse` was introduced.

**What stays independent is what the cross-surface test exists to check.** The reference still writes out Step 1.5's derivation — number match, unambiguous title match, never self-referential — separately from `plan-lint`'s. Sharing a *tokenizer* costs that nothing; the two implementations of the *algorithm* are the point.

## Fixtures, and why agreement alone wasn't enough

Two fixtures now sit on the boundaries. Both assert an expected set outright, not just agreement — two surfaces can agree on a wrong answer, and under a shared tokenizer that risk goes up, not down.

Writing them surfaced two ways a fixture can quietly prove nothing, both of which I hit:

- `RESTS_ON_RE` anchors at column 0, so an indented `Rests on:` line in the follow-ups section matched neither parser and the fixture passed under both.
- In the first draft of the variants fixture, both grammars reached `{1}` by different routes — a false agreement.

Verified by mutation: restoring the old grammar fails **4** tests, including agreement on both new fixtures. The first draft failed 0.

Suite goes **504 → 506**. Rebased onto `main` after #263, #264, and #265 merged; the vermin gate #263 added passes against the `_planparse` changes.

## Not addressed

A malformed label (`Task 2a`) is silently skipped rather than reported. That's a `plan-lint` validation gap, not a divergence — both surfaces now agree it contributes nothing — and it wants its own issue rather than being folded in here.