### PR TITLE
fix: only Criticals block in every episode; telemetry hook matches Agent; supervised /next runs to decisions

### DIFF
--- a/commands/next.md
+++ b/commands/next.md
@@ -36,6 +36,15 @@ rejected at intake — never approved by default, never inferred.
 stop with the closing block below, even when the result is a clean pass and the next step is
 obvious. The user advances the flow; you never do.
 
+**A piece runs to its next real decision without asking (#371).** Inside a piece — and
+inside a `story-supervised` story under an epic — never pause to ask "run it now?", "pick
+up the next task?", or "ready when you are". `story-supervised` means the human is
+*present* for the class of work (`reference/epic-plan-contract.md`), not that each step
+needs a fresh go. The stops are the decisions this door already names — a stop/rethink
+token, a Critical waiver, a round cap, a fork, a sign-off, the ship verdict, appetite — plus
+`PAUSED`/park with a named cause. Everything else is a report line, not a question. Measure:
+human turns per supervised story ≤ decisions made (`scripts/retro-stats` counts both).
+
 **One deliberate exception, inside a piece rather than between pieces.** Pieces 2 (design)
 and 3 (build) each used to be two pieces — a handoff, then a separate `/review` this door
 ran once the handoff's output existed — and each pair required its own confirmation to

--- a/commands/review.md
+++ b/commands/review.md
@@ -420,10 +420,13 @@ recommendation. The findings arrive tiered — `critical` / `important` / `track
 `report.py`'s anchor-or-demote — and which verdict a `critical` earns is read from its
 `dimension`, the judge's own name for the check that produced it:
 
-- **PROCEED TO PLAN** — design is sound; only `track` findings.
-- **REVISE** — one or more `important` findings, or a `critical` on `journeys`,
-  `simplicity`, `mental-model`, or `success-signal` — a fixable design flaw (missing state,
-  confusing step). List the specific changes needed in priority order.
+- **PROCEED TO PLAN** — no `critical`. `important` findings ride out this verdict as
+  recorded should-fix work: list them in the verdict as inputs for whatever plans the
+  build — `reference/gate-vocabulary.md`'s rule, "only a Critical blocks", holds here
+  exactly as it does for the work episode. An Important never re-opens a design round.
+- **REVISE** — a `critical` on `journeys`, `simplicity`, `mental-model`, or
+  `success-signal` — a fixable design flaw (missing state, confusing step). List the
+  specific changes needed in priority order.
 - **RETHINK** — a `critical` whose `dimension` is `problem`, `principles`, or `scope`:
   problem validity, principle conflict, or "what we're NOT building". Go back to brainstorm
   and explain why.
@@ -750,13 +753,15 @@ product-reviewer's findings — and the premortem-auditor's REALIZED findings, w
 the same three tiers — decide this episode's verdict; a `critical`'s route is read from the
 product lane's `dimension` at `acceptance`:
 
-- **SHIP** — implementation delivers the intended experience; only `track` findings.
-  Closes the episode.
-- **FIX AND RE-REVIEW** — one or more `important` findings, or a `critical` fixable with
-  targeted work: on `error-states`, `journeys`, `language`, `missing`, or `spec-fidelity`,
-  or any premortem REALIZED `critical`. List them with severity, each specific enough to
-  go directly into the engineering chain as a fix task; when the fixes land, this episode
-  re-enters for its one
+- **SHIP** — implementation delivers the intended experience; no `critical`. `important`
+  findings ride out a SHIP as recorded should-fix work (`episode-finding`, status `open`),
+  carried to the PR's follow-ups at closeout — `reference/gate-vocabulary.md`'s
+  rule, "only a Critical blocks", the same rule the work episode already follows. An
+  Important never triggers a re-review round. Closes the episode.
+- **FIX AND RE-REVIEW** — a `critical` fixable with targeted work: on `error-states`,
+  `journeys`, `language`, `missing`, or `spec-fidelity`, or any premortem REALIZED
+  `critical`. List them with severity, each specific enough to go directly into the
+  engineering chain as a fix task; when the fixes land, this episode re-enters for its one
   re-review round. **Route by scale:** a fix at story scale — a missing capability, real
   implementation work rather than a targeted correction — routes into the work episode: it
   lands as implementation work, and — the closed work episode having no round left to

--- a/hooks/dispatch-telemetry.sh
+++ b/hooks/dispatch-telemetry.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# PreToolUse hook on `Task` (wired in hooks.json): appends one `dispatch`
+# PreToolUse hook on the subagent-dispatch tool — named `Agent` in current
+# Claude Code, `Task` in older builds; hooks.json matches both — appends one `dispatch`
 # record per review agent sent out — studious's or gauntlet's — to
 # .studious/telemetry/<branch-slug>.jsonl via gate-ledger. Contract:
 # reference/telemetry-format.md; this script only calls `telemetry-dispatch`.
@@ -43,7 +44,7 @@ fields=$(printf '%s' "$input" | jq -r '
 ' 2>/dev/null) || exit 0
 IFS=$'\037' read -r tool subagent run_id step_id parent_step_id prompt_bytes self_report <<<"$fields"
 
-[ "${tool:-}" = "Task" ] || exit 0
+case "${tool:-}" in Agent|Task) ;; *) exit 0 ;; esac
 [ -n "${subagent:-}" ] || exit 0
 
 # --- self-report suppression: epic-driver.js stamps the ledger call into its

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -23,7 +23,7 @@
         ]
       },
       {
-        "matcher": "Task",
+        "matcher": "Agent|Task",
         "hooks": [
           {
             "type": "command",

--- a/reference/audit-compilation.md
+++ b/reference/audit-compilation.md
@@ -12,7 +12,7 @@ Every auditor lane lands in exactly one of four states before compiling. Classif
 
 ### Carried forward
 
-When this round was narrowed, every narrowing-tracked lane **not** in `.gates.audit.blockingLanes` was not re-dispatched — it is **carried forward**, not unaudited: the prior round's compiled verdict already proved it contributed no Confirmed Critical, which is what made narrowing possible. Carry it forward as one PASS-status Summary line — "`<lane>`: carried forward, no Confirmed Critical as of `<sha>`" — and nothing else. Do not reproduce, paraphrase, or re-derive any Important/Track findings that lane raised previously; if they still apply, resurfacing them is the job of the episode findings ledger's carried records (gate-command rounds only — the epic driver has no episode ledger and relies on its own cross-lane spot-check pass until #274 collapses the two implementations) or a future full audit, not this carry-forward.
+When this round was narrowed, every narrowing-tracked lane **not** in `.gates.audit.blockingLanes` was not re-dispatched — it is **carried forward**, not unaudited: the prior round's compiled verdict already proved it contributed no Confirmed Critical, which is what made narrowing possible. Carry it forward as one PASS-status Summary line — "`<lane>`: carried forward, no Confirmed Critical as of `<sha>`" — and nothing else. Do not reproduce, paraphrase, or re-derive any Important/Track findings that lane raised previously; if they still apply, resurfacing them is the job of the episode findings ledger's carried records (gate-command rounds; the epic driver records with bare `record` and relies on its own cross-lane spot-check pass instead) or a future full audit, not this carry-forward.
 
 ### AGENT DIED
 

--- a/reference/epic-plan-contract.md
+++ b/reference/epic-plan-contract.md
@@ -73,6 +73,10 @@ the plan must state at approval:
 - The supervised story has no branch and no worktree yet. Taking it over means running
   `/next` against it from the user's own checkout, on the branch the driver would
   have used.
+- **Supervised means present, not consent-per-piece.** The human's presence is what
+  makes the prompt-prose class safe; it is not a license for `/next` to ask before each
+  piece. A supervised story runs every piece to the next real decision — the stops
+  `commands/next.md` names — and reports; it never asks "run the next piece?" (#371).
 
 ## Gate profile — computed from the plan's own data, decided by the user
 

--- a/reference/gate-vocabulary.md
+++ b/reference/gate-vocabulary.md
@@ -39,14 +39,19 @@ The terms the episode rows above are written against, one line each (#289):
   at the cap, `episode-verdict` accepts a terminal verdict over it instead (re-entry is
   spent), and set-aside dispositions of already-recorded findings land while it rides.
   The design-review and decide doors adopt the episode verbs in a later landing; the
-  epic driver's own retry cap is a separate constant until #274 collapses the two
-  implementations — this bound governs the episode verbs only, not those loops.
+  epic driver records with bare `record` and bounds its own fix loop with a separate
+  constant (`MAX_FIX_CYCLES`) — this bound governs the episode verbs only, not those
+  loops. `scripts/retro-stats` reads a driver-recorded gate from `.gates[<gate>]` when
+  no episode exists.
 - **lane profile** — the set of specialist review lanes (auditors/reviewers) a round
   dispatches for this changeset: the always-on lanes plus the conditionally-routed
   ones, per `commands/review.md`'s routing rules.
 - **open** — a finding's status while it awaits its answer. An Important may ride out
-  a terminal `PASS` still `open`: the readout's "N open" beside a pass names unfinished
-  should-fix work, never a blocked verdict — only a Critical blocks.
+  a terminal `PASS`, `PROCEED TO PLAN`, or `SHIP` still `open`: the readout's "N open"
+  beside a pass names unfinished should-fix work, never a blocked verdict — **only a
+  Critical blocks, in every episode** (design, work, delivery). An Important never opens
+  a fix-and-re-review round on its own; it rides to `/build`'s plan inputs or `/ship`'s
+  follow-ups.
 - **carried** — a finding's status when it rides through the verdict recorded but
   unfixed, rather than blocking; a Critical reaches `carried` only with a recorded
   waiver (`bin/gate-ledger episode-finding`, per its convergence rules).

--- a/reference/telemetry-format.md
+++ b/reference/telemetry-format.md
@@ -116,7 +116,8 @@ branch — the honest limit of what a `PreToolUse` hook can know.
 **The interactive commands emit nothing themselves.** `/review`, `/review --delivery`,
 and `/health` are prose read by a human-invoked session; a per-lane ledger call in their
 fan-out would spend 11–13 extra Bash round-trips per round recording what the hook
-already sees for free. `hooks/dispatch-telemetry.sh` fires on the `Task` tool and writes
+already sees for free. `hooks/dispatch-telemetry.sh` fires on the subagent-dispatch tool
+(`Agent` in current Claude Code, `Task` in older builds; `hooks.json` matches both) and writes
 one dispatch line per lane; the commands carry a pointer to this file, nothing else.
 
 **The driver emits explicitly**, because it is code and knows things no hook can
@@ -136,7 +137,9 @@ Verified against code.claude.com/docs/en/hooks (Common input fields, PreToolUse)
 assumed: every hook receives `session_id`, `transcript_path`, `cwd`, `permission_mode`,
 and `hook_event_name`; `PreToolUse` adds `tool_name`, `tool_input`, and `tool_use_id`;
 `agent_id` and `agent_type` are present only when the hook fires inside a subagent call;
-and `PreToolUse` matchers match the tool name, so `"Task"` is a valid matcher.
+and `PreToolUse` matchers match the tool name as a regex, so `"Agent|Task"` is a valid
+matcher. The dispatch tool was renamed `Task` → `Agent`; a `"Task"`-only matcher recorded
+zero hook lines across every run before 2026-09-08 (#367).
 
 **Assumed, not verified:** the documentation does not enumerate the `Task` tool's own
 `tool_input` fields. The hook reads `subagent_type` and `prompt` from it and exits

--- a/scripts/retro-stats
+++ b/scripts/retro-stats
@@ -310,21 +310,31 @@ def stories_section(data: dict[str, Any]) -> list[str]:
 
 def rounds_section(data: dict[str, Any]) -> list[str]:
     rows = []
-    for work in data["works"]:
-        branch = branch_of(work)
-        history = [h for h in work.get("history", []) if isinstance(h, dict)]
+    # Story branches carry a work file; an epic branch (the finale's gates) carries
+    # none, so it contributes an empty history and renders only from the ledger.
+    sources: list[tuple[str, list[dict[str, Any]]]] = [
+        (branch_of(w), [h for h in w.get("history", []) if isinstance(h, dict)]) for w in data["works"]
+    ]
+    work_branches = {b for b, _ in sources}
+    sources += [(str(e["branch"]), []) for e in data["epics"] if e.get("branch") and e["branch"] not in work_branches]
+    for branch, history in sources:
         for gate in GATES:
             entries = [h for h in history if h.get("step") == gate]
             episodes = [EPISODE_LINE.match(line) for line in data["episodes"].get((branch, gate), [])]
             matched = [m for m in episodes if m]
             escalated = any(line.startswith("escalated\t") for line in data["episodes"].get((branch, gate), []))
-            if not entries and not matched:
+            # A driver-run gate records with bare `record` and opens no episode: the
+            # verdict lives in `gate-get`'s `.gates[<gate>]` only.
+            record = ((data["gates"].get(branch) or {}).get("gates") or {}).get(gate) or {}
+            if not entries and not matched and not record:
                 continue
             ledger_cell = "unmeasured" if data["episodes_failed"] else "—"
             if matched:
                 last = matched[-1]
                 ledger_cell = f"{len(matched)} episode(s), round {last.group('round')} of {last.group('cap')}, {last.group('verdict') or 'no verdict yet'}"
                 ledger_cell += ", escalated" if escalated else ""
+            elif record:
+                ledger_cell = f"no episode — `record` {record.get('verdict', '?')} at {record.get('sha', '?')}"
             rows.append(
                 [
                     f"`{branch}`",

--- a/skills/shape/SKILL.md
+++ b/skills/shape/SKILL.md
@@ -283,10 +283,13 @@ them:
 
 **On `PROCEED TO PLAN`:** stop and report. Session verdict `DESIGNED` (first pass) or
 `REVISED` (this session already redrafted once, below) plus the episode's own
-`PROCEED TO PLAN`, in the same message. Name `/build` as the next door -- `/shape` doesn't
-run it.
+`PROCEED TO PLAN`, in the same message. List any `important` findings the episode
+recorded -- they ride out this verdict as `/build`'s plan inputs, never as a reason to
+redraft (`reference/gate-vocabulary.md`: only a Critical blocks). Name `/build` as the
+next door -- `/shape` doesn't run it.
 
-**On `REVISE`:** redraft the doc in place, addressing the findings in priority order, in
+**On `REVISE`** (a Critical on a fixable dimension -- never an Important alone):
+redraft the doc in place, addressing the findings in priority order, in
 the sections they name. Then re-run Step 5 (`design-lint`, fixed to clean) and Step 6 --
 which resolves to case 3, the resume path, since the doc already carries a
 `## Revision History` heading from the sign-off round Step 6 just finished -- until every

--- a/tests/python/test_retro_stats.py
+++ b/tests/python/test_retro_stats.py
@@ -310,6 +310,23 @@ class TestCliEndToEnd(unittest.TestCase):
             out = run_script(["--repo", str(repo)]).stdout
             self.assertIn("| `docs-auditor` | 1 | 1 | 1 | 0 | 0 | 0 |", out)
 
+    def test_driver_recorded_gate_without_an_episode_renders_from_gate_get(self) -> None:
+        """The epic driver records with bare `record` and opens no episode. The rounds
+        table must still show that gate — from `.gates[<gate>]` — for a story branch
+        with a work file and for the epic branch (the finale's gates), which has none."""
+        with tmp_repo() as repo:
+            self._seed(repo)
+            self._gl(repo, "work-set", "--slug", "e1--s2", "--title", "s", "--source", "epic:e1", "--branch", "epic/e1--s2", "--phase", "audit")
+            subprocess.run(["git", "checkout", "-q", "-b", "epic/e1--s2"], cwd=repo, check=True)
+            self._gl(repo, "record", "--gate", "audit", "--verdict", "PASS")
+            subprocess.run(["git", "checkout", "-q", "-b", "epic/e1"], cwd=repo, check=True)
+            self._gl(repo, "record", "--gate", "acceptance", "--verdict", "SHIP")
+            subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+            out = run_script(["--repo", str(repo)]).stdout
+            self.assertRegex(out, r"\| `epic/e1--s2` \| audit \| — \| — \| no episode — `record` PASS at [0-9a-f]+ \|")
+            self.assertRegex(out, r"\| `epic/e1` \| acceptance \| — \| — \| no episode — `record` SHIP at [0-9a-f]+ \|")
+            self.assertIn("| `epic/e1--s1` | audit | 2 | PASS | 1 episode(s), round 2 of 2, PASS |", out)
+
     def test_blocking_lane_survives_only_while_the_retry_record_stands(self) -> None:
         """`gate-get` holds one record per gate; the PASS that followed replaced the
         retry record, so the seeded lane is not named blocking any more."""

--- a/tests/test_dispatch_telemetry.sh
+++ b/tests/test_dispatch_telemetry.sh
@@ -145,11 +145,18 @@ check "a gauntlet: prefix on a non-judge name writes nothing" "0" "$(lines "$f")
 run_hook "$d" "$(payload '' 'do a thing')" >/dev/null
 check "missing subagent_type writes nothing" "0" "$(lines "$f")"
 run_hook "$d" "$(jq -nc '{hook_event_name:"PreToolUse",tool_name:"Bash",session_id:"s",tool_input:{command:"pytest"}}')" >/dev/null
-check "a non-Task tool writes nothing" "0" "$(lines "$f")"
+check "a non-dispatch tool writes nothing" "0" "$(lines "$f")"
 run_hook "$d" "$(jq -nc '{hook_event_name:"PreToolUse",tool_name:"Task",tool_use_id:"t",tool_input:{subagent_type:"security-auditor",prompt:"x"}}')" >/dev/null
 check "missing session_id writes nothing" "0" "$(lines "$f")"
 run_hook "$d" "$(payload security-auditor 'audit this STUDIOUS-TELEMETRY-SELF-REPORT and report it yourself')" >/dev/null
 check "driver-stamped prompt is suppressed" "0" "$(lines "$f")"
+
+# --- the dispatch tool is named Agent in current Claude Code (#367): both names record ---
+d=$(sandbox)
+f=$(telemetry_file "$d" feat/foo)
+run_hook "$d" "$(jq -nc '{hook_event_name:"PreToolUse",tool_name:"Agent",session_id:"sess-1",tool_use_id:"toolu_02",tool_input:{subagent_type:"studious:security-auditor",prompt:"x"}}')" >/dev/null
+check "the Agent tool name writes a record" "1" "$(lines "$f")"
+check "hooks.json matches both dispatch tool names" "Agent|Task" "$(jq -r '.hooks.PreToolUse[] | select(.hooks[0].command | contains("dispatch-telemetry")) | .matcher' "$ROOT/hooks/hooks.json")"
 
 # --- no plugin root, no ledger: silent no-op, never an error ---
 d=$(sandbox)


### PR DESCRIPTION
## Summary
- **Only a Critical blocks, in every episode.** `commands/review.md` Part 4 (design + delivery) said "one or more `important` → REVISE / FIX AND RE-REVIEW", contradicting `reference/gate-vocabulary.md`'s ratified rule that the work episode already follows. Every review loop in the evidence lived there: driver-collapse's 7 design rounds (0 Criticals in rounds 4–7), acceptance-altitude-evidence's 10, #351's 5 delivery rounds. Importants now ride out PROCEED TO PLAN / SHIP as recorded should-fix work; `/shape` Step 7 redrafts only on a Critical.
- **Telemetry hook recorded zero lines ever** — matcher and script keyed on tool name `Task`; the tool is `Agent`. `hooks.json` now matches `Agent|Task`, the script accepts both, test added.
- **Supervised `/next` runs to the next real decision** instead of asking "run it now?" between pieces (`commands/next.md`, `reference/epic-plan-contract.md`).
- **`scripts/retro-stats` renders driver-recorded gates** from `.gates[<gate>]` when no episode exists (story and epic branches), with a test; the three "until #274 collapses the two implementations" clauses now describe what the driver does.

Closes #361, closes #367, closes #371.

## Test plan
- [x] `pytest tests/python` 907 passed; `unittest tests/jig` 584 OK
- [x] `bash tests/test_dispatch_telemetry.sh` (new Agent-name case), `test_gate_ledger.sh`, `test_evidence_capture.sh`, `test_session_start.sh`, `test_workflows_lint.sh`
- [x] shellcheck, markdownlint, ruff, vermin, check_references, validate_plugin, check_gate_independence