### PR TITLE
docs: re-affirm design-record disposability against the SDLC playbook triad

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,10 @@ do not share a runner or a conftest. Don't unify them opportunistically.
 
 ## Where a design record lives
 
-Ratified 2026-07-25 (#219, #216, #181). One rule, two classes:
+Ratified 2026-07-25 (#219, #216, #181). Re-affirmed 2026-09-05 (#313) against a
+committed-artifact alternative (Anthropic's AI-native SDLC playbook's `intent.md`/
+`spec.md`/`plan.md`); the ruling and its rationale are
+`docs/design-record-disposability.md`. One rule, two classes:
 
 - **Disposable** — a `/shape` doc (`docs/design/<slug>.md`), `PLAN.md`, and demonstration
   scratch. Gitignored, branch-local, removed by `/ship` at closeout. Never committed;

--- a/docs/design-record-disposability.md
+++ b/docs/design-record-disposability.md
@@ -1,0 +1,47 @@
+# Design records stay disposable — 2026-09-05 re-affirmation
+
+**Status:** ratified · **Date:** 2026-09-05 · **Ruling on:** [#313](https://github.com/jacquardlabs/studious/issues/313) · **Milestone:** [#20 (M0)](https://github.com/jacquardlabs/studious/milestone/20)
+
+CLAUDE.md's "Where a design record lives" (ratified 2026-07-25, #219/#216/#181) makes
+`docs/design/<slug>.md` and `PLAN.md` gitignored and branch-local, removed at closeout;
+only the pre-mortem register (`docs/studious/premortems/<slug>.md`), the review reports
+under `docs/studious/<area>-reviews/`, and decision records at `docs/` root outlive the
+branch. #313 asked whether the software-factory work (M0 and after) should reopen that
+rule, because Anthropic's AI-native SDLC playbook (2026-08-21) commits `intent.md`,
+`spec.md`, and `plan.md` to version control and cites them from PR review, and #31 (spec
+traceability) is only possible on that model.
+
+## Decision
+
+**The rule stands, unchanged.** The durable spine for a feature's history is the
+pre-mortem register, `docs/studious/decisions.jsonl` (the `/bet` verdict journal,
+`reference/decision-journal-format.md`), and the PR evidence table `/ship` assembles at
+closeout — not a committed spec or plan. `docs/design/<slug>.md` and `PLAN.md` keep dying
+at merge. **#31 stays parked by design**, not by oversight: it asks for traceability that
+only a committed spec can give, and a committed spec is exactly what this ruling rejects.
+
+## Why, against the alternative actually on the table
+
+The playbook's `intent.md`/`spec.md`/`plan.md` triad is real prior art, not a strawman —
+it is what a comparable vendor playbook does, and it is why this got re-litigated instead
+of assumed. Rejected anyway, because a committed design record is **the fourth document
+class** the 2026-07-25 rule exists to prevent, and the cost of that fourth class is
+already on this repo's own record: `docs/superpowers/{plans,specs}/` held 42 of this
+repo's own design records under a third-party product's name, and 35 had gone stale
+before it was deleted rather than renamed. Traceability bought at that price — a growing
+pile of specs nobody is committed to keeping current — is not traceability, it's drift
+with a paper trail.
+
+What retrieves a feature's design history instead: the pre-mortem register records
+`Branch:` and `SHA:`, which resolve through git history without a path that expires. A
+disposable doc that lived on a merged branch is one `git show <sha>:<path>` away for as
+long as the branch's commits survive, which is exactly as long as anything else this repo
+keeps.
+
+## What would overturn this
+
+If a future story needs #31's traceability badly enough to pay the fourth-class cost —
+concretely, if the pre-mortem register + evidence table prove insufficient to answer
+"why does this code look like this" for a real incident — reopen #313 with that incident
+named. Don't reopen it on the strength of a vendor blog post alone; that evidence was
+already weighed here and found insufficient on its own.

--- a/tests/python/test_design_record_disposability.py
+++ b/tests/python/test_design_record_disposability.py
@@ -1,0 +1,67 @@
+"""The 2026-09-05 re-affirmation of the disposability rule (#313) records itself, and
+the fourth document class it rejected does not quietly reappear.
+
+#313 asked whether the software-factory work should reopen CLAUDE.md's "Where a design
+record lives" (ratified 2026-07-25) in favor of a committed intent/spec/plan triad. The
+answer was no — see `docs/design-record-disposability.md` — and this test pins three
+things a later change could silently undo: the ruling record exists and is cited from
+CLAUDE.md, it names both paths the rule already governs, and no committed file has crept
+in under the exact triad names the ruling rejected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RULING = REPO_ROOT / "docs" / "design-record-disposability.md"
+
+
+def test_the_ruling_record_exists() -> None:
+    assert RULING.exists(), (
+        "docs/design-record-disposability.md is the #313 ruling CLAUDE.md cites — "
+        "it must not be renamed or removed without updating that citation"
+    )
+
+
+def test_claude_md_cites_the_ruling() -> None:
+    claude_md = (REPO_ROOT / "CLAUDE.md").read_text()
+    assert "design-record-disposability.md" in claude_md, (
+        "CLAUDE.md's 'Where a design record lives' section must cite the #313 "
+        "re-affirmation by path, the same way it cites the 2026-07-25 ratification"
+    )
+
+
+def test_the_ruling_names_both_disposable_paths() -> None:
+    text = RULING.read_text()
+    assert "docs/design/" in text
+    assert "PLAN.md" in text
+
+
+def test_the_ruling_names_what_it_rejected() -> None:
+    """The ruling is a decision against a named alternative, not an assertion — a
+    reader needs to see what was weighed and rejected, not just the verdict."""
+    text = RULING.read_text()
+    for token in ("intent.md", "spec.md", "plan.md"):
+        assert token in text, f"the rejected playbook artifact {token!r} must be named"
+
+
+def test_no_committed_playbook_triad_file() -> None:
+    """The fourth document class this ruling rejects is a committed intent.md,
+    spec.md, or plan.md anywhere in the tree — not just at the root, since a
+    per-feature docs/design/<slug>/spec.md would be the same drift under a deeper
+    path. PLAN.md itself is covered by test_no_ignored_paths_tracked.py; this checks
+    the sibling names that rule doesn't watch."""
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "ls-files"], cwd=REPO_ROOT, capture_output=True, text=True, check=True
+    )
+    tracked = result.stdout.splitlines()
+    offenders = [
+        p for p in tracked if Path(p).name in ("intent.md", "spec.md", "plan.md")
+    ]
+    assert not offenders, (
+        "a committed intent.md/spec.md/plan.md is the fourth document class #313 "
+        f"rejected: {offenders}"
+    )


