### PR TITLE
feat: /ship --epic — epic closeout proposes decision patches and files follow-ups

### DIFF
--- a/reference/epic-orchestration.md
+++ b/reference/epic-orchestration.md
@@ -660,6 +660,14 @@ create` keystroke. A died or refused PR dispatch never un-records `ready`: the e
 stays ready, and running `gh pr create` from the epic branch by hand is still exactly
 as available as it always was.
 
+**Closeout (#247) is a separate, human-invoked step, never this dispatch's job.**
+`skills/ship/SKILL.md`'s "Epic scope" (`/ship --epic <slug>`) proposes decision
+patches and per-item-confirms follow-up issues from what is now durably on the ledger
+— the settled `--decisions` from step 8, the findings ledger, the parked stories.
+Nothing about it runs unattended: filing an issue needs a human's per-item word, the
+same rule the story-scale path already follows, so it stays out of every dispatch this
+section names.
+
 A finale gate (audit or acceptance) whose fix cycles run out while it still holds its
 own retry token (`FIX AND RE-REVIEW`) does not end the run reading
 as an unexplained "not ready": it adds one entry to the "Needs you" queue below naming

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Closes out a BUILT branch — an assembled PR evidence table (Done-means item -> verification method -> evidence link -> pass), a cctx session-cost footer with a preview-only harvest offer, per-item-confirmed follow-up filing, proposed (never auto-applied) PRODUCT.md/DESIGN.md/CLAUDE.md decision patches, a dated build report, and MERGE | PR | KEEP | DISCARD verdict + cleanup. Use when the user says /ship, or a /build session has already reported BUILT (with /review and /review --delivery already passed) and the branch is ready to close out. `/ship --handback` is the PR-less variant a dispatched worker uses to return its branch — manifest and summary only, no episode, no PR. Never invents evidence, never files an issue or applies a harvest without explicit per-item confirmation in the same turn, and never writes a decision patch to a context doc itself.
+description: Closes out a BUILT branch — an assembled PR evidence table (Done-means item -> verification method -> evidence link -> pass), a cctx session-cost footer with a preview-only harvest offer, per-item-confirmed follow-up filing, proposed (never auto-applied) PRODUCT.md/DESIGN.md/CLAUDE.md decision patches, a dated build report, and MERGE | PR | KEEP | DISCARD verdict + cleanup. Use when the user says /ship, or a /build session has already reported BUILT (with /review and /review --delivery already passed) and the branch is ready to close out. `/ship --handback` is the PR-less variant a dispatched worker uses to return its branch — manifest and summary only, no episode, no PR. `/ship --epic <slug>` is the human-invoked epic-scale closeout run after the finale's PR is open — proposed decision patches and per-item-confirmed follow-up filing from the epic's own recorded decisions and findings, no evidence table and no verdict. Never invents evidence, never files an issue or applies a harvest without explicit per-item confirmation in the same turn, and never writes a decision patch to a context doc itself.
 ---
 
 # /ship
@@ -21,7 +21,7 @@ a hard requirement. It assumes the human invoked it because the branch is
 ready, the same trust boundary `/build`'s own `BUILT` → "run `/review`
 next" hand-off already relies on.
 
-## Two modes
+## Three modes
 
 - **`/ship`** — the full closeout below: evidence table, cost footer, follow-ups,
   decision patches, dated report, and one of `MERGE` / `PR` / `KEEP` / `DISCARD`.
@@ -30,9 +30,67 @@ next" hand-off already relies on.
   episode is convened, no PR is opened, no verdict is recorded. Follow
   `reference/handback-contract.md`, which carries that procedure in full; consult it,
   don't restate it here, and don't run any of the six steps below on this path.
+- **`/ship --epic <slug>`** — epic-scale closeout (#247), human-invoked after the epic
+  finale reaches `ready` and its PR is open. See "Epic scope" below; it runs neither
+  Steps 1–6 nor `--handback`'s procedure.
 
 Convening is not judging: `/ship` may convene the delivery episode as a convenience, but
 the verdict is always `/review`'s. This door never writes one.
+
+## Epic scope
+
+**`/ship --epic <slug>`** never runs Steps 1–6 below — those are story-scale, and an
+epic's worktree is already gone by the time this runs (`reference/epic-orchestration.md`'s
+finale removes it once `ready` is recorded). This is additive follow-up work on an
+already-open PR, human-invoked only — `workflows/epic-driver.js` never runs this itself,
+the same "never a producer, never dispatched on the human's behalf" boundary every
+`producer`-class door respects (CLAUDE.md's bookkeeping-boundary bullet).
+
+**Read the ledger fresh, not anything embedded earlier.** Everything this needs is
+already durable and queryable at any time, so there is nothing to re-derive from a
+specific run's own report:
+
+- `gate-ledger epic-get --slug <slug>` — the epic goal, and every story's recorded
+  `decisions` (the settled forks from the plan piece's one interview, #311) and
+  `mergeClass` (#312).
+- `gate-ledger epic-findings --epic <slug>` — every finding this epic recorded; filter
+  to `Track` severity (`BLOCKER`/`SHOULD FIX` findings already gated the finale itself —
+  re-litigating them here is exactly the re-derivation `reference/epic-orchestration.md`'s
+  findings-closure lane exists to stop).
+- The `story-supervised` parks recorded in the same `epic-get` output — each carries its
+  own `story-supervised: <reason>` prefix (`reference/epic-orchestration.md`'s "Close
+  every invocation the same way").
+- The epic pre-mortem register at `docs/studious/premortems/<slug>-epic.md` — read for
+  context on what the epic was watching for. Its per-item REALIZED/NOT REALIZED verdicts
+  from the finale's own audit round are not persisted separately from that run's report;
+  this step does not attempt to resurrect them, only to read the register's own text.
+
+**Propose decision patches — Step 4's exact posture, epic-scoped inputs.** Design
+decisions that outlive the feature (a settled fork with lasting consequences, a
+Track-tier finding that reads as a convention gap rather than a one-off nit) become
+proposed diffs against `PRODUCT.md` / `DESIGN.md` / `CLAUDE.md`. Print the diff blocks.
+Never call `Edit`, `Write`, `git apply`, or any other patch mechanism against those three
+files in this step, under any branch of this flow, even after an explicit "yes" — the
+same absolute rule Step 4 states for the story path.
+
+**File follow-ups — Step 3's mechanism, verbatim, epic-scoped sources.** One draft per
+parked story (title + body citing the epic and the story's own park reason) and one per
+Track-tier finding (title + body citing the epic, the story, the lane, and the
+fingerprint). Draft the full batch first — imperative title under 70 characters, a body
+of at most 5 lines — and present it to the human before filing anything.
+**Confirmation is per-item, not all-or-nothing**, exactly as Step 3 requires: the human
+accepts, edits, or skips each draft individually, and only confirmed drafts reach `gh
+issue create`. A `gh issue create` failure (auth, rate limit) surfaces by name, per item.
+
+**Evidence needs no separate assembly here.** Each landed story's own `/ship` run already
+built its evidence table into that story's PR before it merged into the epic branch; the
+epic PR's own body (the finale's dispatch, #253) already cites
+`gate-ledger evidence-list --branch "epic/<slug>" --dedupe`. Point at those rather than
+re-running Step 1 at epic scale.
+
+**No Step 6 here.** The epic's worktree is already released and its branch already has an
+open PR — there is no verdict to report and no cleanup left to perform. `/ship --epic`
+is purely additive: it proposes patches and files confirmed follow-ups, and stops.
 
 Six steps, in order. Steps 1 and 5 are mechanical (scripts decide); Steps
 2–4 always end on an explicit human decision in the same turn; Step 6

--- a/tests/jig/test_finish_skill.py
+++ b/tests/jig/test_finish_skill.py
@@ -379,7 +379,11 @@ class TestShipEpicScope(unittest.TestCase):
         self.assertPhraseIn("`/ship --epic <slug>`")
 
     def test_epic_scope_never_runs_steps_one_through_six(self) -> None:
-        self.assertPhraseIn("never runs Steps 1–6 below")
+        # The doc's own range notation uses an en dash between the digits.
+        # Built from an escape rather than the literal glyph so ruff's
+        # ambiguous-unicode check doesn't flag this source file over a
+        # character this test only needs to match, not display.
+        self.assertPhraseIn(f"never runs Steps 1{chr(0x2013)}6 below")
         self.assertPhraseIn("No Step 6 here")
 
     def test_epic_scope_is_human_invoked_never_dispatched_by_the_driver(self) -> None:

--- a/tests/jig/test_finish_skill.py
+++ b/tests/jig/test_finish_skill.py
@@ -360,3 +360,46 @@ class TestFinishResolvesTheEvidenceFolderByAsking(unittest.TestCase):
         self.assertEqual(self.flat_body.count(contents), 1, "the manifest description has one home")
         exit_zero_at = self.flat_body.index(normalize_ws("It prints one folder path — absolute, since the store lives outside the tracked tree — on exit 0."))
         self.assertLess(exit_zero_at, self.flat_body.index(contents))
+
+
+class TestShipEpicScope(unittest.TestCase):
+    """`/ship --epic <slug>` (#247) — epic-scale closeout, human-invoked after the
+    epic finale's PR is open. Never Steps 1-6; never dispatched by
+    workflows/epic-driver.js."""
+
+    def setUp(self) -> None:
+        self.body = SKILL_MD.read_text(encoding="utf-8")
+        self.flat_body = normalize_ws(self.body)
+
+    def assertPhraseIn(self, phrase: str) -> None:
+        self.assertIn(normalize_ws(phrase), self.flat_body, f"phrase not found (whitespace-normalized): {phrase!r}")
+
+    def test_three_modes_are_named(self) -> None:
+        self.assertPhraseIn("## Three modes")
+        self.assertPhraseIn("`/ship --epic <slug>`")
+
+    def test_epic_scope_never_runs_steps_one_through_six(self) -> None:
+        self.assertPhraseIn("never runs Steps 1–6 below")
+        self.assertPhraseIn("No Step 6 here")
+
+    def test_epic_scope_is_human_invoked_never_dispatched_by_the_driver(self) -> None:
+        self.assertPhraseIn("human-invoked only")
+        self.assertPhraseIn("`workflows/epic-driver.js` never runs this itself")
+
+    def test_epic_scope_reads_the_ledger_fresh_not_an_embedded_report(self) -> None:
+        self.assertPhraseIn("Read the ledger fresh, not anything embedded earlier")
+        self.assertPhraseIn("gate-ledger epic-get --slug <slug>")
+        self.assertPhraseIn("gate-ledger epic-findings --epic <slug>")
+
+    def test_epic_scope_reuses_step_4s_propose_never_apply_posture(self) -> None:
+        self.assertPhraseIn("Step 4's exact posture, epic-scoped inputs")
+        self.assertPhraseIn(
+            "Never call `Edit`, `Write`, `git apply`, or any other patch mechanism against those three"
+        )
+
+    def test_epic_scope_reuses_step_3s_confirmation_mechanism_verbatim(self) -> None:
+        self.assertPhraseIn("Step 3's mechanism, verbatim, epic-scoped sources")
+        self.assertPhraseIn("Confirmation is per-item, not all-or-nothing")
+
+    def test_epic_scope_does_not_reassemble_evidence(self) -> None:
+        self.assertPhraseIn("Evidence needs no separate assembly here")


### PR DESCRIPTION
Closes #247.

17 epics have run with zero closeouts. The epic path's only human turns are
plan approval and the PR (#253); nothing proposed a `PRODUCT.md`/`DESIGN.md`/
`CLAUDE.md` patch or filed a follow-up issue from an epic's settled decisions
or parked stories, the way `/ship`'s story-scale Steps 3 and 4 already do for
a single branch.

## Design

Re-pointed per #253's door-rename correction — no new `/close-epic` door.
`/ship --epic <slug>` is **human-invoked, after the finale's PR is open**,
never dispatched by `workflows/epic-driver.js` (which sits on
`check_gate_independence.py`'s guarded surface and has no human in its loop
for exactly this reason — filing an issue needs a per-item confirmation the
automated finale dispatch can't give). This landed as a pure `skills/ship/
SKILL.md` change: no new dispatch, no touch to `workflows/epic-driver.js`,
no change to the guarded surface.

**Reads everything fresh from the durable ledger**, not anything embedded in
one run's report:
- `gate-ledger epic-get --slug <slug>` — the epic goal, each story's recorded
  `--decisions` (#311) and `mergeClass` (#312).
- `gate-ledger epic-findings --epic <slug>` — filtered to `Track` severity
  (`BLOCKER`/`SHOULD FIX` already gated the finale itself).
- The `story-supervised` parks, and the epic pre-mortem register for context.

**Reuses two existing steps verbatim, rather than re-deriving them:**
- Step 4's propose-never-apply posture for decision patches.
- Step 3's per-item-confirm mechanism for follow-up issues — one draft per
  parked story, one per Track-tier finding.

No evidence re-assembly (the epic PR already carries it, per #253) and no
Step 6 (the worktree is already gone; there's no verdict to report). This is
purely additive: propose, confirm, file, stop.

## Verification

```
npx -y markdownlint-cli2
uv run --no-project python scripts/check_references.py
uv run --no-project python scripts/validate_plugin.py
uv run --no-project python scripts/check_gate_independence.py
uv run --no-project --with pytest pytest tests/python -v      # 778 passed
uv run --no-project python3 -m unittest discover -s tests/jig  # 477 passed
```