### PR TITLE
feat: add scripts/stamp-bridge, viva sign-off fires /next locally

### DIFF
--- a/reference/epic-orchestration.md
+++ b/reference/epic-orchestration.md
@@ -232,6 +232,10 @@ recording which route produced this approval and when.
    surfaces whichever was recorded, which is how the driver (and a human re-reading
    this epic later) tells the two routes apart. Never omit it: an epic with no recorded
    approval is exactly the state a status of `proposed` (below) is for, not `approved`.
+   `<round-ref>` itself is `scripts/stamp-bridge`'s (#315) to define: the viva review
+   round's output filename plus the first 12 hex digits of that file's own sha256, e.g.
+   `viva:review-r2.json@a1b2c3d4e5f6` — reproducible from the artifact alone, distinct
+   across two rounds that happen to share a filename.
 
    **An agent authoring a brief for the viva route records `--status proposed`
    first** — before any human has seen it — so `epic-reconcile` can see a pending

--- a/scripts/stamp-bridge
+++ b/scripts/stamp-bridge
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""stamp-bridge -- fires `/next <slug>` on a recorded viva sign-off (issue #315).
+
+After the async-approval ruling (#311), an agent-authored brief for the viva
+route is recorded `epic-set --status proposed` before any human sees it
+(`reference/epic-orchestration.md`'s step 8 note). Nothing then starts the
+run without a human at a terminal -- this script is that missing link,
+invoked once a human has stamped the brief in viva. **The stamp is the
+license to fire**: CLAUDE.md's infra-door invariant forbids a write
+"dispatched, scheduled, or triggered on the human's behalf without them
+typing it in that turn" -- the human's `/complete` in viva, resolved to a
+recorded, all-approved round on disk, is that typing, for this one epic,
+once.
+
+Local transport only (2026-09-06 billing ruling): `claude -p "/next <slug>"
+--permission-mode dontAsk` runs under the caller's own Claude Code
+subscription, the same as an interactive session. **No `--max-budget-usd`
+is passed.** `reference/epic-pricing.md` is explicit that the appetite the
+user approved is recorded and enforced in *tokens*
+(`workflows/epic-driver.js`'s own `budget` primitive) and that a derived
+dollar figure "would be a rate table stored in a ledger, going stale
+silently against every price change" -- so this script does not invent
+one. The Claude Code Routine API cloud transport the issue also names stays
+deferred, API-key-metered and out of scope for the canary.
+
+**Double-fire guard.** Refuses unless the epic's recorded `status` is
+exactly `proposed` and it carries no `approval` yet -- the #316 supervisor
+re-runs things, and a second stamp on an already-approved epic must be a
+no-op, not a second `/next` invocation racing the first.
+
+**Sign-off check.** Reads a viva review-round output file (`ReviewOutput`
+per `docs/headless-contract.md` v12 -- `sections: [{id, verdict, ...}]`).
+Refuses unless `sections` is a non-empty list and every entry's `verdict` is
+`"approved"`. Viva's own `POST /complete` guard already enforces this before
+writing the file (a partly-approved round refuses to complete), so this is
+belt-and-suspenders, not the only gate -- but the file is untrusted disk
+state as far as this script is concerned, never taken on faith.
+
+**Round-ref.** `--approval viva:<round-ref>` needs a concrete value; nothing
+upstream defines its shape. This script uses
+`<output-filename>@<sha256-of-its-bytes, first 12 hex>` -- reproducible from
+the artifact alone, and distinct across two rounds that happen to share a
+filename.
+
+Exit codes: 0 = flipped and fired (or, under `--dry-run`, would have); 1 =
+epic not eligible to flip, or the round is not signed off; 2 = usage error,
+missing files, or `gate-ledger`/`claude` not found. Python 3.9 floor, stdlib
+only, matching `scripts/intake`'s conventions.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _gitutil import git_repo_root, run  # noqa: E402
+
+
+def is_signed_off(output: dict[str, Any]) -> bool:
+    """True iff `output` is a ReviewOutput whose every section is approved."""
+    sections = output.get("sections")
+    if not isinstance(sections, list) or not sections:
+        return False
+    return all(isinstance(s, dict) and s.get("verdict") == "approved" for s in sections)
+
+
+def round_ref(output_path: Path, raw: bytes) -> str:
+    digest = hashlib.sha256(raw).hexdigest()[:12]
+    return f"{output_path.name}@{digest}"
+
+
+def eligible_to_flip(epic: dict[str, Any]) -> bool:
+    return epic.get("status") == "proposed" and not epic.get("approval")
+
+
+def next_argv(slug: str) -> list[str]:
+    return ["claude", "-p", f"/next {slug}", "--permission-mode", "dontAsk"]
+
+
+def epic_set_argv(gate_ledger: Path, slug: str, approval: str) -> list[str]:
+    return [str(gate_ledger), "epic-set", "--slug", slug, "--status", "approved", "--approval", approval]
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="stamp-bridge",
+        description="Flip a proposed epic to approved on a viva sign-off, then fire /next <slug>.",
+    )
+    parser.add_argument("--slug", required=True, help="the epic slug recorded via epic-set")
+    parser.add_argument("--viva-output", required=True, help="path to viva's ReviewOutput file (review-r{N}.json)")
+    parser.add_argument("--repo", default=".", help="path inside the target repo (default: current directory)")
+    parser.add_argument("--dry-run", action="store_true", help="print the planned commands, change nothing, run nothing")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo_root = git_repo_root(Path(args.repo).resolve())
+    if repo_root is None:
+        print(f"error: '{args.repo}' is not inside a git repository", file=sys.stderr)
+        return 2
+
+    gate_ledger = repo_root / "bin" / "gate-ledger"
+    if not gate_ledger.is_file():
+        print(f"error: no bin/gate-ledger at '{repo_root}'", file=sys.stderr)
+        return 2
+
+    output_path = Path(args.viva_output)
+    try:
+        raw = output_path.read_bytes()
+    except OSError as exc:
+        print(f"error: could not read '{output_path}': {exc}", file=sys.stderr)
+        return 2
+    try:
+        output = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"error: '{output_path}' is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    if not is_signed_off(output):
+        print(f"error: '{output_path}' is not a fully-approved viva review round", file=sys.stderr)
+        return 1
+
+    proc = run([str(gate_ledger), "epic-get", "--slug", args.slug], cwd=repo_root)
+    if proc.returncode != 0 or not proc.stdout.strip():
+        print(f"error: no recorded epic '{args.slug}'", file=sys.stderr)
+        return 1
+    try:
+        epic = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"error: epic-get returned non-JSON output: {exc}", file=sys.stderr)
+        return 2
+
+    if not eligible_to_flip(epic):
+        print(
+            f"error: epic '{args.slug}' is not eligible for the stamp bridge "
+            f"(status={epic.get('status')!r}, approval={epic.get('approval')!r})",
+            file=sys.stderr,
+        )
+        return 1
+
+    ref = round_ref(output_path, raw)
+    approval = f"viva:{ref}"
+    set_argv = epic_set_argv(gate_ledger, args.slug, approval)
+    fire_argv = next_argv(args.slug)
+
+    if args.dry_run:
+        print(f"would run: {' '.join(set_argv)}")
+        print(f"would run: {' '.join(fire_argv)}")
+        return 0
+
+    set_proc = run(set_argv, cwd=repo_root)
+    if set_proc.returncode != 0:
+        print(f"error: epic-set failed: {set_proc.stderr.strip()}", file=sys.stderr)
+        return 1
+
+    if shutil.which("claude") is None:
+        print("error: 'claude' not found on PATH", file=sys.stderr)
+        return 2
+
+    fire_proc = subprocess.run(fire_argv, cwd=repo_root, check=False)
+    return 0 if fire_proc.returncode == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/jig/test_stamp_bridge.py
+++ b/tests/jig/test_stamp_bridge.py
@@ -1,0 +1,229 @@
+"""Tests for `scripts/stamp-bridge` (issue #315).
+
+Unit tests against the pure helpers, plus end-to-end tests through
+`--dry-run` against a throwaway repo with a real `bin/gate-ledger` copy --
+never shells to `claude`, and `--dry-run` never shells to `gate-ledger`'s
+own `epic-set` either.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.machinery
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from _tempgit import init_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "stamp-bridge"
+GATE_LEDGER = REPO_ROOT / "bin" / "gate-ledger"
+
+APPROVED_ROUND = {"round": 2, "sections": [{"id": "s1", "verdict": "approved"}, {"id": "s2", "verdict": "approved"}]}
+PARTIAL_ROUND = {"round": 1, "sections": [{"id": "s1", "verdict": "approved"}, {"id": "s2", "verdict": "changes"}]}
+
+
+def _module():
+    loader = importlib.machinery.SourceFileLoader("_stamp_bridge_under_test", str(SCRIPT))
+    spec = importlib.util.spec_from_file_location("_stamp_bridge_under_test", SCRIPT, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+class TestIsSignedOff(unittest.TestCase):
+    def setUp(self) -> None:
+        self.m = _module()
+
+    def test_all_approved_sections_is_signed_off(self) -> None:
+        self.assertTrue(self.m.is_signed_off(APPROVED_ROUND))
+
+    def test_any_non_approved_section_is_not_signed_off(self) -> None:
+        self.assertFalse(self.m.is_signed_off(PARTIAL_ROUND))
+
+    def test_empty_sections_is_not_signed_off(self) -> None:
+        self.assertFalse(self.m.is_signed_off({"sections": []}))
+
+    def test_missing_sections_is_not_signed_off(self) -> None:
+        self.assertFalse(self.m.is_signed_off({"answers": []}))
+
+
+class TestEligibleToFlip(unittest.TestCase):
+    def setUp(self) -> None:
+        self.m = _module()
+
+    def test_proposed_with_no_approval_is_eligible(self) -> None:
+        self.assertTrue(self.m.eligible_to_flip({"status": "proposed"}))
+
+    def test_already_approved_is_not_eligible(self) -> None:
+        self.assertFalse(self.m.eligible_to_flip({"status": "approved", "approval": "interactive"}))
+
+    def test_running_status_is_not_eligible(self) -> None:
+        self.assertFalse(self.m.eligible_to_flip({"status": "running"}))
+
+    def test_proposed_with_stale_approval_is_not_eligible(self) -> None:
+        # Belt-and-suspenders: `status` and `approval` should always move together,
+        # but a hand-edited or partially-written ledger file shouldn't re-fire.
+        self.assertFalse(self.m.eligible_to_flip({"status": "proposed", "approval": "viva:x@y"}))
+
+
+class TestRoundRef(unittest.TestCase):
+    def test_ref_is_reproducible_from_the_same_bytes(self) -> None:
+        m = _module()
+        raw = json.dumps(APPROVED_ROUND).encode("utf-8")
+        ref1 = m.round_ref(Path("review-r2.json"), raw)
+        ref2 = m.round_ref(Path("review-r2.json"), raw)
+        self.assertEqual(ref1, ref2)
+        self.assertTrue(ref1.startswith("review-r2.json@"))
+        self.assertEqual(ref1.split("@", 1)[1], hashlib.sha256(raw).hexdigest()[:12])
+
+    def test_different_bytes_yield_different_refs(self) -> None:
+        m = _module()
+        ref1 = m.round_ref(Path("review-r2.json"), b"a")
+        ref2 = m.round_ref(Path("review-r2.json"), b"b")
+        self.assertNotEqual(ref1, ref2)
+
+
+class TestNextArgv(unittest.TestCase):
+    def test_no_budget_flag_is_ever_passed(self) -> None:
+        # reference/epic-pricing.md: the recorded appetite is tokens, and a derived
+        # dollar figure "would be a rate table stored in a ledger, going stale
+        # silently" -- this script must never invent one.
+        m = _module()
+        argv = m.next_argv("my-epic")
+        self.assertNotIn("--max-budget-usd", argv)
+        self.assertIn("/next my-epic", argv)
+        self.assertIn("--permission-mode", argv)
+        self.assertIn("dontAsk", argv)
+
+
+class TestCliDryRun(unittest.TestCase):
+    """End-to-end through --dry-run: real bin/gate-ledger, but no epic-set write and no claude invocation."""
+
+    def _install_gate_ledger(self, repo: Path) -> Path:
+        if not shutil.which("jq"):
+            self.skipTest("jq not available")
+        bin_dir = repo / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        gate_ledger_copy = bin_dir / "gate-ledger"
+        shutil.copy(GATE_LEDGER, gate_ledger_copy)
+        gate_ledger_copy.chmod(0o755)
+        return gate_ledger_copy
+
+    def _init_epic(self, repo: Path, slug: str, status: str = "proposed") -> None:
+        gate_ledger_copy = self._install_gate_ledger(repo)
+        proc = subprocess.run(
+            [str(gate_ledger_copy), "epic-set", "--slug", slug, "--title", "t", "--goal", "g", "--status", status],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def _write_round(self, path: Path, payload: dict) -> None:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_dry_run_on_eligible_epic_and_signed_off_round_reports_both_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            self._init_epic(repo, "my-epic")
+            round_path = repo / "review-r2.json"
+            self._write_round(round_path, APPROVED_ROUND)
+
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--slug", "my-epic", "--viva-output", str(round_path), "--repo", str(repo), "--dry-run"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("epic-set", proc.stdout)
+            self.assertIn("--approval", proc.stdout)
+            self.assertIn("/next my-epic", proc.stdout)
+            self.assertNotIn("--max-budget-usd", proc.stdout)
+
+    def test_partial_round_refuses(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            self._init_epic(repo, "my-epic")
+            round_path = repo / "review-r1.json"
+            self._write_round(round_path, PARTIAL_ROUND)
+
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--slug", "my-epic", "--viva-output", str(round_path), "--repo", str(repo), "--dry-run"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 1)
+
+    def test_already_approved_epic_refuses(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            self._init_epic(repo, "my-epic", status="approved")
+            round_path = repo / "review-r2.json"
+            self._write_round(round_path, APPROVED_ROUND)
+
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--slug", "my-epic", "--viva-output", str(round_path), "--repo", str(repo), "--dry-run"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 1)
+
+    def test_unknown_epic_refuses(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            self._install_gate_ledger(repo)
+            round_path = repo / "review-r2.json"
+            self._write_round(round_path, APPROVED_ROUND)
+
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--slug", "nope", "--viva-output", str(round_path), "--repo", str(repo), "--dry-run"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 1)
+
+    def test_missing_viva_output_exits_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            self._install_gate_ledger(repo)
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--slug", "my-epic", "--viva-output", str(repo / "nope.json"), "--repo", str(repo), "--dry-run"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 2)
+
+    def test_non_repo_path_exits_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--slug", "x", "--viva-output", str(Path(tmp) / "y.json"), "--repo", tmp, "--dry-run"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`scripts/stamp-bridge` (#315) is the missing link the async-approval ruling (#311) needs: an agent-authored brief for the viva route is recorded `epic-set --status proposed` before any human sees it, and nothing then started the run. This script does, once a human stamps it in viva.

- **Sign-off check**: refuses unless the viva output file is a `ReviewOutput` with a non-empty `sections` list and every section's `verdict == "approved"`. Viva's own `POST /complete` guard already enforces all-approved before writing the file, so this is belt-and-suspenders — the file is still read as untrusted disk state, never taken on faith.
- **Double-fire guard**: refuses unless the epic's recorded `status` is exactly `proposed` with no `approval` yet, so a #316 supervisor re-run against an already-approved epic is a no-op, not a second `/next` invocation racing the first.
- **Round-ref**: `<output-filename>@<first-12-hex-of-its-sha256>` — reproducible from the artifact alone. Documented at `reference/epic-orchestration.md`'s one prior forward reference to `<round-ref>`, which had no shape defined until now.
- **No `--max-budget-usd`**: `reference/epic-pricing.md` is explicit that the appetite the user approved is recorded and enforced in tokens (the driver's own `budget` primitive), and a derived dollar figure "would be a rate table stored in a ledger, going stale silently against every price change." This script doesn't invent one.
- **Local transport only**, per the 2026-09-06 billing ruling: `claude -p "/next <slug>" --permission-mode dontAsk` runs under the caller's own subscription. The cloud Routine-API transport the issue also names stays deferred and API-key-metered.
- `--dry-run` prints both planned commands and touches nothing — used for every test below.

**Scope gap surfaced, not built here**: nothing yet authors the brief itself and records `--status proposed` on the viva route (`epic-orchestration.md:236` describes the agent; I didn't find a non-interactive brief-authoring entry in `commands/next.md` today). The S2 dogfood gate's "zero typed commands between the label and the PR" has this one unbuilt link between `scripts/intake` and this bridge — flagging for the next stage, not folding into #315.

## Test plan

- [x] `uv run --no-project python3 -m unittest discover -s tests/jig -p 'test_stamp_bridge.py' -v` — 17/17 pass
- [x] `uv run --no-project python3 -m unittest discover -s tests/jig -v` — 520/520 pass (repo-wide)
- [x] `uv run --no-project --with pytest pytest tests/python -q` — 778/778 pass
- [x] `uv run --no-project --with ruff==0.16.0 ruff check scripts tests/jig` — clean
- [x] `uv run --no-project --with vermin==1.8.0 vermin --no-tips -t=3.9- scripts/` — 3.8-clean
- [x] `uv run --no-project python scripts/check_references.py` / `validate_plugin.py` / `check_gate_independence.py` — pass
- [x] `npx -y markdownlint-cli2` — clean