### PR TITLE
fix: build-script exit-code gaps blocking clean unattended evidence (#208, #242)

### DIFF
--- a/scripts/verify
+++ b/scripts/verify
@@ -16,8 +16,12 @@ item list from exactly one of two sources:
   `scripts/_planparse.py` module so the two scripts can't drift apart.
   `--task` names the task by its heading number (`3` or `Task 3`).
   A `script`/`test-backed` item's backtick-quoted repo-relative method
-  path becomes its `command` verbatim; that derivation is fully
-  mechanical. A `probe` item's artifact/pattern isn't in the plan grammar
+  path becomes its `command`, resolved mechanically (issue #208, never a
+  guess): verbatim when the path is itself executable; run through
+  whichever test runner owns its tree when it is a `.py` file under
+  `tests/python/` (`pytest`) or `tests/jig/` (`unittest discover`,
+  narrowed to that one filename) — see `resolve_command_for_method`'s own
+  docstring below for the full rule. A `probe` item's artifact/pattern isn't in the plan grammar
   at all, so it comes from the optional `--probe-spec <json>` supplement
   (see `PROBE_SPEC_SCHEMA` below) — a task whose block has probe items
   but no supplement entry for them is a usage error (exit 2) naming
@@ -105,13 +109,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
+import shlex
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from textwrap import indent
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -236,7 +242,51 @@ def parse_item_tier(item: Item) -> tuple[str, str | None]:
     return tier_word, method_path
 
 
-def derive_items_from_plan(plan_path: Path, task_label: str, probe_spec_path: Path | None) -> dict:
+def resolve_command_for_method(method_path: str, repo_root: Path) -> str:
+    """Turn a `script`/`test-backed` item's cited method path into a runnable shell
+    command, mechanically -- never a guess (issue #208).
+
+    `scripts/plan-lint`'s own `check_item_tier` requires only that the path *exist*
+    on disk; most of what satisfies that -- every test file, every `SKILL.md`, every
+    markdown report -- carries no execute bit and no shebang. Treating the path
+    itself as the command (this repo's behavior before this fix) fails every one of
+    those deterministically with exit 126 ("Permission denied"), regardless of
+    whether the underlying claim is true.
+
+    Two cases get a real command:
+    - The path is executable on disk: unchanged, verbatim -- this is jig's own
+      handful of directly-runnable scripts (`scripts/plan-lint`, `scripts/verify`,
+      ...).
+    - The path is a `.py` file under one of this repo's two test trees
+      (CLAUDE.md's "Two test runners, deliberately"): the command runs that ONE
+      file through whichever runner already owns its tree -- `pytest <path> -q`
+      for `tests/python/`, `python3 -m unittest discover -s <dir> -p <basename>`
+      for `tests/jig/` (unittest has no single-file invocation; `-p` narrows
+      discovery to one filename so the rest of the tree isn't swept in).
+
+    Anything else falls through to the path itself, unchanged -- the same
+    behavior as before this fix, and out of its scope: a `test-backed` item
+    citing neither an executable nor a file under either test tree is a plan-
+    authoring problem `scripts/plan-lint` should catch, not something this
+    script can rescue by guessing an interpreter.
+    """
+    full = repo_root / method_path
+    if os.access(full, os.X_OK):
+        return method_path
+    if full.suffix == ".py" and full.is_file():
+        try:
+            parts = full.resolve().relative_to(repo_root.resolve()).parts
+        except ValueError:
+            parts = ()
+        if parts[:2] == ("tests", "python"):
+            return f"python3 -m pytest {shlex.quote(method_path)} -q"
+        if parts[:2] == ("tests", "jig"):
+            directory = str(PurePosixPath(*parts[:-1]))
+            return f"python3 -m unittest discover -s {shlex.quote(directory)} -p {shlex.quote(parts[-1])}"
+    return method_path
+
+
+def derive_items_from_plan(plan_path: Path, task_label: str, probe_spec_path: Path | None, repo_root: Path) -> dict:
     """Build an ITEMS_SCHEMA document mechanically from `plan_path`'s named
     task block; raises ValueError (a usage error, exit 2) on any problem —
     fail closed, never a silently partial item list."""
@@ -288,7 +338,8 @@ def derive_items_from_plan(plan_path: Path, task_label: str, probe_spec_path: Pa
 
     def derive(item: Item, tier: str, method_path: str | None) -> dict:
         if tier in COMMAND_TIERS:
-            return {"id": int(item.num), "kind": item.kind, "tier": tier, "command": method_path}
+            command = resolve_command_for_method(method_path, repo_root)
+            return {"id": int(item.num), "kind": item.kind, "tier": tier, "command": command}
         entry = probe_spec[item.num]
         derived = {"id": int(item.num), "kind": item.kind, "tier": tier, "artifact": entry["artifact"]}
         if "pattern" in entry:
@@ -456,10 +507,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
+    repo = Path(args.repo).resolve()
 
     try:
         data = (
-            derive_items_from_plan(Path(args.plan), args.task, Path(args.probe_spec) if args.probe_spec else None)
+            derive_items_from_plan(Path(args.plan), args.task, Path(args.probe_spec) if args.probe_spec else None, repo)
             if args.plan
             else load_items(Path(args.items))
         )
@@ -468,7 +520,6 @@ def main(argv: list[str]) -> int:
         return 2
 
     items = data["items"]
-    repo = Path(args.repo).resolve()
     has_probe = any(item["tier"] == "probe" for item in items)
 
     since_ts: float | None = None

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -218,7 +218,9 @@ may appear anywhere in the block. No `Risk:` line means `LOW` — see Cadence.
    own original evidence folder: `evidence-capture` always stamps against
    current `HEAD`, so reusing the task's own original evidence folder
    would misdate the retroactive inspection against a later, unrelated
-   commit made after that task's own `PASS`.
+   commit made after that task's own `PASS`. This call shares step 7's
+   exit-code-2 refusal on a resumed session — route it exactly the same
+   way (step 7, below), never a restated copy of that routing here.
 
 ## Step 2 — Per task, in spine order
 
@@ -479,6 +481,36 @@ For each task block, in order:
      committed change, so `evidence-capture`'s clean-tree check has a real,
      clean tree to check (issue #45) instead of refusing before task 1 ever
      completes.
+
+     **Exit code 2, "evidence directory already exists": not a task FAIL,
+     same as `verify`'s own exit 2 above — a usage error, and it never
+     counts against the Failure routine's two-failure budget** (issue
+     #242). It fires on a `/build` re-invoked after a PAUSE for a task
+     whose evidence this session (or an earlier one) already captured.
+     Distinguish two causes mechanically, never by re-running the capture
+     and hoping:
+     - Run `scripts/evidence-capture resolve --branch <branch> --task
+       <id>` and read the resolved folder's `manifest.json` `commit_sha`
+       field. **If it equals this task's own just-verified commit
+       (`verify`'s `results.json` sha, or the executor's returned SHA):**
+       the prior capture already answers for this exact commit — **skip
+       this call entirely** and proceed straight to `status-flip` below.
+       This is the ordinary resumed-session case, not a problem to fix.
+     - **If it names an earlier commit, or `resolve` itself finds no
+       match:** the existing folder is genuinely stale or foreign to this
+       attempt — re-run the exact same `evidence-capture` call with
+       `--force` added, once. If that second call also fails, stop and
+       report **PAUSED**, naming "evidence-capture usage error persisted
+       after retry" — the same recovery shape step 5 already uses for a
+       `verify` usage error, never a fresh dispatch and never the
+       Failure routine, which is for a check *result*, not a bookkeeping
+       refusal.
+
+     Keep the recovery instruction in exactly one home: this bullet routes
+     the decision, the script's own refusal message
+     (`scripts/evidence-capture`) still names the mechanical fix
+     (`--force`, or remove the directory) — never restate that fix's
+     wording here, only when to reach for it.
    - **No evidence commit exists any more, deliberately.** `evidence-capture`
      writes to the main checkout's gitignored `.studious/build-evidence/` —
      outside this worktree's tracked tree entirely — so the capture leaves

--- a/tests/jig/test_build_skill.py
+++ b/tests/jig/test_build_skill.py
@@ -698,6 +698,50 @@ class TestBuildSkillBody(unittest.TestCase):
         self.assertPhraseIn("a real bug the project's own M0 dogfood surfaced")
         self.assertPhraseIn("read for meaning and don't reproduce it")
 
+    def test_evidence_capture_exit_2_is_routed_never_a_task_fail(self) -> None:
+        # #242: exit code 2 from evidence-capture ("evidence directory
+        # already exists") had no documented recovery in step 2.7 -- a
+        # /build re-invoked after a PAUSE walked straight into it with no
+        # branch to follow. Same non-FAIL-budget treatment as verify's own
+        # exit 2 above it.
+        self.assertPhraseIn(
+            "not a task FAIL, same as `verify`'s own exit 2 above — a usage error, "
+            "and it never counts against the Failure routine's two-failure budget"
+        )
+
+    def test_evidence_capture_exit_2_names_all_three_routes(self) -> None:
+        # The issue's own framing: skip / Failure-routine / escalate --
+        # one of the three, not a restatement of the script's rm -rf hint.
+        self.assertPhraseIn("skip this call entirely")
+        self.assertPhraseIn("re-run the exact same")
+        self.assertPhraseIn("evidence-capture` call with")
+        self.assertPhraseIn("--force")
+        self.assertPhraseIn("report **PAUSED**")
+        self.assertPhraseIn('naming "evidence-capture usage error persisted after retry"')
+        self.assertPhraseIn("never a fresh dispatch and never the Failure routine")
+
+    def test_evidence_capture_exit_2_distinguishes_idempotent_from_stale(self) -> None:
+        # The mechanical distinction that makes this a routing decision
+        # rather than a guess: read the resolved folder's manifest sha
+        # back and compare it to the commit that was just verified.
+        self.assertPhraseIn("evidence-capture resolve --branch")
+        self.assertPhraseIn("manifest.json")
+        self.assertPhraseIn("commit_sha")
+
+    def test_the_recovery_instruction_lives_in_one_home(self) -> None:
+        # The script's own refusal message still names the mechanical fix
+        # (--force / remove the directory); step 2.7 must route the
+        # decision, never restate that script's wording.
+        self.assertPhraseIn("Keep the recovery instruction in exactly one home")
+        self.assertPhraseIn("never restate that fix's")
+
+    def test_step_1_5_retroactive_capture_points_at_the_same_routing(self) -> None:
+        # #242's second half: the retroactive catch-up capture shares the
+        # exact same refusal and must not carry its own separate copy of
+        # the routing rule.
+        self.assertPhraseIn("This call shares step 7's")
+        self.assertPhraseIn("never a restated copy of that routing here")
+
 
 if __name__ == "__main__":
     import sys

--- a/tests/jig/test_verify.py
+++ b/tests/jig/test_verify.py
@@ -79,15 +79,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "verify"
 
 
-def _script_constant(name: str):
-    """Read a module-level constant out of `verify` by importing it by path.
-
-    The bound the probe tests exercise has to be the one `verify` actually
-    applies; restating the number here would let the two drift apart silently,
-    which is the failure `DEFAULT_TIMEOUT_SECONDS` was already filed for (#227).
-    Loading under a non-`__main__` name leaves the CLI entry point dormant.
-    The loader is explicit because `verify` has no `.py` suffix, so importlib
-    cannot infer one from the filename.
+def _verify_module():
+    """Import `verify` by path, under a non-`__main__` name so its CLI entry
+    point stays dormant. The loader is explicit because `verify` has no `.py`
+    suffix, so importlib cannot infer one from the filename.
     """
     loader = importlib.machinery.SourceFileLoader("_verify_under_test", str(SCRIPT))
     spec = importlib.util.spec_from_file_location("_verify_under_test", SCRIPT, loader=loader)
@@ -98,9 +93,19 @@ def _script_constant(name: str):
     sys.modules[spec.name] = module
     try:
         spec.loader.exec_module(module)
-        return getattr(module, name)
+        return module
     finally:
         sys.modules.pop(spec.name, None)
+
+
+def _script_constant(name: str):
+    """Read a module-level constant out of `verify`.
+
+    The bound the probe tests exercise has to be the one `verify` actually
+    applies; restating the number here would let the two drift apart silently,
+    which is the failure `DEFAULT_TIMEOUT_SECONDS` was already filed for (#227).
+    """
+    return getattr(_verify_module(), name)
 
 
 MAX_PROBE_ARTIFACT_BYTES = _script_constant("MAX_PROBE_ARTIFACT_BYTES")
@@ -741,6 +746,168 @@ class TestVerifyPlanModeDerivation(unittest.TestCase):
             self.assertEqual(result.returncode, 1)
             self.assertIn("[FAIL] item 1", result.stdout)
             self.assertIn("[PASS] item 2", result.stdout)
+
+
+class TestResolveCommandForMethod(unittest.TestCase):
+    """`resolve_command_for_method` (#208) — the mechanical, never-a-guess
+    mapping from a cited method path to a runnable command. Pure-function
+    tests against the loaded module, no subprocess: what these check is the
+    derivation itself, not whether a shell can run the result."""
+
+    def setUp(self) -> None:
+        self.module = _verify_module()
+
+    def test_an_executable_path_is_returned_verbatim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            write_method_script(repo, "scripts/ok", exit_code=0)
+            self.assertEqual(
+                self.module.resolve_command_for_method("scripts/ok", repo), "scripts/ok"
+            )
+
+    def test_a_non_executable_py_file_under_tests_python_maps_to_pytest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            target = repo / "tests" / "python" / "test_thing.py"
+            target.parent.mkdir(parents=True)
+            target.write_text("def test_ok():\n    pass\n", encoding="utf-8")
+            self.assertEqual(
+                self.module.resolve_command_for_method("tests/python/test_thing.py", repo),
+                "python3 -m pytest tests/python/test_thing.py -q",
+            )
+
+    def test_a_non_executable_py_file_under_tests_jig_maps_to_unittest_discover(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            target = repo / "tests" / "jig" / "test_thing.py"
+            target.parent.mkdir(parents=True)
+            target.write_text("import unittest\n", encoding="utf-8")
+            self.assertEqual(
+                self.module.resolve_command_for_method("tests/jig/test_thing.py", repo),
+                "python3 -m unittest discover -s tests/jig -p test_thing.py",
+            )
+
+    def test_a_non_executable_py_file_outside_either_test_tree_is_unchanged(self) -> None:
+        """Out of this fix's scope, deliberately: a plan-authoring problem
+        scripts/plan-lint should catch, not something this script rescues by
+        guessing an interpreter."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            target = repo / "scripts" / "helper.py"
+            target.parent.mkdir(parents=True)
+            target.write_text("pass\n", encoding="utf-8")
+            self.assertEqual(
+                self.module.resolve_command_for_method("scripts/helper.py", repo),
+                "scripts/helper.py",
+            )
+
+    def test_a_non_executable_non_python_file_is_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            target = repo / "skills" / "build" / "SKILL.md"
+            target.parent.mkdir(parents=True)
+            target.write_text("# doc\n", encoding="utf-8")
+            self.assertEqual(
+                self.module.resolve_command_for_method("skills/build/SKILL.md", repo),
+                "skills/build/SKILL.md",
+            )
+
+    def test_a_path_that_does_not_exist_on_disk_is_unchanged(self) -> None:
+        """The do-line fallback case (plan-lint's check_item_tier): a method
+        the plan promises an earlier task will create. Not yet resolvable
+        either way -- unchanged, same as a path outside both test trees."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            self.assertEqual(
+                self.module.resolve_command_for_method("not/created/yet.py", repo),
+                "not/created/yet.py",
+            )
+
+
+class TestVerifyPlanModeMethodPathResolutionEndToEnd(unittest.TestCase):
+    """#208's actual regression, reproduced and fixed end to end: a
+    `test-backed` item citing a real, non-executable test file under
+    `tests/jig/` used to fail every time with exit 126 ("Permission
+    denied"), regardless of whether the cited test passed. Exercised
+    through `tests/jig/` specifically because stdlib `unittest` needs no
+    extra dependency in whatever environment runs this suite; the
+    `tests/python/` (pytest) mapping is covered at the unit level above."""
+
+    def test_a_passing_test_under_tests_jig_now_passes_instead_of_126(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            target = repo / "tests" / "jig" / "test_regression.py"
+            target.parent.mkdir(parents=True)
+            target.write_text(
+                "import unittest\n\n"
+                "class T(unittest.TestCase):\n"
+                "    def test_ok(self):\n"
+                "        self.assertTrue(True)\n",
+                encoding="utf-8",
+            )
+            plan = write_plan(
+                repo,
+                plan_task(
+                    1,
+                    items=(
+                        "1. [cap] the regression test passes "
+                        "(tier: test-backed `tests/jig/test_regression.py`)\n"
+                    ),
+                ),
+            )
+            result = run_script(["--plan", str(plan), "--task", "1", "--repo", str(repo)])
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("[PASS] item 1", result.stdout)
+            self.assertNotIn("Permission denied", result.stdout)
+
+    def test_a_failing_test_under_tests_jig_reports_fail_not_a_permission_error(self) -> None:
+        """Proves the fix actually runs the cited test rather than
+        vacuously passing every non-executable path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            target = repo / "tests" / "jig" / "test_regression.py"
+            target.parent.mkdir(parents=True)
+            target.write_text(
+                "import unittest\n\n"
+                "class T(unittest.TestCase):\n"
+                "    def test_fails(self):\n"
+                "        self.assertTrue(False)\n",
+                encoding="utf-8",
+            )
+            plan = write_plan(
+                repo,
+                plan_task(
+                    1,
+                    items=(
+                        "1. [cap] the regression test passes "
+                        "(tier: test-backed `tests/jig/test_regression.py`)\n"
+                    ),
+                ),
+            )
+            result = run_script(["--plan", str(plan), "--task", "1", "--repo", str(repo)])
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[FAIL] item 1", result.stdout)
+            self.assertNotIn("Permission denied", result.stdout)
+
+    def test_a_non_test_tree_non_executable_method_still_behaves_as_before(self) -> None:
+        """Out of #208's scope, deliberately unchanged: this is the honest
+        signal that the plan cited a file this script has no mechanical way
+        to run, not a silently swallowed gap."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            target = repo / "docs" / "note.md"
+            target.parent.mkdir(parents=True)
+            target.write_text("# note\n", encoding="utf-8")
+            plan = write_plan(
+                repo,
+                plan_task(
+                    1,
+                    items=("1. [cap] c (tier: script `docs/note.md`)\n"),
+                ),
+            )
+            result = run_script(["--plan", str(plan), "--task", "1", "--repo", str(repo)])
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[FAIL] item 1", result.stdout)
 
 
 class TestVerifyPlanModeUsageErrors(unittest.TestCase):


### PR DESCRIPTION
Closes #208. Closes #242.

Part of M0's S1 (exit): unattended runs need clean evidence, and both of these
block that today.

## #208 — scripts/verify ran a bare method path as a shell command

`derive_items_from_plan`'s mechanized `--plan`/`--task` item derivation set a
`script`/`test-backed` item's `command` to its backtick-quoted method path
verbatim, then ran it via the shell. `scripts/plan-lint`'s own `check_item_tier`
only requires that path to *exist* on disk — most of what satisfies that (every
test file, every `SKILL.md`, every markdown report) carries no execute bit and
no shebang, so any such item failed deterministically with exit 126, regardless
of whether the underlying claim was true. A jig#84 regression: the pre-#84
hand-transcription path let the Foreman author the command field directly, a
capability #84's mechanization removed with no equivalent for these two tiers.

New `resolve_command_for_method()`: unchanged when the path is itself
executable; run through whichever test runner owns its tree (CLAUDE.md's "Two
test runners, deliberately") when it's a non-executable `.py` file under
`tests/python/` (`pytest`) or `tests/jig/` (`unittest discover`, narrowed to
that one filename). Anything else falls through unchanged — deliberately out
of scope: a plan-authoring problem `plan-lint` should catch, not something
this script rescues by guessing an interpreter.

## #242 — /build had no documented recovery for evidence-capture's exit 2

`scripts/evidence-capture` exits 2 ("evidence directory already exists")
whenever its target folder is present and `--force` wasn't passed — reachable
from step 2.7 on a `/build` re-invoked after a PAUSE, and shared by step 1.5's
retroactive catch-up capture. Neither step named a recovery.

Step 2.7 now routes it exactly like `verify`'s own exit 2 above it: a usage
error, never a task FAIL, never counted against the Failure routine's
two-failure budget. Distinguishes the two real causes mechanically, via
`evidence-capture resolve`'s own `manifest.json` `commit_sha`:
- same commit already captured (a resumed session) → skip the call entirely;
- an earlier or foreign commit → retry once with `--force`, then `PAUSED`.

Step 1.5 points at the same routing rather than carrying a second copy of it.

## Verification

```
npx -y markdownlint-cli2
uv run --no-project python scripts/check_references.py
uv run --no-project python scripts/validate_plugin.py
uv run --no-project python scripts/check_gate_independence.py
uv run --no-project --with pytest pytest tests/python -v      # 778 passed
uv run --no-project python3 -m unittest discover -s tests/jig  # 484 passed
uv run --no-project --with ruff==0.16.0 ruff check scripts tests/jig
uv run --no-project --with vermin==1.8.0 vermin --no-tips -t=3.9- scripts/
```