### PR TITLE
feat: add scripts/epic-supervisor, re-fire /next from reconcile alone

### DIFF
--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -1753,18 +1753,28 @@ cmd_epic_set() {
   return "$rc"
 }
 
-cmd_epic_run_log() { # --slug E --landed N -> appends one per-invocation landed count
+cmd_epic_run_log() { # --slug E --landed N [--tokens-spent N] -> appends one per-invocation record
   # The write half of the zero-landed stop-loss (#268). Separate verb rather than
   # an epic-set flag for the same reason work-log is separate from work-set: this
   # appends an event, it does not set a field. reference/epic-orchestration.md calls it
   # once at the close of every driver invocation, with the count the driver
   # returned — the only number a run report can be wrong about without the
   # stop-loss ever arming, which is why tests/test_gate_ledger.sh pins it.
-  local slug="" landed=""
+  #
+  # `--tokens-spent` (#316) is optional and honestly so: nothing in
+  # `workflows/epic-driver.js` returns a per-run spent figure to `/next` today
+  # (only `budget.remaining()`, read internally to decide whether to keep
+  # dispatching, per the same "no usable primitive" honesty
+  # `reference/epic-orchestration.md`'s `budget.note` already states elsewhere).
+  # Recorded when a caller has one to give, summed by a reader
+  # (`scripts/epic-supervisor`, #316) against `.appetite.tokens` — absent runs
+  # contribute 0, never treated as "unknown, so don't stop."
+  local slug="" landed="" tokens_spent=""
   while [ $# -gt 0 ]; do
     case "$1" in
-      --slug)   slug="$2"; shift 2 ;;
-      --landed) landed="$2"; shift 2 ;;
+      --slug)         slug="$2"; shift 2 ;;
+      --landed)       landed="$2"; shift 2 ;;
+      --tokens-spent) tokens_spent="$2"; shift 2 ;;
       *) echo "gate-ledger: unknown arg '$1'" >&2; return 2 ;;
     esac
   done
@@ -1774,6 +1784,10 @@ cmd_epic_run_log() { # --slug E --landed N -> appends one per-invocation landed 
   fi
   case "$landed" in
     *[!0-9]*) echo "gate-ledger: --landed must be a non-negative integer" >&2; return 2 ;;
+  esac
+  case "$tokens_spent" in
+    '') ;;
+    *[!0-9]*) echo "gate-ledger: --tokens-spent must be a non-negative integer" >&2; return 2 ;;
   esac
   if ! have jq || ! have git; then
     echo "gate-ledger: epic-run-log skipped (jq and git required)" >&2
