### PR TITLE
feat: add scripts/park-packet and park-resolve, browser-resolvable parks

### DIFF
--- a/reference/epic-orchestration.md
+++ b/reference/epic-orchestration.md
@@ -366,6 +366,22 @@ If the epic's status is still `approved`, mark the run started:
 
 ### 1 · Reconcile — evidence first
 
+**Apply any browser-submitted park resolutions first (#317), before the read
+everything below trusts:**
+
+```bash
+scripts/park-resolve --slug "<slug>" --repo "<repo root>"
+```
+
+A park resolved in the browser while nobody was watching a terminal is exactly the
+kind of un-park `reference/epic-orchestration.md`'s own "Skips, amendments, and
+un-parking" section already licenses — this call applies it through the same
+`gate-ledger` verbs a human would type by hand, never a new mechanism. Idempotent:
+a story no longer recorded `parked` is skipped, so re-running this against a stale
+`answers.json` is a no-op. A non-zero exit here is worth surfacing in the run report
+(one resolution refused or failed), never worth stopping the invocation over — the
+rest of Reconcile proceeds either way.
+
 Recorded state must match evidence before anything is dispatched; evidence wins, and
 the files get corrected (via `gate-ledger`, never by hand) when they disagree. One
 call resolves all of it:
@@ -1067,6 +1083,20 @@ Landed this run: <story> — <phase>: <outcome> (<Nm>) → <phase>: <outcome> (<
   gate-ledger work-get --slug "<slug>--<story>"
 Run /next when you're ready, or resolve the queue first.
 ```
+
+**After rendering, write a browser-facing packet for every gate-parked story (#317) —
+additive, the terminal block above is unchanged either way:**
+
+```bash
+scripts/park-packet --slug "<slug>" --repo "<repo root>"
+```
+
+One viva QA round per gate-parked story, read fresh from the ledger every run — never
+carried over from a prior invocation's own report. A `story-supervised` park (the
+second `Needs you` bullet form above) gets no packet: it has no gate verdict or
+branch to show, and its resolution is `/next "<slug>--<story>"` at a terminal, exactly
+as printed. This call is best-effort reporting, not a gate: a non-zero exit is worth a
+line in the run report, never worth failing the invocation over.
 
 `<scope line>` is always exactly one of the five renderings the jq above produces
 when its read succeeds — identical composition for a `Needs you` entry and a

--- a/scripts/park-packet
+++ b/scripts/park-packet
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""park-packet -- write a viva QA round for every gate-parked story (issue #317).
+
+`/next`'s "Needs you" queue (`reference/epic-orchestration.md`) renders to a
+terminal, and under a supervisor (#316) nobody is reading one. This script
+is the browser-facing half: one viva `QAInput` round
+(`docs/headless-contract.md` v12, `--mode qa`) per gate-parked story,
+written fresh from the ledger every time it runs -- never from a prior
+run's own memory, the same durability reasoning `/ship --epic`'s reads
+already follow (a transient report is not the record; the ledger is).
+
+**A park is a decision, not a document to review section-by-section** --
+QA mode, never review mode. One question per park: `id` is the
+epic-qualified slug, `text` is the story's own recorded `reason` (already
+`"<gate>: <verdict> -- <one clause>"` per the Judgment-park convention),
+`hint` carries the evidence pointers a human needs to actually decide
+(branch sha, the `work-get`/`evidence-list` commands, any unresolved
+findings recorded against this story), `context` is the epic goal plus
+which stories this one blocks. **No `recommended_choice`** -- this script
+carries no judgment, only assembly. `choices` is the three ledger-backed
+resolutions `reference/epic-orchestration.md`'s "Skips, amendments, and
+un-parking" section actually supports: `waive` (accept the risk, closing
+any open finding recorded against this story), `amend` (carry a note
+forward as guidance and retry), `drop` (abandon the story).
+
+**A `story-supervised` park gets no packet.** It was parked before
+anything ever dispatched -- no branch, no worktree, no gate verdict to
+show -- and its own resolution is `/next "<slug>--<story>"` at a terminal,
+exactly as `reference/epic-orchestration.md` already documents. Never its
+business, the same line #316's supervisor draws for the same reason.
+
+**Layout.** `.viva/parks/<slug>--<story>/qa-input.json` -- one subdirectory
+per park, not one flat `.viva/qa-input.json`, because viva's `server.url`
+(headless contract §4) is written to `Path(--output).parent`, and two
+parks sharing one directory would collide on it the moment both are open
+at once.
+
+Exit codes: 0 = ran (zero packets written is a complete answer -- nothing
+parked); 2 = usage error, no such epic, or `gate-ledger` missing. Python
+3.9 floor, stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _gitutil import git_repo_root, run  # noqa: E402
+
+CHOICES = ["waive", "amend", "drop"]
+
+
+def is_story_supervised_park(story: dict[str, Any]) -> bool:
+    return story.get("status") == "parked" and str(story.get("reason") or "").startswith("story-supervised:")
+
+
+def is_gate_park(story: dict[str, Any]) -> bool:
+    return story.get("status") == "parked" and not is_story_supervised_park(story)
+
+
+def blocked_dependents(story_slug: str, stories: dict[str, Any]) -> list[str]:
+    return sorted(
+        s for s, obj in stories.items() if story_slug in (obj.get("deps") or []) and obj.get("status") not in ("landed", "dropped")
+    )
+
+
+def parse_findings_tsv(output: str) -> list[dict[str, str]]:
+    """Parse `epic-findings --unresolved`'s TSV body (skips the summary line)."""
+    rows = []
+    for line in output.splitlines()[1:]:
+        parts = line.split("\t")
+        if len(parts) != 7:
+            continue
+        status, severity, story, lane, fingerprint, raised_sha, resolved_sha = parts
+        rows.append(
+            {"status": status, "severity": severity, "story": story, "lane": lane, "fingerprint": fingerprint, "raisedSha": raised_sha, "resolvedSha": resolved_sha}
+        )
+    return rows
+
+
+def findings_for_story(findings: list[dict[str, str]], story_slug: str) -> list[dict[str, str]]:
+    return [f for f in findings if f.get("story") == story_slug]
+
+
+def evidence_hint(epic_slug: str, story_slug: str, story: dict[str, Any], story_findings: list[dict[str, str]]) -> str:
+    qualified = f"{epic_slug}--{story_slug}"
+    lines = [
+        f"gate-ledger work-get --slug {qualified}",
+        f"gate-ledger evidence-list --branch epic/{qualified} --dedupe",
+    ]
+    for f in story_findings:
+        lines.append(f"unresolved finding: {f['severity']} {f['fingerprint']} ({f['lane']}, status {f['status']})")
+    return " | ".join(lines)
+
+
+def packet_for(epic_slug: str, story_slug: str, story: dict[str, Any], epic: dict[str, Any], story_findings: list[dict[str, str]]) -> dict[str, Any]:
+    """Pure: one QAInput round for one gate-parked story."""
+    deps_note = blocked_dependents(story_slug, epic.get("stories") or {})
+    blocks = f"; blocks {', '.join(deps_note)}" if deps_note else ""
+    return {
+        "mode": "qa",
+        "context": f"Epic {epic_slug} -- {epic.get('goal', '')}{blocks}",
+        "questions": [
+            {
+                "id": f"{epic_slug}--{story_slug}",
+                "text": str(story.get("reason") or ""),
+                "hint": evidence_hint(epic_slug, story_slug, story, story_findings),
+                "choices": list(CHOICES),
+            }
+        ],
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="park-packet",
+        description="Write one viva QA round per gate-parked story, read fresh from the ledger.",
+    )
+    parser.add_argument("--slug", required=True, help="the epic slug recorded via epic-set")
+    parser.add_argument("--repo", default=".", help="path inside the target repo (default: current directory)")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo_root = git_repo_root(Path(args.repo).resolve())
+    if repo_root is None:
+        print(f"error: '{args.repo}' is not inside a git repository", file=sys.stderr)
+        return 2
+
+    gate_ledger = repo_root / "bin" / "gate-ledger"
+    if not gate_ledger.is_file():
+        print(f"error: no bin/gate-ledger at '{repo_root}'", file=sys.stderr)
+        return 2
+
+    reconcile_proc = run([str(gate_ledger), "epic-reconcile", "--slug", args.slug], cwd=repo_root)
+    if reconcile_proc.returncode != 0 or not reconcile_proc.stdout.strip():
+        print(f"error: no recorded epic '{args.slug}'", file=sys.stderr)
+        return 2
+    try:
+        reconcile = json.loads(reconcile_proc.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"error: epic-reconcile returned non-JSON output: {exc}", file=sys.stderr)
+        return 2
+
+    epic = reconcile.get("epic") or {}
+    stories = epic.get("stories") or {}
+
+    findings_proc = run([str(gate_ledger), "epic-findings", "--epic", args.slug, "--unresolved"], cwd=repo_root)
+    findings = parse_findings_tsv(findings_proc.stdout) if findings_proc.returncode == 0 else []
+
+    written = []
+    for story_slug, story in sorted(stories.items()):
+        if not is_gate_park(story):
+            continue
+        packet = packet_for(args.slug, story_slug, story, epic, findings_for_story(findings, story_slug))
+        park_dir = repo_root / ".viva" / "parks" / f"{args.slug}--{story_slug}"
+        park_dir.mkdir(parents=True, exist_ok=True)
+        (park_dir / "qa-input.json").write_text(json.dumps(packet, indent=2) + "\n", encoding="utf-8")
+        written.append(str(park_dir / "qa-input.json"))
+
+    print(json.dumps(written, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/park-resolve
+++ b/scripts/park-resolve
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""park-resolve -- apply a browser-submitted park decision (issue #317).
+
+The other half of `scripts/park-packet`: scans `.viva/parks/<slug>--*/` for
+an `answers.json` viva wrote after a human resolved that park's `qa-input.json`
+in the browser, and applies the chosen resolution through
+`gate-ledger`, never by hand-editing ledger state
+(`reference/epic-orchestration.md`'s "Amendments go through this command").
+
+**Idempotent against the ledger, not file presence.** A story whose recorded
+`status` is no longer `parked` is skipped -- already resolved, by this
+script or a human at a terminal -- so re-running against a stale
+`answers.json` left on disk is a no-op, never a second write.
+
+**The three choices, mapped to the exact verbs
+`reference/epic-orchestration.md`'s "Skips, amendments, and un-parking"
+section names:**
+
+- **`waive`** -- accepts the risk. Closes every unresolved finding recorded
+  against this story (`epic-finding --status waived --waiver <note>`), then
+  un-parks (`epic-story-set --status pending --reason "resolved: waived --
+  <note>" --reset-retry <gate>`). Refuses with no write at all when `note`
+  is empty -- a waiver with no reason is exactly what
+  `cmd_epic_finding`'s own validation already refuses for a Critical, and
+  this script does not create a code path around that by omitting the flag
+  for anything below Critical.
+- **`amend`** -- un-parks with the human's note carried forward as guidance
+  (`--carried-findings`), never `--decisions`: this is a human accepting an
+  agent's diagnosis or supplying their own, not the settled answer to an
+  interview fork (`epic-orchestration.md`'s own distinction between the two
+  fields). `note` is optional here; an empty one un-parks with no carried
+  guidance at all, which is still a legitimate "just try again."
+- **`drop`** -- `epic-story-set --status dropped`. No note required.
+
+`<gate>` for `--reset-retry` is read off the story's own recorded `reason`
+(`"<gate>: <verdict> -- <one clause>"`), never re-typed by a caller.
+
+Exit codes: 0 = ran (nothing to resolve is a complete answer); 1 = one or
+more resolutions failed or were refused; 2 = usage error, no such epic, or
+`gate-ledger` missing. Python 3.9 floor, stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _gitutil import git_repo_root, run  # noqa: E402
+
+
+def gate_from_reason(reason: str) -> str:
+    """The `<gate>` token off a story's `"<gate>: <verdict> -- <clause>"` reason.
+
+    Empty if unparseable, or if the reason is a `story-supervised:` park --
+    that prefix names no gate at all (`park-packet` never issues a packet
+    for one; this guard is defense-in-depth for a story-supervised park
+    resolved by some other path).
+    """
+    if not reason.startswith("story-supervised:") and ":" in reason:
+        return reason.split(":", 1)[0].strip()
+    return ""
+
+
+def parse_findings_tsv(output: str) -> list[dict[str, str]]:
+    """Parse `epic-findings --unresolved`'s TSV body (skips the summary line).
+
+    Duplicated from `scripts/park-packet` rather than imported: both are
+    extensionless CLI scripts, not a package, and this is five lines.
+    """
+    rows = []
+    for line in output.splitlines()[1:]:
+        parts = line.split("\t")
+        if len(parts) != 7:
+            continue
+        status, severity, story, lane, fingerprint, raised_sha, resolved_sha = parts
+        rows.append(
+            {"status": status, "severity": severity, "story": story, "lane": lane, "fingerprint": fingerprint, "raisedSha": raised_sha, "resolvedSha": resolved_sha}
+        )
+    return rows
+
+
+def resolution_argv(
+    gate_ledger: str, epic_slug: str, story_slug: str, story: dict[str, Any], choice: str, note: str, story_findings: list[dict[str, str]]
+) -> list[list[str]] | None:
+    """Pure: the sequence of gate-ledger argv this resolution requires, or None when refused."""
+    gate = gate_from_reason(str(story.get("reason") or ""))
+    if choice == "waive":
+        if not note.strip():
+            return None
+        calls = [
+            [gate_ledger, "epic-finding", "--epic", epic_slug, "--story", story_slug, "--lane", f["lane"], "--severity", f["severity"], "--fingerprint", f["fingerprint"], "--status", "waived", "--waiver", note]
+            for f in story_findings
+        ]
+        calls.append(
+            [gate_ledger, "epic-story-set", "--epic", epic_slug, "--slug", story_slug, "--status", "pending", "--reason", f"resolved: waived -- {note}"]
+            + (["--reset-retry", gate] if gate else [])
+        )
+        return calls
+    if choice == "amend":
+        argv = [gate_ledger, "epic-story-set", "--epic", epic_slug, "--slug", story_slug, "--status", "pending", "--reason", f"resolved: amended -- {note}" if note.strip() else "resolved: amended"]
+        if gate:
+            argv += ["--reset-retry", gate]
+        if note.strip():
+            argv += ["--carried-findings", note]
+        return [argv]
+    if choice == "drop":
+        return [[gate_ledger, "epic-story-set", "--epic", epic_slug, "--slug", story_slug, "--status", "dropped"]]
+    return None
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="park-resolve",
+        description="Apply browser-submitted park resolutions from .viva/parks/<slug>--*/answers.json.",
+    )
+    parser.add_argument("--slug", required=True, help="the epic slug recorded via epic-set")
+    parser.add_argument("--repo", default=".", help="path inside the target repo (default: current directory)")
+    parser.add_argument("--dry-run", action="store_true", help="print the resolutions that would apply; write nothing")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo_root = git_repo_root(Path(args.repo).resolve())
+    if repo_root is None:
+        print(f"error: '{args.repo}' is not inside a git repository", file=sys.stderr)
+        return 2
+
+    gate_ledger = repo_root / "bin" / "gate-ledger"
+    if not gate_ledger.is_file():
+        print(f"error: no bin/gate-ledger at '{repo_root}'", file=sys.stderr)
+        return 2
+
+    reconcile_proc = run([str(gate_ledger), "epic-reconcile", "--slug", args.slug], cwd=repo_root)
+    if reconcile_proc.returncode != 0 or not reconcile_proc.stdout.strip():
+        print(f"error: no recorded epic '{args.slug}'", file=sys.stderr)
+        return 2
+    try:
+        reconcile = json.loads(reconcile_proc.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"error: epic-reconcile returned non-JSON output: {exc}", file=sys.stderr)
+        return 2
+
+    epic = reconcile.get("epic") or {}
+    stories = epic.get("stories") or {}
+
+    findings_proc = run([str(gate_ledger), "epic-findings", "--epic", args.slug, "--unresolved"], cwd=repo_root)
+    findings = parse_findings_tsv(findings_proc.stdout) if findings_proc.returncode == 0 else []
+
+    ok = True
+    parks_dir = repo_root / ".viva" / "parks"
+    prefix = f"{args.slug}--"
+    for park_dir in sorted(parks_dir.glob(f"{prefix}*")) if parks_dir.is_dir() else []:
+        story_slug = park_dir.name[len(prefix) :]
+        answers_path = park_dir / "answers.json"
+        if not answers_path.is_file():
+            continue
+        story = stories.get(story_slug)
+        if story is None or story.get("status") != "parked":
+            continue
+        try:
+            output = json.loads(answers_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"error: could not read '{answers_path}': {exc}", file=sys.stderr)
+            ok = False
+            continue
+        answer = next((a for a in output.get("answers") or [] if a.get("id") == f"{args.slug}--{story_slug}"), None)
+        if answer is None:
+            continue
+        story_findings = [f for f in findings if f.get("story") == story_slug]
+        calls = resolution_argv(str(gate_ledger), args.slug, story_slug, story, answer.get("choice") or "", answer.get("note") or "", story_findings)
+        if calls is None:
+            print(f"error: refused to resolve '{story_slug}' ({answer.get('choice')!r} with no note)", file=sys.stderr)
+            ok = False
+            continue
+        for call in calls:
+            if args.dry_run:
+                print(f"would run: {' '.join(call)}")
+                continue
+            proc = run(call, cwd=repo_root)
+            if proc.returncode != 0:
+                print(f"error: {' '.join(call)} failed: {proc.stderr.strip()}", file=sys.stderr)
+                ok = False
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/jig/test_park_packet.py
+++ b/tests/jig/test_park_packet.py
@@ -1,0 +1,178 @@
+"""Tests for `scripts/park-packet` (issue #317)."""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from _tempgit import init_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "park-packet"
+GATE_LEDGER = REPO_ROOT / "bin" / "gate-ledger"
+
+
+def _module():
+    loader = importlib.machinery.SourceFileLoader("_park_packet_under_test", str(SCRIPT))
+    spec = importlib.util.spec_from_file_location("_park_packet_under_test", SCRIPT, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+class TestParkClassification(unittest.TestCase):
+    def setUp(self) -> None:
+        self.m = _module()
+
+    def test_gate_park_is_a_gate_park(self) -> None:
+        story = {"status": "parked", "reason": "audit: FIX AND RE-REVIEW -- unresolved finding"}
+        self.assertTrue(self.m.is_gate_park(story))
+        self.assertFalse(self.m.is_story_supervised_park(story))
+
+    def test_story_supervised_park_is_not_a_gate_park(self) -> None:
+        story = {"status": "parked", "reason": "story-supervised: majority prompt-prose -- take it through /next"}
+        self.assertFalse(self.m.is_gate_park(story))
+        self.assertTrue(self.m.is_story_supervised_park(story))
+
+    def test_a_pending_story_is_neither(self) -> None:
+        story = {"status": "pending"}
+        self.assertFalse(self.m.is_gate_park(story))
+        self.assertFalse(self.m.is_story_supervised_park(story))
+
+
+class TestBlockedDependents(unittest.TestCase):
+    def test_finds_stories_depending_on_this_one_not_yet_settled(self) -> None:
+        m = _module()
+        stories = {
+            "a": {"status": "parked"},
+            "b": {"status": "pending", "deps": ["a"]},
+            "c": {"status": "landed", "deps": ["a"]},
+            "d": {"status": "pending", "deps": ["other"]},
+        }
+        self.assertEqual(m.blocked_dependents("a", stories), ["b"])
+
+
+class TestFindingsTsv(unittest.TestCase):
+    def test_parses_rows_and_filters_by_story(self) -> None:
+        m = _module()
+        tsv = (
+            "epic e -- 2 finding(s), 2 unresolved, 0 attestation(s)\n"
+            "open\tCritical\talpha\tsecurity-auditor\tsec-1\ta1b2c3d\t-\n"
+            "carried\tImportant\tbeta\tcode-auditor\tcode-1\td4e5f6a\t-\n"
+        )
+        rows = m.parse_findings_tsv(tsv)
+        self.assertEqual(len(rows), 2)
+        alpha = m.findings_for_story(rows, "alpha")
+        self.assertEqual(len(alpha), 1)
+        self.assertEqual(alpha[0]["fingerprint"], "sec-1")
+
+    def test_summary_only_line_yields_no_rows(self) -> None:
+        m = _module()
+        self.assertEqual(m.parse_findings_tsv("epic e -- 0 finding(s), 0 unresolved, 0 attestation(s)\n"), [])
+
+
+class TestPacketFor(unittest.TestCase):
+    def setUp(self) -> None:
+        self.m = _module()
+
+    def test_packet_shape_and_required_fields(self) -> None:
+        epic = {"goal": "ship the thing", "stories": {"a": {"status": "parked"}}}
+        story = {"status": "parked", "reason": "audit: FIX AND RE-REVIEW -- unresolved finding"}
+        packet = self.m.packet_for("my-epic", "a", story, epic, [])
+        self.assertEqual(packet["mode"], "qa")
+        self.assertEqual(len(packet["questions"]), 1)
+        q = packet["questions"][0]
+        self.assertEqual(q["id"], "my-epic--a")
+        self.assertEqual(q["text"], story["reason"])
+        self.assertEqual(q["choices"], ["waive", "amend", "drop"])
+        self.assertNotIn("recommended_choice", q)
+
+    def test_context_names_blocked_dependents(self) -> None:
+        epic = {"goal": "g", "stories": {"a": {"status": "parked"}, "b": {"status": "pending", "deps": ["a"]}}}
+        story = {"status": "parked", "reason": "audit: FIX -- x"}
+        packet = self.m.packet_for("e", "a", story, epic, [])
+        self.assertIn("blocks b", packet["context"])
+
+    def test_hint_carries_unresolved_findings(self) -> None:
+        epic = {"goal": "g", "stories": {}}
+        story = {"status": "parked", "reason": "audit: FIX -- x"}
+        findings = [{"status": "open", "severity": "Critical", "story": "a", "lane": "security-auditor", "fingerprint": "sec-1", "raisedSha": "x", "resolvedSha": "-"}]
+        packet = self.m.packet_for("e", "a", story, epic, findings)
+        self.assertIn("sec-1", packet["questions"][0]["hint"])
+        self.assertIn("Critical", packet["questions"][0]["hint"])
+
+
+class TestCliEndToEnd(unittest.TestCase):
+    def _install_gate_ledger(self, repo: Path) -> Path:
+        if not shutil.which("jq"):
+            self.skipTest("jq not available")
+        bin_dir = repo / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        copy = bin_dir / "gate-ledger"
+        shutil.copy(GATE_LEDGER, copy)
+        copy.chmod(0o755)
+        return copy
+
+    def _gl(self, ledger: Path, repo: Path, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run([str(ledger), *args], cwd=repo, capture_output=True, text=True, check=False)
+
+    def test_writes_one_packet_per_gate_park_and_none_for_story_supervised(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            ledger = self._install_gate_ledger(repo)
+            self._gl(ledger, repo, "epic-set", "--slug", "e1", "--title", "t", "--goal", "g", "--status", "running")
+            self._gl(ledger, repo, "epic-story-set", "--epic", "e1", "--slug", "gated", "--title", "s",
+                     "--status", "parked", "--reason", "audit: FIX AND RE-REVIEW -- unresolved finding")
+            self._gl(ledger, repo, "epic-story-set", "--epic", "e1", "--slug", "supervised", "--title", "s2",
+                     "--status", "parked", "--reason", "story-supervised: majority prompt-prose -- take it through /next")
+            self._gl(ledger, repo, "epic-story-set", "--epic", "e1", "--slug", "landed", "--title", "s3", "--status", "landed")
+
+            proc = subprocess.run([sys.executable, str(SCRIPT), "--slug", "e1", "--repo", str(repo)], capture_output=True, text=True, check=False)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            written = json.loads(proc.stdout)
+            self.assertEqual(len(written), 1)
+
+            packet_path = repo / ".viva" / "parks" / "e1--gated" / "qa-input.json"
+            self.assertTrue(packet_path.is_file())
+            packet = json.loads(packet_path.read_text(encoding="utf-8"))
+            self.assertEqual(packet["questions"][0]["id"], "e1--gated")
+            self.assertFalse((repo / ".viva" / "parks" / "e1--supervised").exists())
+            self.assertFalse((repo / ".viva" / "parks" / "e1--landed").exists())
+
+    def test_no_parks_writes_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            ledger = self._install_gate_ledger(repo)
+            self._gl(ledger, repo, "epic-set", "--slug", "e2", "--title", "t", "--goal", "g", "--status", "running")
+            proc = subprocess.run([sys.executable, str(SCRIPT), "--slug", "e2", "--repo", str(repo)], capture_output=True, text=True, check=False)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(json.loads(proc.stdout), [])
+
+    def test_unknown_epic_exits_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            self._install_gate_ledger(repo)
+            proc = subprocess.run([sys.executable, str(SCRIPT), "--slug", "nope", "--repo", str(repo)], capture_output=True, text=True, check=False)
+            self.assertEqual(proc.returncode, 2)
+
+    def test_non_repo_path_exits_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            proc = subprocess.run([sys.executable, str(SCRIPT), "--slug", "x", "--repo", tmp], capture_output=True, text=True, check=False)
+            self.assertEqual(proc.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/jig/test_park_resolve.py
+++ b/tests/jig/test_park_resolve.py
@@ -1,0 +1,207 @@
+"""Tests for `scripts/park-resolve` (issue #317)."""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from _tempgit import init_repo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "park-resolve"
+GATE_LEDGER = REPO_ROOT / "bin" / "gate-ledger"
+
+
+def _module():
+    loader = importlib.machinery.SourceFileLoader("_park_resolve_under_test", str(SCRIPT))
+    spec = importlib.util.spec_from_file_location("_park_resolve_under_test", SCRIPT, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+class TestGateFromReason(unittest.TestCase):
+    def test_extracts_the_gate_token(self) -> None:
+        m = _module()
+        self.assertEqual(m.gate_from_reason("audit: FIX AND RE-REVIEW -- unresolved finding"), "audit")
+
+    def test_unparseable_reason_yields_empty(self) -> None:
+        m = _module()
+        self.assertEqual(m.gate_from_reason("no colon here"), "")
+
+
+class TestResolutionArgv(unittest.TestCase):
+    def setUp(self) -> None:
+        self.m = _module()
+        self.story = {"status": "parked", "reason": "audit: FIX AND RE-REVIEW -- unresolved finding"}
+
+    def test_waive_with_no_note_is_refused(self) -> None:
+        self.assertIsNone(self.m.resolution_argv("gl", "e", "s", self.story, "waive", "", []))
+
+    def test_waive_closes_every_unresolved_finding_then_unparks(self) -> None:
+        findings = [
+            {"status": "open", "severity": "Critical", "story": "s", "lane": "security-auditor", "fingerprint": "sec-1", "raisedSha": "x", "resolvedSha": "-"},
+            {"status": "carried", "severity": "Important", "story": "s", "lane": "code-auditor", "fingerprint": "code-1", "raisedSha": "y", "resolvedSha": "-"},
+        ]
+        calls = self.m.resolution_argv("gl", "e", "s", self.story, "waive", "accepted, low risk", findings)
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(calls[0][:2], ["gl", "epic-finding"])
+        self.assertIn("sec-1", calls[0])
+        self.assertIn("waived", calls[0])
+        self.assertIn("accepted, low risk", calls[0])
+        self.assertIn("code-1", calls[1])
+        self.assertEqual(calls[2][:2], ["gl", "epic-story-set"])
+        self.assertIn("pending", calls[2])
+        self.assertIn("--reset-retry", calls[2])
+        self.assertIn("audit", calls[2])
+
+    def test_waive_with_no_findings_still_unparks(self) -> None:
+        calls = self.m.resolution_argv("gl", "e", "s", self.story, "waive", "no findings recorded, still resolving", [])
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][:2], ["gl", "epic-story-set"])
+
+    def test_amend_carries_the_note_forward(self) -> None:
+        calls = self.m.resolution_argv("gl", "e", "s", self.story, "amend", "try the other approach", [])
+        self.assertEqual(len(calls), 1)
+        argv = calls[0]
+        self.assertIn("--carried-findings", argv)
+        self.assertIn("try the other approach", argv)
+        self.assertIn("--reset-retry", argv)
+        self.assertNotIn("--decisions", argv)
+
+    def test_amend_with_no_note_still_unparks_with_no_carried_findings(self) -> None:
+        calls = self.m.resolution_argv("gl", "e", "s", self.story, "amend", "", [])
+        self.assertEqual(len(calls), 1)
+        self.assertNotIn("--carried-findings", calls[0])
+
+    def test_drop_needs_no_note(self) -> None:
+        calls = self.m.resolution_argv("gl", "e", "s", self.story, "drop", "", [])
+        self.assertEqual(len(calls), 1)
+        self.assertIn("dropped", calls[0])
+
+    def test_unknown_choice_is_refused(self) -> None:
+        self.assertIsNone(self.m.resolution_argv("gl", "e", "s", self.story, "recommend", "note", []))
+
+    def test_story_supervised_reasons_have_no_gate_to_reset(self) -> None:
+        story = {"status": "parked", "reason": "story-supervised: majority prompt-prose -- take it through /next"}
+        calls = self.m.resolution_argv("gl", "e", "s", story, "amend", "note", [])
+        self.assertNotIn("--reset-retry", calls[0])
+
+
+class TestCliEndToEnd(unittest.TestCase):
+    def _install_gate_ledger(self, repo: Path) -> Path:
+        if not shutil.which("jq"):
+            self.skipTest("jq not available")
+        bin_dir = repo / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        copy = bin_dir / "gate-ledger"
+        shutil.copy(GATE_LEDGER, copy)
+        copy.chmod(0o755)
+        return copy
+
+    def _gl(self, ledger: Path, repo: Path, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run([str(ledger), *args], cwd=repo, capture_output=True, text=True, check=False)
+
+    def _write_answer(self, repo: Path, epic: str, story: str, choice: str, note: str = "") -> None:
+        park_dir = repo / ".viva" / "parks" / f"{epic}--{story}"
+        park_dir.mkdir(parents=True, exist_ok=True)
+        (park_dir / "answers.json").write_text(
+            json.dumps({"answers": [{"id": f"{epic}--{story}", "choice": choice, "note": note}]}), encoding="utf-8"
+        )
+
+    def test_drop_answer_applies_and_is_idempotent_on_rerun(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            ledger = self._install_gate_ledger(repo)
+            self._gl(ledger, repo, "epic-set", "--slug", "e1", "--title", "t", "--goal", "g", "--status", "running")
+            self._gl(ledger, repo, "epic-story-set", "--epic", "e1", "--slug", "s1", "--title", "s",
+                     "--status", "parked", "--reason", "audit: FIX -- x")
+            self._write_answer(repo, "e1", "s1", "drop")
+
+            proc = subprocess.run([sys.executable, str(SCRIPT), "--slug", "e1", "--repo", str(repo)], capture_output=True, text=True, check=False)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            epic_json = json.loads((repo / ".studious" / "epics" / "e1.json").read_text(encoding="utf-8"))
+            self.assertEqual(epic_json["stories"]["s1"]["status"], "dropped")
+
+            # Re-run: story is no longer 'parked', so this is a no-op, not a re-drop.
+            proc2 = subprocess.run([sys.executable, str(SCRIPT), "--slug", "e1", "--repo", str(repo)], capture_output=True, text=True, check=False)
+            self.assertEqual(proc2.returncode, 0, proc2.stderr)
+
+    def test_amend_answer_unparks_with_carried_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            ledger = self._install_gate_ledger(repo)
+            self._gl(ledger, repo, "epic-set", "--slug", "e2", "--title", "t", "--goal", "g", "--status", "running")
+            self._gl(ledger, repo, "epic-story-set", "--epic", "e2", "--slug", "s1", "--title", "s",
+                     "--status", "parked", "--reason", "audit: FIX -- x")
+            self._write_answer(repo, "e2", "s1", "amend", "try approach B")
+
+            proc = subprocess.run([sys.executable, str(SCRIPT), "--slug", "e2", "--repo", str(repo)], capture_output=True, text=True, check=False)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            epic_json = json.loads((repo / ".studious" / "epics" / "e2.json").read_text(encoding="utf-8"))
+            self.assertEqual(epic_json["stories"]["s1"]["status"], "pending")
+            self.assertIn("try approach B", epic_json["stories"]["s1"]["carriedFindings"])
+
+    def test_waive_answer_with_no_note_is_refused_and_leaves_story_parked(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            ledger = self._install_gate_ledger(repo)
+            self._gl(ledger, repo, "epic-set", "--slug", "e3", "--title", "t", "--goal", "g", "--status", "running")
+            self._gl(ledger, repo, "epic-story-set", "--epic", "e3", "--slug", "s1", "--title", "s",
+                     "--status", "parked", "--reason", "audit: FIX -- x")
+            self._write_answer(repo, "e3", "s1", "waive", "")
+
+            proc = subprocess.run([sys.executable, str(SCRIPT), "--slug", "e3", "--repo", str(repo)], capture_output=True, text=True, check=False)
+            self.assertEqual(proc.returncode, 1)
+            epic_json = json.loads((repo / ".studious" / "epics" / "e3.json").read_text(encoding="utf-8"))
+            self.assertEqual(epic_json["stories"]["s1"]["status"], "parked")
+
+    def test_dry_run_writes_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            ledger = self._install_gate_ledger(repo)
+            self._gl(ledger, repo, "epic-set", "--slug", "e4", "--title", "t", "--goal", "g", "--status", "running")
+            self._gl(ledger, repo, "epic-story-set", "--epic", "e4", "--slug", "s1", "--title", "s",
+                     "--status", "parked", "--reason", "audit: FIX -- x")
+            self._write_answer(repo, "e4", "s1", "drop")
+
+            proc = subprocess.run([sys.executable, str(SCRIPT), "--slug", "e4", "--repo", str(repo), "--dry-run"], capture_output=True, text=True, check=False)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("would run", proc.stdout)
+            epic_json = json.loads((repo / ".studious" / "epics" / "e4.json").read_text(encoding="utf-8"))
+            self.assertEqual(epic_json["stories"]["s1"]["status"], "parked")
+
+    def test_no_answer_files_is_a_no_op(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            ledger = self._install_gate_ledger(repo)
+            self._gl(ledger, repo, "epic-set", "--slug", "e5", "--title", "t", "--goal", "g", "--status", "running")
+            proc = subprocess.run([sys.executable, str(SCRIPT), "--slug", "e5", "--repo", str(repo)], capture_output=True, text=True, check=False)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_unknown_epic_exits_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            self._install_gate_ledger(repo)
+            proc = subprocess.run([sys.executable, str(SCRIPT), "--slug", "nope", "--repo", str(repo)], capture_output=True, text=True, check=False)
+            self.assertEqual(proc.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`/next`'s "Needs you" block (`reference/epic-orchestration.md`) renders to a terminal, and under a #316 supervisor nobody is reading one. #317 is the browser-facing half, in two scripts:

**`scripts/park-packet --slug S --repo R`** — writes one viva `QAInput` round (`docs/headless-contract.md` v12, `--mode qa`) per gate-parked story, read fresh from `epic-reconcile`/`epic-findings` every run:
- `id`: `<slug>--<story>`; `text`: the story's own recorded `reason` verbatim (already `"<gate>: <verdict> — <clause>"`); `hint`: evidence pointers (`work-get`/`evidence-list` commands) plus any unresolved findings recorded against the story; `context`: epic goal + which stories this one blocks.
- `choices: ["waive", "amend", "drop"]` — the three ledger-backed resolutions `epic-orchestration.md`'s own "Skips, amendments, and un-parking" section names. **No `recommended_choice`** — this script carries no judgment.
- **A `story-supervised` park gets no packet** — it has no branch, no worktree, no verdict to show, and its resolution stays `/next "<slug>--<story>"` at a terminal, same "never its business" line #316's supervisor draws.
- Layout: `.viva/parks/<slug>--<story>/qa-input.json`, one subdirectory per park — `server.url` is written to `Path(--output).parent` (headless contract §4), so a flat shared directory would collide the moment two parks are open at once.

**`scripts/park-resolve --slug S --repo R [--dry-run]`** — scans `.viva/parks/<slug>--*/answers.json` and applies the chosen resolution through `gate-ledger`, never by hand-editing state:
- `waive`: closes every unresolved finding recorded against the story (`epic-finding --status waived --waiver <note>`), then un-parks. **Refuses with no write at all when `note` is empty** — the same discipline `cmd_epic_finding` already enforces for a Critical, extended here rather than routed around.
- `amend`: un-parks with the note carried forward via `--carried-findings`, never `--decisions` — a human accepting/supplying a diagnosis is not the same act as answering an interview fork, and the doc already draws that line.
- `drop`: `epic-story-set --status dropped`.
- Idempotent against the ledger, not file presence: a story no longer recorded `parked` is skipped, so a stale `answers.json` left on disk is a no-op on re-run.

**Two additive prose hooks in `reference/epic-orchestration.md`**, terminal path unchanged either way: Reconcile now runs `park-resolve` before trusting its own `epic-reconcile` read; the close-invocation step runs `park-packet` after rendering the "Needs you" block.

## Test plan

- [x] `uv run --no-project python3 -m unittest discover -s tests/jig -p 'test_park_packet.py' -v` — 13/13 pass
- [x] `uv run --no-project python3 -m unittest discover -s tests/jig -p 'test_park_resolve.py' -v` — 16/16 pass
- [x] `uv run --no-project python3 -m unittest discover -s tests/jig -v` — 568/568 pass (repo-wide)
- [x] `uv run --no-project --with pytest pytest tests/python -q` — 778/778 pass
- [x] `uv run --no-project --with ruff==0.16.0 ruff check scripts tests/jig` — clean
- [x] `uv run --no-project --with vermin==1.8.0 vermin --no-tips -t=3.9- scripts/` — 3.8-clean
- [x] `uv run --no-project python scripts/check_references.py` / `validate_plugin.py` / `check_gate_independence.py` — pass
- [x] `npx -y markdownlint-cli2` — clean
- [x] `bash tests/test_gate_ledger.sh && bash tests/test_evidence_capture.sh && bash tests/test_dispatch_telemetry.sh` — pass