### PR DESCRIPTION
Closes #313.

Studious's disposability rule (`docs/design/`, `PLAN.md` gitignored and branch-local;
the pre-mortem register + `decisions.jsonl` + PR evidence table are the durable spine)
stays as ratified 2026-07-25. #313 asked whether the software-factory work (M0) should
reopen it in favor of Anthropic's AI-native SDLC playbook's committed
`intent.md`/`spec.md`/`plan.md` triad.

**Decision: keep the current rule.** A committed design record is the fourth document
class the 2026-07-25 rule exists to prevent — `docs/superpowers/{plans,specs}/` already
showed the cost (42 records, 35 stale) before it was deleted. `#31` (spec traceability)
stays parked by design.

## Changes

- `docs/design-record-disposability.md` — the durable ruling record: what was decided,
  what alternative it was ruled against, and what would overturn it.
- `CLAUDE.md` — one sentence in "Where a design record lives" citing the re-affirmation.
- `tests/python/test_design_record_disposability.py` — pins the CLAUDE.md citation, the
  named disposable paths, the rejected playbook filenames, and that no committed
  `intent.md`/`spec.md`/`plan.md` creeps into the tree.

No code change — `.gitignore`, `test_no_ignored_paths_tracked.py`, and `/ship`'s closeout
are unchanged, because the ruling's whole content is that they were already right.

## Verification

```
npx -y markdownlint-cli2
uv run --no-project python scripts/check_references.py
uv run --no-project python scripts/validate_plugin.py
uv run --no-project python scripts/check_gate_independence.py
uv run --no-project --with pytest pytest tests/python -v   # 762 passed
```