@@ -1792,8 +1806,18 @@ cmd_epic_run_log() { # --slug E --landed N -> appends one per-invocation landed 
   # shellcheck disable=SC2016 # jq's own $var syntax, not shell expansion
   json_update "$file" \
     '.updatedAt = $t
-     | .runs = (((.runs // []) + [{at: $t, landed: ($n | tonumber)}]) | .[-($cap | tonumber):])' \
-    --arg n "$landed" --arg cap "$EPIC_RUN_HISTORY_CAP" --arg t "$(now_iso)"
+     | .runs = (((.runs // []) + [{at: $t, landed: ($n | tonumber)}
+         + (if $ts != "" then {tokensSpent: ($ts | tonumber)} else {} end)])
+       | .[-($cap | tonumber):])' \
+    --arg n "$landed" --arg ts "$tokens_spent" --arg cap "$EPIC_RUN_HISTORY_CAP" --arg t "$(now_iso)"
+  local rc=$?
+  if [ "$rc" -eq 0 ]; then
+    # shellcheck disable=SC2016 # jq's own $var syntax, not shell expansion
+    append_event "$slug" "" "epic-run" \
+      '{landed: ($n | tonumber)} + (if $ts != "" then {tokensSpent: ($ts | tonumber)} else {} end)' \
+      --arg n "$landed" --arg ts "$tokens_spent"
+  fi
+  return "$rc"
 }
 
 cmd_epic_get() {
@@ -2903,5 +2927,5 @@ case "${1:-}" in
   evidence-list)   shift; cmd_evidence_list "$@" ;;
   telemetry-dispatch) shift; cmd_telemetry_dispatch "$@" ;;
   gc)              shift; cmd_gc "$@" ;;
-  *) echo "usage: gate-ledger {record --gate G --verdict V [--blocking-lanes L1,L2] | status | gate-get [--branch B] | episode-open --gate G | episode-round --gate G | episode-verdict --gate G --verdict V [--blocking-lanes L1,L2] | episode-finding --gate G --fingerprint F --status open|closed|carried|waived|rejected-as-noise [--lane L] [--severity Critical|Important|Track] [--regression-of FP] [--waiver R] | episode-get --gate G [--findings | --history] | work-set --slug S [--title T] [--source SRC] [--branch B] [--design-doc P] [--declared-files F1,F2] [--phase PH] | work-log --slug S ([--step ST --outcome O] | --scope-delta-phase PH2 (--scope-delta-files F1,F2 | --scope-delta-unmeasured [--scope-delta-reason dispatch-failed|no-declaration|unsafe-path]) | --amend-file F --amend-reason R) [--phase PH] | work-assign --slug S --phase PH --brief B [--artifacts A1,A2] [--branch BR] [--worktree W] | work-get --slug S | work-list | epic-set --slug S [--title T] [--source SRC] [--goal G] [--branch B] [--premortem P] [--concurrency N] [--status ST] [--appetite-tokens N] [--appetite-episodes N] [--canary on|off] [--acceptance-altitude per-story|delivery-boundary] [--approval interactive|viva:REF] | epic-run-log --slug E --landed N | epic-finding --epic E --story S --lane L --severity Critical|Important|Track --fingerprint F --status open|closed|carried|waived|rejected-as-noise [--waiver R] [--sha X] | epic-attest --epic E --story S --lane L [--sha X] | epic-findings --epic E [--unresolved | --attestations] | epic-story-set --epic E --slug S [--title T] [--source SRC] [--criteria C] [--decisions D] [--carried-findings F] [--deps D] [--gates G] [--status ST] [--reason R] [--worktree P] [--bump-retry GATE] [--reset-retry GATE] [--merge-class auto-merge|human-approve|never-unattended] | epic-get --slug S | epic-reconcile --slug S [--override-stop-loss] | epic-list | worktree-path --slug S [--story ST | --json] | evidence-append --command C --exit-code N --output-digest D --origin interactive|subagent [--agent-type T] | evidence-list [--branch B] [--dedupe] | telemetry-dispatch --run-id R --step-id S --role RL --routing-reason static|override|classifier:vN|ab:ARM [--parent-step-id P] [--task-id T] [--skill K] [--model M] [--effort E] [--capturer hook|driver] [--feature k=v ...] | gc [--force]}" >&2; exit 2 ;;
+  *) echo "usage: gate-ledger {record --gate G --verdict V [--blocking-lanes L1,L2] | status | gate-get [--branch B] | episode-open --gate G | episode-round --gate G | episode-verdict --gate G --verdict V [--blocking-lanes L1,L2] | episode-finding --gate G --fingerprint F --status open|closed|carried|waived|rejected-as-noise [--lane L] [--severity Critical|Important|Track] [--regression-of FP] [--waiver R] | episode-get --gate G [--findings | --history] | work-set --slug S [--title T] [--source SRC] [--branch B] [--design-doc P] [--declared-files F1,F2] [--phase PH] | work-log --slug S ([--step ST --outcome O] | --scope-delta-phase PH2 (--scope-delta-files F1,F2 | --scope-delta-unmeasured [--scope-delta-reason dispatch-failed|no-declaration|unsafe-path]) | --amend-file F --amend-reason R) [--phase PH] | work-assign --slug S --phase PH --brief B [--artifacts A1,A2] [--branch BR] [--worktree W] | work-get --slug S | work-list | epic-set --slug S [--title T] [--source SRC] [--goal G] [--branch B] [--premortem P] [--concurrency N] [--status ST] [--appetite-tokens N] [--appetite-episodes N] [--canary on|off] [--acceptance-altitude per-story|delivery-boundary] [--approval interactive|viva:REF] | epic-run-log --slug E --landed N [--tokens-spent N] | epic-finding --epic E --story S --lane L --severity Critical|Important|Track --fingerprint F --status open|closed|carried|waived|rejected-as-noise [--waiver R] [--sha X] | epic-attest --epic E --story S --lane L [--sha X] | epic-findings --epic E [--unresolved | --attestations] | epic-story-set --epic E --slug S [--title T] [--source SRC] [--criteria C] [--decisions D] [--carried-findings F] [--deps D] [--gates G] [--status ST] [--reason R] [--worktree P] [--bump-retry GATE] [--reset-retry GATE] [--merge-class auto-merge|human-approve|never-unattended] | epic-get --slug S | epic-reconcile --slug S [--override-stop-loss] | epic-list | worktree-path --slug S [--story ST | --json] | evidence-append --command C --exit-code N --output-digest D --origin interactive|subagent [--agent-type T] | evidence-list [--branch B] [--dedupe] | telemetry-dispatch --run-id R --step-id S --role RL --routing-reason static|override|classifier:vN|ab:ARM [--parent-step-id P] [--task-id T] [--skill K] [--model M] [--effort E] [--capturer hook|driver] [--feature k=v ...] | gc [--force]}" >&2; exit 2 ;;
 esac

