### PR TITLE
refactor: consolidate docs/jig/ report and demonstration paths onto their live homes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ __pycache__/
 # (covered by the .studious/ entry above), and /ship's PR body is the record.
 /PLAN.md
 docs/design/
-docs/jig/demonstrations/
 
 # A/B eval run output — regenerate with scripts/run_ab_eval.py (tests/ab/README.md)
 ab-results/

--- a/scripts/build-report
+++ b/scripts/build-report
@@ -2,7 +2,7 @@
 """jig's build-report script (story finish-skill, issue #20).
 
 `/ship`'s Step 5: writes a dated, durable build report --
-`docs/jig/reports/YYYY-MM-DD-<story-slug>-build-report.md` -- same class
+`docs/studious/build-reports/YYYY-MM-DD-<story-slug>-build-report.md` -- same class
 and naming shape as studious's own dated review reports
 (`docs/studious/<kind>-reviews/YYYY-MM-DD-<kind>-review.md`), reusing an
 established convention rather than inventing a new report shape.
@@ -35,9 +35,9 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="build-report",
-        description="Write /ship's dated build report to docs/jig/reports/.",
+        description="Write /ship's dated build report to docs/studious/build-reports/.",
     )
-    parser.add_argument("--repo", default=".", help="path to the repo docs/jig/reports/ is written under")
+    parser.add_argument("--repo", default=".", help="path to the repo docs/studious/build-reports/ is written under")
     parser.add_argument("--slug", required=True, help="the story's slug (used in the report's filename)")
     parser.add_argument("--content", required=True, help="path to the already-assembled markdown report body")
     parser.add_argument("--date", default=None, help="report date, YYYY-MM-DD (default: today, UTC)")
@@ -62,7 +62,7 @@ def main(argv: list[str]) -> int:
 
     repo = Path(args.repo).resolve()
     date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    reports_root = repo / "docs" / "jig" / "reports"
+    reports_root = repo / "docs" / "studious" / "build-reports"
     report_path = reports_root / f"{date}-{args.slug}-build-report.md"
 
     if report_path.exists() and not args.force:

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -300,8 +300,8 @@ new issue numbers) and which were skipped, and the proposed decision patches
 verbatim — into a single markdown file, then call
 `scripts/build-report --repo <worktree> --slug <story-slug> --content
 <path>` (optionally `--date`; defaults to today, UTC). This writes
-`docs/jig/reports/YYYY-MM-DD-<story-slug>-build-report.md` — same class and
-naming shape as studious's own dated review reports. `build-report` only
+`docs/studious/build-reports/YYYY-MM-DD-<story-slug>-build-report.md` — same
+class and naming shape as studious's own dated review reports. `build-report` only
 performs the mechanical write; it never drafts, summarizes, or judges the
 content itself — that assembly is this step's own job, not the script's.
 
@@ -335,7 +335,7 @@ default.
 
 Every verdict shares the same cleanup step *before* whichever git action
 happens: remove `docs/design/<story-slug>.md` and `PLAN.md` (and any
-scratch `docs/jig/demonstrations/` narrative, if used). A project that
+scratch `docs/design/demonstrations/` narrative, if used). A project that
 gitignores them the way this plugin does has nothing to commit — delete
 them from the worktree and say so. A project that tracks them needs a
 `git rm` commit whose message notes the promoted-elsewhere destination.

--- a/tests/jig/test_build_report.py
+++ b/tests/jig/test_build_report.py
@@ -3,7 +3,7 @@
 Checks this story's acceptance criteria mechanically
 (the finish-skill story, Step 5):
 
-1. Happy path: writes `docs/jig/reports/YYYY-MM-DD-<slug>-build-report.md`
+1. Happy path: writes `docs/studious/build-reports/YYYY-MM-DD-<slug>-build-report.md`
    with the caller-supplied content copied in verbatim -- this script is a
    mechanical write, never a summarizer or judge of that content.
 2. `--date` defaults to today (UTC) when omitted.
@@ -40,7 +40,7 @@ class TestBuildReportHappyPath(unittest.TestCase):
             repo.mkdir()
             content = Path(tmp) / "body.md"
             content.write_text("# Build report\n\nSome assembled content.\n", encoding="utf-8")
-            reports_root = repo / "docs" / "jig" / "reports"
+            reports_root = repo / "docs" / "studious" / "build-reports"
 
             result = run_script(
                 ["--repo", str(repo), "--slug", "finish-skill", "--date", "2026-07-12", "--content", str(content)]
@@ -63,7 +63,7 @@ class TestBuildReportHappyPath(unittest.TestCase):
 
             self.assertEqual(result.returncode, 0, result.stderr)
             today = datetime.now(UTC).strftime("%Y-%m-%d")
-            expected = repo / "docs" / "jig" / "reports" / f"{today}-finish-skill-build-report.md"
+            expected = repo / "docs" / "studious" / "build-reports" / f"{today}-finish-skill-build-report.md"
             self.assertTrue(expected.is_file())
 
 
@@ -86,7 +86,7 @@ class TestBuildReportCollision(unittest.TestCase):
 
             third = run_script([*args, "--force"])
             self.assertEqual(third.returncode, 0, third.stderr)
-            report_path = repo / "docs" / "jig" / "reports" / "2026-07-12-finish-skill-build-report.md"
+            report_path = repo / "docs" / "studious" / "build-reports" / "2026-07-12-finish-skill-build-report.md"
             self.assertEqual(report_path.read_text(encoding="utf-8"), "second version\n")
 
 

--- a/tests/jig/test_finish_skill.py
+++ b/tests/jig/test_finish_skill.py
@@ -189,7 +189,7 @@ class TestFinishSkillBody(PhraseInBodyMixin, unittest.TestCase):
 
     def test_build_report_invocation_and_path_are_named(self) -> None:
         self.assertIn("scripts/build-report", self.body)
-        self.assertIn("docs/jig/reports/", self.body)
+        self.assertIn("docs/studious/build-reports/", self.body)
         self.assertIn("YYYY-MM-DD-<story-slug>-build-report.md", self.body)
 
     def test_build_report_does_not_commit_itself(self) -> None:

--- a/tests/python/test_no_jig_prose.py
+++ b/tests/python/test_no_jig_prose.py
@@ -6,10 +6,14 @@ the marketplace entry was deleted. The conditionals that *acted* on that name
 are guarded separately (`tests/jig/test_gate_handoffs.py`); this guards the
 prose, which regresses easily because old wording gets copied forward.
 
-`docs/jig/` and `tests/jig/` survive as real directory names — the evidence
-layout is pinned in `reference/evidence-format.md` and renaming it would break
-the one contract a gate is allowed to rely on. So the rule is not "the string
-never appears," it is "every appearance is part of one of those paths."
+`docs/jig/` and `tests/jig/` survive as real directory names. `tests/jig/` is
+live — the build scripts' own test tree. `docs/jig/` is historical only:
+`docs/jig/reports/`, `docs/jig/reviews/`, and `docs/jig/evidence/` hold dated
+records from before the evidence/report stores moved to `.studious/` and
+`docs/studious/` (see `/exorcist:seance` G-13) — real committed files, never
+renamed after the fact, but no longer where anything new gets written. So the
+rule is not "the string never appears," it is "every appearance is part of
+one of those paths."
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

G-13 from `docs/exorcist/seance-2026-09-05/register.json`. `docs/jig/` has been historical-only since the evidence/report stores moved to `.studious/` and `docs/studious/` — `reference/evidence-format.md` no longer mentions it — but `scripts/build-report` and `skills/ship/SKILL.md` still wrote new reports there.

- `scripts/build-report` now writes to `docs/studious/build-reports/`, matching the `docs/studious/<kind>-reviews/` naming convention already used elsewhere.
- `skills/ship/SKILL.md`'s demonstration-scratch prose now points at `docs/design/demonstrations/` (disposable tier, per CLAUDE.md's "Where a design record lives"), not `docs/studious/` (durable-only) — the register's own proposed banishment had this wrong; corrected during triage.
- `.gitignore`'s `docs/jig/demonstrations/` entry is now redundant (`docs/design/` already covers it) and dropped rather than repointed.
- `tests/python/test_no_jig_prose.py`'s docstring rationale updated: `docs/jig/` survives as historical record, not because a live contract still points at it.

The old, dated `docs/jig/reports/` and `docs/jig/reviews/` files are untouched — historical record, never renamed after the fact.

Stacked on #331 (base is that branch, not `main`) since this touches `skills/ship/SKILL.md` which #331 doesn't, but keeping them separate per the register's own triage.

## Test plan

- [x] `pytest tests/python` — 779 passed
- [x] `unittest discover -s tests/jig` — 584 passed (16 expected skips)
- [x] `scripts/check_references.py` — passes
- [x] `markdownlint-cli2` — 0 issues
- [x] `ruff check` — clean (1 pre-existing, unrelated UP017 finding)
- [x] Manual end-to-end run of `build-report` confirming the new write path