### PR TITLE
feat: add scripts/intake, deterministic ready-issue eligibility filter

### DIFF
--- a/scripts/intake
+++ b/scripts/intake
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""intake -- deterministic pre-filter for `ready`-labelled issues (issue #314).
+
+`reference/epic-plan-contract.md`'s "Story class" section names two of
+`epic-default`'s prerequisites as computations over data an issue already
+holds -- a stated file surface, and whether the source issue carries
+acceptance criteria -- and one as the planner's judgment (an unfamiliar
+surface). This script computes the two mechanical ones only. It never
+assigns `epic-default` itself: that class is decided at plan approval
+(`epic-plan-contract.md`'s "Story class" section, and PRODUCT.md's merge-
+authority matrix, #312), by a human or the plan piece reading the brief.
+`eligible` here means "passes both mechanical triggers" -- necessary, not
+sufficient.
+
+**The two triggers, computed:**
+
+1. **Not majority prompt-prose.** Backtick-quoted paths named in the issue
+   body are matched against `reference/audit-routing-signals.md`'s Prompt
+   signal list (`PROMPT_SIGNAL_GLOBS` below mirrors that list; a copy, not
+   a restatement of authority -- `tests/jig/test_intake.py` fails if the
+   two drift, the same mirror-plus-test shape `design-lint` uses for
+   `reference/design-doc-contract.md`). A majority of named paths matching
+   -> the issue fails this trigger.
+2. **Acceptance criteria with citations.** An "Acceptance criteria"
+   heading (any depth, case-insensitive) followed by at least one list
+   item, at least one of which carries a concrete citation: a
+   backtick-quoted path, a `file:line` span, a URL, or a `#<N>` issue
+   reference. Anything short of that fails this trigger.
+
+Read-only against GitHub except one rejection comment on an ineligible
+issue, naming the failing clause and the `story-supervised` route
+(`epic-plan-contract.md`'s own words) -- never opens, closes, labels, or
+edits an issue. The comment carries an HTML sentinel
+(`<!-- studious-intake: clause=<slug> -->`) and is skipped if a comment
+with that exact sentinel is already on the issue, so a supervisor
+re-running intake (#316) never re-posts the same finding. Issue text is
+untrusted data, read only, never executed or interpolated into a shell
+command.
+
+Two read paths: `gh issue list` (live) or `--from-json <file>` (a saved
+`gh issue list --json number,title,body,url` array), the latter for
+`tests/jig/test_intake.py` and for #315's bridge to consume without a
+second `gh` round-trip. Python 3.9 floor -- vermin runs over this file --
+stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from fnmatch import fnmatchcase
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _gitutil import git_repo_root, run  # noqa: E402
+
+# Mirrors reference/audit-routing-signals.md's Prompt signal section.
+# tests/jig/test_intake.py pins these substrings against that file's text
+# so a future edit to the canonical list surfaces as a test failure here
+# rather than a silent drift.
+PROMPT_SIGNAL_GLOBS = (
+    "agents/*.md",
+    "commands/*.md",
+    "skills/**/SKILL.md",
+    ".claude/agents/**",
+    ".claude/commands/**",
+    ".claude/skills/**",
+    "output-styles/**",
+    "CLAUDE.md",
+    "**/CLAUDE.md",
+    "AGENTS.md",
+    ".cursorrules",
+    ".cursor/rules/**",
+    ".github/copilot-instructions.md",
+    "GEMINI.md",
+)
+
+_BACKTICK = re.compile(r"`([^`\n]+)`")
+_ACCEPTANCE_HEADING = re.compile(r"^#{1,6}\s*acceptance criteria\s*$", re.IGNORECASE)
+_LIST_ITEM = re.compile(r"^\s*[-*]\s+(.*\S)")
+_CITATION = re.compile(r"`[^`]+`|https?://\S+|#\d+|\b[\w./-]+:\d+\b")
+
+
+def _is_prompt_signal_path(path: str, plugin_repo: bool) -> bool:
+    """One named path against the mirrored Prompt signal glob list."""
+    if "prompt" in Path(path).name.lower() or "prompt" in path.lower():
+        return True
+    if plugin_repo and fnmatchcase(path, "reference/**"):
+        return True
+    return any(fnmatchcase(path, glob) for glob in PROMPT_SIGNAL_GLOBS)
+
+
+def named_paths(body: str) -> list[str]:
+    """Backtick-quoted, path-shaped spans in an issue body, in order."""
+    return [span for span in _BACKTICK.findall(body) if "/" in span or "." in span]
+
+
+def prompt_prose_share(paths: list[str], plugin_repo: bool) -> float | None:
+    """Fraction of named paths matching the Prompt signal list, or None if no paths named."""
+    if not paths:
+        return None
+    matches = sum(1 for p in paths if _is_prompt_signal_path(p, plugin_repo))
+    return matches / len(paths)
+
+
+def has_acceptance_criteria_with_citations(body: str) -> bool:
+    lines = body.splitlines()
+    for i, line in enumerate(lines):
+        if not _ACCEPTANCE_HEADING.match(line.strip()):
+            continue
+        for later in lines[i + 1 :]:
+            if later.strip().startswith("#"):
+                break
+            item = _LIST_ITEM.match(later)
+            if item and _CITATION.search(item.group(1)):
+                return True
+    return False
+
+
+def classify_issue(issue: dict[str, Any], plugin_repo: bool) -> dict[str, Any]:
+    """Pure classification of one issue dict (`number`, `title`, `body`, `url`)."""
+    body = issue.get("body") or ""
+    paths = named_paths(body)
+    share = prompt_prose_share(paths, plugin_repo)
+    majority_prompt_prose = share is not None and share > 0.5
+    has_criteria = has_acceptance_criteria_with_citations(body)
+
+    failing_clauses = []
+    if majority_prompt_prose:
+        failing_clauses.append(
+            "majority prompt-prose file surface (reference/audit-routing-signals.md's "
+            "Prompt signal list) -- story-supervised route"
+        )
+    if not has_criteria:
+        failing_clauses.append(
+            "source issue has no acceptance criteria with citations -- story-supervised route"
+        )
+
+    return {
+        "number": issue.get("number"),
+        "title": issue.get("title"),
+        "url": issue.get("url"),
+        "eligible": not failing_clauses,
+        "failing_clauses": failing_clauses,
+        "named_paths": paths,
+        "prompt_prose_share": share,
+    }
+
+
+def _clause_slug(clause: str) -> str:
+    return "prompt-prose" if clause.startswith("majority prompt-prose") else "no-acceptance-criteria"
+
+
+def _sentinel(clause: str) -> str:
+    return f"<!-- studious-intake: clause={_clause_slug(clause)} -->"
+
+
+def _rejection_comment_body(result: dict[str, Any], clause: str) -> str:
+    return (
+        f"{_sentinel(clause)}\n"
+        "Not eligible for unattended (`epic-default`) scheduling from `scripts/intake`:\n\n"
+        f"- {clause}\n\n"
+        "Route: `story-supervised` (`reference/epic-plan-contract.md`'s Story class "
+        "section) -- this stays in scope, but a human runs it via `/next` rather than "
+        "the driver dispatching it unattended."
+    )
+
+
+def _existing_sentinels(repo_root: Path, number: int) -> set[str]:
+    proc = run(["gh", "issue", "view", str(number), "--json", "comments"], cwd=repo_root)
+    if proc.returncode != 0:
+        return set()
+    try:
+        comments = json.loads(proc.stdout).get("comments", [])
+    except json.JSONDecodeError:
+        return set()
+    return {
+        f"<!-- studious-intake: clause={m.group(1)} -->"
+        for c in comments
+        for m in [re.search(r"<!-- studious-intake: clause=(\S+) -->", c.get("body") or "")]
+        if m
+    }
+
+
+def post_rejection_comments(repo_root: Path, results: list[dict[str, Any]]) -> bool:
+    """Post one comment per new failing clause on each ineligible issue. Returns True iff every post succeeded."""
+    all_ok = True
+    for result in results:
+        if result["eligible"]:
+            continue
+        number = result["number"]
+        existing = _existing_sentinels(repo_root, number)
+        for clause in result["failing_clauses"]:
+            if _sentinel(clause) in existing:
+                continue
+            body = _rejection_comment_body(result, clause)
+            proc = run(["gh", "issue", "comment", str(number), "--body", body], cwd=repo_root)
+            if proc.returncode != 0:
+                print(f"error: could not comment on #{number}: {proc.stderr.strip()}", file=sys.stderr)
+                all_ok = False
+    return all_ok
+
+
+def _is_plugin_repo(repo_root: Path) -> bool:
+    return (repo_root / ".claude-plugin").is_dir()
+
+
+def _fetch_ready_issues(repo_root: Path) -> list[dict[str, Any]] | None:
+    proc = run(
+        ["gh", "issue", "list", "--label", "ready", "--state", "open", "--json", "number,title,body,url"],
+        cwd=repo_root,
+    )
+    if proc.returncode != 0:
+        print(f"error: gh issue list failed: {proc.stderr.strip()}", file=sys.stderr)
+        return None
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"error: gh issue list returned non-JSON output: {exc}", file=sys.stderr)
+        return None
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="intake",
+        description="Deterministic epic-default eligibility pre-filter for ready-labelled issues.",
+    )
+    parser.add_argument("--repo", default=".", help="path inside the target repo (default: current directory)")
+    parser.add_argument("--out", help="write the JSON result array here instead of stdout")
+    parser.add_argument("--from-json", help="read issues from this file instead of calling gh")
+    parser.add_argument("--no-comment", action="store_true", help="skip posting rejection comments")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo_root = git_repo_root(Path(args.repo).resolve())
+    if repo_root is None:
+        print(f"error: '{args.repo}' is not inside a git repository", file=sys.stderr)
+        return 2
+
+    if args.from_json:
+        try:
+            issues = json.loads(Path(args.from_json).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"error: could not read '{args.from_json}': {exc}", file=sys.stderr)
+            return 2
+    else:
+        issues = _fetch_ready_issues(repo_root)
+        if issues is None:
+            return 2
+
+    plugin_repo = _is_plugin_repo(repo_root)
+    results = [classify_issue(issue, plugin_repo) for issue in issues]
+
+    ok = True
+    if not args.no_comment:
+        ok = post_rejection_comments(repo_root, results)
+
+    output = json.dumps(results, indent=2)
+    if args.out:
+        Path(args.out).write_text(output + "\n", encoding="utf-8")
+    else:
+        print(output)
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/jig/test_intake.py
+++ b/tests/jig/test_intake.py
@@ -1,0 +1,188 @@
+"""Tests for `scripts/intake` (issue #314).
+
+Two layers: unit tests against `classify_issue` (no `gh`, no subprocess),
+and end-to-end tests driving the CLI's `--from-json`/`--no-comment` path
+against a throwaway repo, which never shells out to `gh`.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from _tempgit import init_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "intake"
+SIGNALS_DOC = (REPO_ROOT / "reference" / "audit-routing-signals.md").read_text(encoding="utf-8")
+
+
+def _intake_module():
+    loader = importlib.machinery.SourceFileLoader("_intake_under_test", str(SCRIPT))
+    spec = importlib.util.spec_from_file_location("_intake_under_test", SCRIPT, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+ACCEPTED_BODY = (
+    "Touch `scripts/foo.py`.\n\n"
+    "## Acceptance criteria\n"
+    "- Verified by `scripts/foo.py` behavior (#12)\n"
+)
+
+PROMPT_BODY = (
+    "Touch `skills/build/SKILL.md` and `commands/next.md`.\n\n"
+    "## Acceptance criteria\n"
+    "- see `x.py:1`\n"
+)
+
+NO_CRITERIA_BODY = "Touch `scripts/foo.py`. No criteria section here."
+
+
+class TestPromptSignalMirror(unittest.TestCase):
+    """`PROMPT_SIGNAL_GLOBS` is a mirror, not a restatement of authority --
+    every glob it carries must trace to a substring the canonical doc
+    actually contains, so a future edit there surfaces here."""
+
+    def test_every_mirrored_glob_traces_to_the_canonical_doc(self) -> None:
+        # Each mirrored glob must appear verbatim in the canonical list, or as
+        # its bare filename for the "at any depth" globs this module adds
+        # (`**/CLAUDE.md`, `**/AGENTS.md`) which the doc states in prose
+        # ("CLAUDE.md (at any depth)") rather than as a literal glob.
+        m = _intake_module()
+        for glob in m.PROMPT_SIGNAL_GLOBS:
+            bare = glob.rsplit("/", 1)[-1]
+            self.assertTrue(
+                glob in SIGNALS_DOC or bare in SIGNALS_DOC,
+                f"{glob!r} not traceable to audit-routing-signals.md",
+            )
+
+    def test_reference_globstar_is_conditioned_on_plugin_repo(self) -> None:
+        self.assertIn("reference/**", SIGNALS_DOC)
+        self.assertIn(".claude-plugin", SIGNALS_DOC)
+
+
+class TestClassifyIssue(unittest.TestCase):
+    def setUp(self) -> None:
+        self.m = _intake_module()
+
+    def test_code_surface_with_cited_criteria_is_eligible(self) -> None:
+        result = self.m.classify_issue({"number": 1, "title": "t", "url": "u", "body": ACCEPTED_BODY}, plugin_repo=True)
+        self.assertTrue(result["eligible"])
+        self.assertEqual(result["failing_clauses"], [])
+
+    def test_majority_prompt_prose_surface_is_ineligible(self) -> None:
+        result = self.m.classify_issue({"number": 2, "title": "t", "url": "u", "body": PROMPT_BODY}, plugin_repo=True)
+        self.assertFalse(result["eligible"])
+        self.assertTrue(any("prompt-prose" in c for c in result["failing_clauses"]))
+
+    def test_missing_acceptance_criteria_is_ineligible(self) -> None:
+        result = self.m.classify_issue({"number": 3, "title": "t", "url": "u", "body": NO_CRITERIA_BODY}, plugin_repo=True)
+        self.assertFalse(result["eligible"])
+        self.assertTrue(any("acceptance criteria" in c for c in result["failing_clauses"]))
+
+    def test_acceptance_heading_with_no_citation_in_any_item_fails(self) -> None:
+        body = "Touch `scripts/foo.py`.\n\n## Acceptance criteria\n- It works well\n"
+        result = self.m.classify_issue({"number": 4, "title": "t", "url": "u", "body": body}, plugin_repo=True)
+        self.assertFalse(result["eligible"])
+
+    def test_reference_glob_only_counts_as_prompt_signal_in_a_plugin_repo(self) -> None:
+        body = "Touch `reference/idioms/python.md`.\n\n## Acceptance criteria\n- see (#12)\n"
+        non_plugin = self.m.classify_issue({"number": 5, "title": "t", "url": "u", "body": body}, plugin_repo=False)
+        plugin = self.m.classify_issue({"number": 5, "title": "t", "url": "u", "body": body}, plugin_repo=True)
+        self.assertTrue(non_plugin["eligible"])
+        self.assertFalse(plugin["eligible"])
+
+    def test_no_named_paths_yields_no_prompt_prose_share(self) -> None:
+        body = "## Acceptance criteria\n- see (#12)\n"
+        result = self.m.classify_issue({"number": 6, "title": "t", "url": "u", "body": body}, plugin_repo=True)
+        self.assertIsNone(result["prompt_prose_share"])
+
+
+class TestRejectionCommentSentinel(unittest.TestCase):
+    def setUp(self) -> None:
+        self.m = _intake_module()
+
+    def test_sentinel_is_stable_per_clause_and_names_story_supervised(self) -> None:
+        result = self.m.classify_issue({"number": 2, "title": "t", "url": "u", "body": PROMPT_BODY}, plugin_repo=True)
+        clause = result["failing_clauses"][0]
+        body = self.m._rejection_comment_body(result, clause)
+        self.assertIn("story-supervised", body)
+        self.assertIn(self.m._sentinel(clause), body)
+
+
+class TestCliFromJson(unittest.TestCase):
+    """End-to-end through the CLI's --from-json/--no-comment path -- never shells to `gh`."""
+
+    def test_from_json_writes_eligible_and_ineligible_results(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            issues_path = repo / "issues.json"
+            issues_path.write_text(
+                json.dumps(
+                    [
+                        {"number": 1, "title": "a", "url": "u1", "body": ACCEPTED_BODY},
+                        {"number": 2, "title": "b", "url": "u2", "body": PROMPT_BODY},
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            out_path = repo / "out.json"
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--repo",
+                    str(repo),
+                    "--from-json",
+                    str(issues_path),
+                    "--no-comment",
+                    "--out",
+                    str(out_path),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            results = json.loads(out_path.read_text(encoding="utf-8"))
+            self.assertEqual(len(results), 2)
+            self.assertTrue(results[0]["eligible"])
+            self.assertFalse(results[1]["eligible"])
+
+    def test_missing_from_json_file_exits_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--repo", str(repo), "--from-json", str(repo / "nope.json"), "--no-comment"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 2)
+
+    def test_non_repo_path_exits_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--repo", tmp, "--no-comment"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`scripts/intake` (#314) filters open `ready`-labelled issues against `reference/epic-plan-contract.md`'s two *mechanical* `epic-default` triggers — the third (unfamiliar surface) stays the planner's judgment and is never computed here:

- **Not majority prompt-prose**, per `reference/audit-routing-signals.md`'s Prompt signal list (mirrored in `PROMPT_SIGNAL_GLOBS`, drift-guarded by `TestPromptSignalMirror`).
- **Acceptance criteria with citations** — an "Acceptance criteria" heading followed by a list item carrying a backtick path, `file:line`, URL, or `#N` reference.

`eligible: true` means "passes both mechanical triggers" — necessary, not sufficient; `epic-default` itself is still decided at plan approval.

Read-only against GitHub except one rejection comment per failing clause, carrying an HTML sentinel so a re-run (the #316 supervisor calling this repeatedly) never re-posts. Never opens, closes, or relabels an issue. Issue text is treated as untrusted data throughout.

`--from-json`/`--no-comment` bypass `gh` entirely — used by the test suite, and available to #315's stamp→dispatch bridge to consume this output without a second `gh` round-trip.

## Test plan

- [x] `python3 -m unittest discover -s tests/jig -p 'test_intake.py' -v` — 12/12 pass
- [x] `uv run --no-project python3 -m unittest discover -s tests/jig -v` — 503/503 pass (repo-wide)
- [x] `uv run --no-project --with pytest pytest tests/python -q` — 778/778 pass
- [x] `uv run --no-project --with ruff==0.16.0 ruff check scripts tests/jig` — clean
- [x] `uv run --no-project --with vermin==1.8.0 vermin --no-tips -t=3.9- scripts/` — 3.8-clean
- [x] `uv run --no-project python scripts/check_references.py` / `validate_plugin.py` / `check_gate_independence.py` — pass
- [x] `npx -y markdownlint-cli2` — clean
- [x] `bash tests/test_gate_ledger.sh && bash tests/test_evidence_capture.sh && bash tests/test_dispatch_telemetry.sh` — pass