--- a/reference/events-format.md
+++ b/reference/events-format.md
@@ -1,11 +1,12 @@
 # Events log format — the epic transition trail and the per-epic findings ledger
 
-`bin/gate-ledger`'s `record`, `epic-set`, `epic-story-set`, `work-set`, and `work-log`
-verbs each append one JSON object per line to `.studious/epics/<epic-slug>.events.jsonl`
+`bin/gate-ledger`'s `record`, `epic-set`, `epic-story-set`, `work-set`, `work-log`, and
+`epic-run-log` verbs each append one JSON object per line to
+`.studious/epics/<epic-slug>.events.jsonl`
 via the shared `append_event()` helper — the append-only counterpart to `json_update()`'s
 role as the shared writer for every mutating verb. This file pins the exact shape so
 drift from what the code actually writes is a visible diff against this doc, not a
-silent surprise. Every one of the five functions' existing arguments, return values,
+silent surprise. Every one of the six functions' existing arguments, return values,
 and exit codes is unchanged; the event append is a side effect only, run after the
 function's own primary snapshot write already succeeded.
 
@@ -56,7 +57,7 @@ No `schemaVersion` per line — matching `reference/evidence-format.md`'s existi
 convention for this repo's append-only logs: each line is a flat, self-describing
 object, not part of one versioned document.
 
-## The five write sites
+## The six write sites
 
 | Function | `kind` | Fires when | Additional fields |
 |---|---|---|---|
@@ -65,6 +66,7 @@ object, not part of one versioned document.
 | `cmd_epic_story_set` | `story` | `--status`, `--reason`, `--bump-retry`, or `--reset-retry` was provided | whichever of `status`, `reason`, `bumpRetryGate`/`resetRetryGate` were passed this call, plus a `retries` field holding that gate's post-write count |
 | `cmd_work_set` | `phase` | `--phase` was provided, and the slug is epic-qualified | `phase` |
 | `cmd_work_log` | `step` | always (its `--step`/`--outcome` are required args), and the slug is epic-qualified | `step`, `outcome`, `phase` (omitted, not empty-string or null, when `--phase` wasn't given this call), `sha` |
+| `cmd_epic_run_log` | `epic-run` | always, and only after the snapshot write (`.runs[]`) already succeeded | `landed`, plus `tokensSpent` when `--tokens-spent` was given this call |
 
 A call that touches only non-transition fields appends nothing: `epic-set --title ...`
 alone, or `epic-story-set --title ... --deps ... --gates ...` with no `--status`/
@@ -81,7 +83,17 @@ keeps the log a runtime transition trail, not a mirror of every plan edit.
 {"at":"2026-07-11T14:20:02Z","epic":"worker-evidence-and-board","story":"board-events-log","kind":"phase","phase":"build"}
 {"at":"2026-07-11T14:22:40Z","epic":"worker-evidence-and-board","story":"board-events-log","kind":"story","status":"landed"}
 {"at":"2026-07-11T14:22:41Z","epic":"worker-evidence-and-board","story":"","kind":"epic-status","status":"ready"}
+{"at":"2026-07-11T14:23:00Z","epic":"worker-evidence-and-board","story":"","kind":"epic-run","landed":2}
 ```
+
+`epic-run` is the one kind carrying no `story` value at all in practice — a driver
+invocation lands zero or more stories, never exactly one, so it is always recorded as an
+epic-level line (`story: ""`), the same convention `cmd_record`'s no-`--` case uses for
+the epic's own integration branch. `scripts/epic-supervisor` (#316) is a reader, not a
+writer: it decides whether to fire `/next` again from `epic-reconcile`'s existing
+`stopLoss` verdict and from `.runs[].tokensSpent`, and never appends here itself — every
+`epic-run` line still comes from `cmd_epic_run_log`, fired at the close of the `/next`
+invocation the supervisor triggered, exactly as it would for one a human typed.
 
 A `gate-verdict` event and a `step` event can describe the same real gate outcome —
 `epic-driver.js`'s `gatePrompt` calls `gate-ledger record --gate ... && gate-ledger

--- a/scripts/epic-supervisor
+++ b/scripts/epic-supervisor
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""epic-supervisor -- one decide-and-maybe-fire cycle for an epic (issue #316).
+
+An epic runs inside one Workflow invocation in one session; a crash or a
+park ends the run, and the documented recovery
+(`reference/epic-orchestration.md` "Reconcile -- evidence first") is a human
+re-typing `/next`. This script is that re-fire, meant to be called
+repeatedly by something else that owns the schedule -- a launchd
+`StartInterval` unit, or a loop around `claude --bg` -- never a scheduler
+itself. Each invocation does exactly one cycle: read the ledger, decide,
+and either fire `/next <slug>` once (foreground, blocking until it returns)
+or stop. Idempotent against the ledger by construction: every decision is
+re-derived fresh from `gate-ledger epic-reconcile`/`epic-get`, nothing is
+cached between invocations, and calling this twice in a row with nothing
+having changed makes the same decision twice.
+
+**Stops, and never overrides the ledger's own word on any of them:**
+
+- `epic.status == "ready"` -- the finale already ran and passed.
+- `epic-reconcile`'s own `stopLoss.refuse` -- two consecutive zero-landed
+  runs (the M11 rule), computed once in `bin/gate-ledger` and read here,
+  never recomputed.
+- Every story settled -- `landed`, `parked`, or `dropped` -- meaning
+  nothing left that an unattended dispatch could move. A `story-supervised`
+  story is recorded `parked` with a `reason` starting `story-supervised:`
+  (`reference/epic-orchestration.md`'s park convention) and is exactly as
+  settled as any other park to this script: **never its business** to
+  un-park one, take it over, or wait on it.
+- Appetite exhausted -- `sum(runs[].tokensSpent) >= appetite.tokens`.
+  **Honestly incomplete**: `workflows/epic-driver.js` returns no per-run
+  spent figure to `/next` today (only `budget.remaining()`, read
+  internally), so `--tokens-spent` is optional at `epic-run-log` and this
+  sum is 0 until a caller starts passing it. This check is real and will
+  fire the day a caller does; until then it never triggers, which is
+  the same honesty `epic-orchestration.md`'s own `budget.note` states for
+  the fallback path -- an unenforceable ceiling has to look different
+  from an enforced one, not silently pretend to be one.
+
+**Never un-parks. Never drops. Never edits a story's status at all** --
+only `/next` (dispatched, or the human) writes those. This script's own
+write surface is nothing: it reads the ledger and, when it decides to
+fire, runs `claude -p`. The fired `/next` invocation is what calls
+`gate-ledger epic-run-log` at its own close, which is also where the
+`epic-run` event line lands (`reference/events-format.md`) -- so "logs
+each fire" is satisfied by the existing single writer, not by a second one
+here recording the same fact twice.
+
+Exit codes: 0 = decided (either fired, or stopped for a legitimate
+reason -- both print a `STOPPED: <reason>` or `FIRED` line a wrapper can
+grep); 1 = fire attempted and failed; 2 = usage error, no such epic, or
+`gate-ledger`/`claude` missing. Python 3.9 floor, stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _gitutil import git_repo_root, run  # noqa: E402
+
+SETTLED_STATUSES = frozenset({"landed", "parked", "dropped"})
+
+
+def tokens_spent(epic: dict[str, Any]) -> int:
+    return sum(int(r.get("tokensSpent") or 0) for r in epic.get("runs") or [])
+
+
+def appetite_exhausted(epic: dict[str, Any]) -> bool:
+    tokens = ((epic.get("appetite") or {}).get("tokens"))
+    if not tokens:
+        return False
+    return tokens_spent(epic) >= int(tokens)
+
+
+def all_stories_settled(epic: dict[str, Any]) -> bool:
+    stories = epic.get("stories") or {}
+    if not stories:
+        return False
+    return all((s.get("status") in SETTLED_STATUSES) for s in stories.values())
+
+
+def decide(reconcile: dict[str, Any]) -> str | None:
+    """Return a stop reason, or None to fire."""
+    epic = reconcile.get("epic") or {}
+    if epic.get("status") == "ready":
+        return "epic is ready -- finale already passed"
+    if (reconcile.get("stopLoss") or {}).get("refuse"):
+        zeros = reconcile["stopLoss"].get("consecutiveZeroLanded")
+        return f"stop-loss armed -- {zeros} consecutive zero-landed runs"
+    if appetite_exhausted(epic):
+        return f"appetite exhausted -- {tokens_spent(epic)} of {epic['appetite']['tokens']} tokens spent"
+    if all_stories_settled(epic):
+        return "every story is landed, parked, or dropped -- nothing left to drive unattended"
+    return None
+
+
+def next_argv(slug: str) -> list[str]:
+    return ["claude", "-p", f"/next {slug}", "--permission-mode", "dontAsk"]
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="epic-supervisor",
+        description="One decide-and-maybe-fire cycle: re-run /next <slug> while gate-reconcile reports unsettled work.",
+    )
+    parser.add_argument("--slug", required=True, help="the epic slug recorded via epic-set")
+    parser.add_argument("--repo", default=".", help="path inside the target repo (default: current directory)")
+    parser.add_argument("--dry-run", action="store_true", help="print the decision and the command that would run; fire nothing")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo_root = git_repo_root(Path(args.repo).resolve())
+    if repo_root is None:
+        print(f"error: '{args.repo}' is not inside a git repository", file=sys.stderr)
+        return 2
+
+    gate_ledger = repo_root / "bin" / "gate-ledger"
+    if not gate_ledger.is_file():
+        print(f"error: no bin/gate-ledger at '{repo_root}'", file=sys.stderr)
+        return 2
+
+    proc = run([str(gate_ledger), "epic-reconcile", "--slug", args.slug], cwd=repo_root)
+    if proc.returncode != 0 or not proc.stdout.strip():
+        print(f"error: no recorded epic '{args.slug}'", file=sys.stderr)
+        return 2
+    try:
+        reconcile = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"error: epic-reconcile returned non-JSON output: {exc}", file=sys.stderr)
+        return 2
+
+    reason = decide(reconcile)
+    if reason is not None:
+        print(f"STOPPED: {reason}")
+        return 0
+
+    fire_argv = next_argv(args.slug)
+    if args.dry_run:
+        print(f"would run: {' '.join(fire_argv)}")
+        return 0
+
+    if shutil.which("claude") is None:
+        print("error: 'claude' not found on PATH", file=sys.stderr)
+        return 2
+
+    fire_proc = subprocess.run(fire_argv, cwd=repo_root, check=False)
+    if fire_proc.returncode != 0:
+        print(f"error: /next exited {fire_proc.returncode}", file=sys.stderr)
+        return 1
+    print("FIRED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/jig/test_epic_supervisor.py
+++ b/tests/jig/test_epic_supervisor.py
@@ -1,0 +1,228 @@
+"""Tests for `scripts/epic-supervisor` (issue #316).
+
+Unit tests against the pure `decide()`/helpers, plus end-to-end tests
+through `--dry-run` against a throwaway repo with a real `bin/gate-ledger`
+copy -- never shells to `claude`.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from _tempgit import init_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "epic-supervisor"
+GATE_LEDGER = REPO_ROOT / "bin" / "gate-ledger"
+
+
+def _module():
+    loader = importlib.machinery.SourceFileLoader("_epic_supervisor_under_test", str(SCRIPT))
+    spec = importlib.util.spec_from_file_location("_epic_supervisor_under_test", SCRIPT, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+def _reconcile(epic: dict, stop_loss_refuse: bool = False, zeros: int = 0) -> dict:
+    return {"epic": epic, "stories": {}, "stopLoss": {"refuse": stop_loss_refuse, "consecutiveZeroLanded": zeros, "limit": 2}}
+
+
+class TestDecide(unittest.TestCase):
+    def setUp(self) -> None:
+        self.m = _module()
+
+    def test_ready_epic_stops(self) -> None:
+        reason = self.m.decide(_reconcile({"status": "ready", "stories": {"a": {"status": "landed"}}}))
+        self.assertIsNotNone(reason)
+        self.assertIn("ready", reason)
+
+    def test_stop_loss_refuse_stops_before_anything_else(self) -> None:
+        epic = {"status": "running", "stories": {"a": {"status": "pending"}}}
+        reason = self.m.decide(_reconcile(epic, stop_loss_refuse=True, zeros=2))
+        self.assertIsNotNone(reason)
+        self.assertIn("stop-loss", reason)
+        self.assertIn("2", reason)
+
+    def test_unsettled_story_and_no_stop_condition_fires(self) -> None:
+        epic = {"status": "running", "stories": {"a": {"status": "pending"}}}
+        self.assertIsNone(self.m.decide(_reconcile(epic)))
+
+    def test_all_settled_stories_stops(self) -> None:
+        epic = {"status": "running", "stories": {"a": {"status": "landed"}, "b": {"status": "parked"}}}
+        reason = self.m.decide(_reconcile(epic))
+        self.assertIsNotNone(reason)
+        self.assertIn("nothing left", reason)
+
+    def test_a_story_supervised_park_is_still_settled(self) -> None:
+        # #316's own text: "story-supervised stories are never its business" --
+        # a park is a park to this script regardless of why.
+        epic = {
+            "status": "running",
+            "stories": {"a": {"status": "parked", "reason": "story-supervised: prompt-prose -- take it through /next"}},
+        }
+        self.assertIsNotNone(self.m.decide(_reconcile(epic)))
+
+    def test_mixed_settled_and_pending_fires(self) -> None:
+        epic = {"status": "running", "stories": {"a": {"status": "landed"}, "b": {"status": "pending"}}}
+        self.assertIsNone(self.m.decide(_reconcile(epic)))
+
+    def test_no_stories_yet_does_not_read_as_settled(self) -> None:
+        epic = {"status": "running", "stories": {}}
+        self.assertIsNone(self.m.decide(_reconcile(epic)))
+
+
+class TestAppetiteExhausted(unittest.TestCase):
+    def setUp(self) -> None:
+        self.m = _module()
+
+    def test_no_appetite_recorded_never_exhausted(self) -> None:
+        self.assertFalse(self.m.appetite_exhausted({"stories": {}}))
+
+    def test_spent_below_ceiling_not_exhausted(self) -> None:
+        epic = {"appetite": {"tokens": 100000}, "runs": [{"landed": 1, "tokensSpent": 40000}]}
+        self.assertFalse(self.m.appetite_exhausted(epic))
+
+    def test_spent_at_or_above_ceiling_is_exhausted(self) -> None:
+        epic = {"appetite": {"tokens": 100000}, "runs": [{"tokensSpent": 60000}, {"tokensSpent": 40000}]}
+        self.assertTrue(self.m.appetite_exhausted(epic))
+
+    def test_runs_missing_tokens_spent_count_as_zero(self) -> None:
+        # Honest incompleteness: a run with no --tokens-spent (the only kind
+        # the driver produces today) never counts toward exhaustion.
+        epic = {"appetite": {"tokens": 1}, "runs": [{"landed": 1}, {"landed": 0}]}
+        self.assertFalse(self.m.appetite_exhausted(epic))
+        self.assertEqual(self.m.tokens_spent(epic), 0)
+
+    def test_reason_via_decide_names_the_actual_numbers(self) -> None:
+        epic = {"status": "running", "appetite": {"tokens": 100}, "runs": [{"tokensSpent": 100}], "stories": {"a": {"status": "pending"}}}
+        reason = self.m.decide(_reconcile(epic))
+        self.assertIn("100 of 100", reason)
+
+
+class TestNextArgv(unittest.TestCase):
+    def test_argv_names_the_slug_and_permission_mode(self) -> None:
+        m = _module()
+        argv = m.next_argv("my-epic")
+        self.assertIn("/next my-epic", argv)
+        self.assertIn("dontAsk", argv)
+
+
+class TestCliDryRun(unittest.TestCase):
+    def _install_gate_ledger(self, repo: Path) -> Path:
+        if not shutil.which("jq"):
+            self.skipTest("jq not available")
+        bin_dir = repo / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        copy = bin_dir / "gate-ledger"
+        shutil.copy(GATE_LEDGER, copy)
+        copy.chmod(0o755)
+        return copy
+
+    def _run(self, repo: Path, slug: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--slug", slug, "--repo", str(repo), "--dry-run"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_unsettled_epic_reports_the_command_it_would_fire(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            ledger = self._install_gate_ledger(repo)
+            subprocess.run(
+                [str(ledger), "epic-set", "--slug", "e1", "--title", "t", "--goal", "g", "--status", "running"],
+                cwd=repo, capture_output=True, text=True, check=False,
+            )
+            subprocess.run(
+                [str(ledger), "epic-story-set", "--epic", "e1", "--slug", "s1", "--title", "s"],
+                cwd=repo, capture_output=True, text=True, check=False,
+            )
+            proc = self._run(repo, "e1")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("/next e1", proc.stdout)
+
+    def test_epic_with_every_story_landed_or_parked_stops(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            ledger = self._install_gate_ledger(repo)
+            subprocess.run(
+                [str(ledger), "epic-set", "--slug", "e2", "--title", "t", "--goal", "g", "--status", "running"],
+                cwd=repo, capture_output=True, text=True, check=False,
+            )
+            subprocess.run(
+                [str(ledger), "epic-story-set", "--epic", "e2", "--slug", "s1", "--title", "s", "--status", "landed"],
+                cwd=repo, capture_output=True, text=True, check=False,
+            )
+            proc = self._run(repo, "e2")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("STOPPED", proc.stdout)
+
+    def test_ready_epic_stops(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            ledger = self._install_gate_ledger(repo)
+            subprocess.run(
+                [str(ledger), "epic-set", "--slug", "e3", "--title", "t", "--goal", "g", "--status", "ready"],
+                cwd=repo, capture_output=True, text=True, check=False,
+            )
+            proc = self._run(repo, "e3")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("STOPPED", proc.stdout)
+            self.assertIn("ready", proc.stdout)
+
+    def test_stop_loss_stops(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            ledger = self._install_gate_ledger(repo)
+            subprocess.run(
+                [str(ledger), "epic-set", "--slug", "e4", "--title", "t", "--goal", "g", "--status", "running"],
+                cwd=repo, capture_output=True, text=True, check=False,
+            )
+            subprocess.run(
+                [str(ledger), "epic-story-set", "--epic", "e4", "--slug", "s1", "--title", "s"],
+                cwd=repo, capture_output=True, text=True, check=False,
+            )
+            subprocess.run([str(ledger), "epic-run-log", "--slug", "e4", "--landed", "0"], cwd=repo, capture_output=True, text=True, check=False)
+            subprocess.run([str(ledger), "epic-run-log", "--slug", "e4", "--landed", "0"], cwd=repo, capture_output=True, text=True, check=False)
+            proc = self._run(repo, "e4")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("STOPPED", proc.stdout)
+            self.assertIn("stop-loss", proc.stdout)
+
+    def test_unknown_epic_exits_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            self._install_gate_ledger(repo)
+            proc = self._run(repo, "nope")
+            self.assertEqual(proc.returncode, 2)
+
+    def test_non_repo_path_exits_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--slug", "x", "--repo", tmp, "--dry-run"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gate_ledger.sh
+++ b/tests/test_gate_ledger.sh
@@ -2470,6 +2470,29 @@ check "epic-run-log requires --landed" "2" \
 check "epic-run-log refuses an unrecorded epic" "2" \
   "$(cd "$da" && "$LEDGER" epic-run-log --slug ghost --landed 1 >/dev/null 2>&1; echo $?)"
 
+# --tokens-spent (#316): optional, so a caller with nothing to report writes
+# exactly as before; recorded per-run, and the write is also mirrored as an
+# events.jsonl line for the same reasons every other transition is.
+de=$(sandbox)
+eef="$de/.studious/epics/priced.events.jsonl"
+( cd "$de" && "$LEDGER" epic-set --slug priced --title P ) >/dev/null
+( cd "$de" && "$LEDGER" epic-run-log --slug priced --landed 1 --tokens-spent 12000 ) >/dev/null
+check "tokens-spent is recorded on the run entry" "12000" \
+  "$(jq -r '.runs[-1].tokensSpent' "$de/.studious/epics/priced.json")"
+( cd "$de" && "$LEDGER" epic-run-log --slug priced --landed 0 ) >/dev/null
+check "a run with no --tokens-spent carries no tokensSpent field" "null" \
+  "$(jq -r '.runs[-1].tokensSpent // null' "$de/.studious/epics/priced.json")"
+check "epic-run-log rejects a non-numeric --tokens-spent" "2" \
+  "$(cd "$de" && "$LEDGER" epic-run-log --slug priced --landed 1 --tokens-spent lots >/dev/null 2>&1; echo $?)"
+check "every epic-run-log call appends one epic-run event" "2" \
+  "$(grep -c '"kind":"epic-run"' "$eef")"
+check "the epic-run event carries landed and tokensSpent" "1 12000" \
+  "$(head -1 "$eef" | jq -r '[.landed, .tokensSpent] | join(" ")')"
+check "an epic-run event with no tokens-spent omits the field" "null" \
+  "$(tail -1 "$eef" | jq -r '.tokensSpent // null')"
+check "epic-run events carry no story (epic-level, per record's own convention)" "" \
+  "$(head -1 "$eef" | jq -r '.story')"
+
 # Run history is bounded — the stop-loss only ever reads the tail.
 db=$(sandbox)
 ( cd "$db" && "$LEDGER" epic-set --slug longrun --title L ) >/dev/null


### PR DESCRIPTION
## Summary

`scripts/epic-supervisor` (#316) is one decide-and-maybe-fire cycle: read `gate-ledger epic-reconcile`, decide, and either fire `/next <slug>` once (foreground, blocking) or stop. It is meant to be called repeatedly by something else that owns the schedule — a launchd `StartInterval` unit, or a loop around `claude --bg` — never a scheduler itself.

**Stops on**, checked in order:
- `epic.status == "ready"` — finale already passed.
- `epic-reconcile`'s own `stopLoss.refuse` — the M11 two-consecutive-zero-landed rule, read from the ledger's existing computation, never re-derived.
- Every story `landed`, `parked`, or `dropped` — nothing left an unattended dispatch could move. A `story-supervised` park is exactly as settled as any other to this script — never its business to un-park, take over, or wait on.
- Appetite exhausted — `sum(runs[].tokensSpent) >= appetite.tokens`.

**Never un-parks, never drops, never edits a story** — its only write is firing `claude -p "/next <slug>" --permission-mode dontAsk`, local-transport per the billing ruling.

**`bin/gate-ledger` change riding along**: `epic-run-log` gains an optional `--tokens-spent`, recorded per run and mirrored as a new `epic-run` event line in `.studious/epics/<slug>.events.jsonl` (`reference/events-format.md` updated — six write sites now, not five). This one write satisfies both the supervisor's appetite check *and* #316's "logs each fire" requirement, via the existing single writer (every `/next` invocation, human- or supervisor-triggered, calls `epic-run-log` at its own close) rather than a second writer recording the same fact twice.

**Honestly incomplete, stated as such in the docstring**: `workflows/epic-driver.js` returns no per-run tokens-spent figure to `/next` today (only `budget.remaining()`, read internally) — so `--tokens-spent` is optional and the appetite check is real but inert until a caller starts passing it. Same honesty pattern `epic-orchestration.md`'s own `budget.note` already uses elsewhere for the fallback path.

**Residual from #182, not resolved here** (per the milestone plan): `main`'s ruleset has 0 required approvals and admin bypass — a supervisor pushing/merging unattended needs a non-admin identity or the human-approve tier is unenforced. This script only fires `/next`; it doesn't merge or push anything itself, so it doesn't need that identity yet, but whatever eventually does will.

## Test plan

- [x] `uv run --no-project python3 -m unittest discover -s tests/jig -p 'test_epic_supervisor.py' -v` — 19/19 pass
- [x] `uv run --no-project python3 -m unittest discover -s tests/jig -v` — 539/539 pass (repo-wide)
- [x] `uv run --no-project --with pytest pytest tests/python -q` — 778/778 pass
- [x] `bash tests/test_gate_ledger.sh` — pass, including new `--tokens-spent`/`epic-run` event round-trips
- [x] `bash tests/test_evidence_capture.sh && bash tests/test_dispatch_telemetry.sh` — pass
- [x] `shellcheck bin/gate-ledger hooks/*.sh tests/test_*.sh` — clean
- [x] `uv run --no-project --with ruff==0.16.0 ruff check scripts tests/jig` — clean
- [x] `uv run --no-project --with vermin==1.8.0 vermin --no-tips -t=3.9- scripts/` — 3.8-clean
- [x] `uv run --no-project python scripts/check_references.py` / `validate_plugin.py` / `check_gate_independence.py` — pass
- [x] `npx -y markdownlint-cli2` — clean