### PR TITLE
feat: /build --candidates N — parallel implementation search with a mechanical rank and a human pick

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,12 @@ appetite is a number you hold yourself.
 ```
 /bet     →  scores the idea, ranks it against the backlog, sets the appetite
    ↓
-/build   →  plans from the issue (or a design doc), then builds — fresh executor per
-            task, script-verified, evidence captured — then convenes /review's work
-            episode itself: up to 13 specialist lanes, plus product acceptance: does
-            this deliver what the bet promised?
+/build   →  plans from the issue (or a design doc), stamped task by task in viva, then
+            builds — fresh executor per task, script-verified, evidence captured — then
+            convenes /review's work episode itself: up to 13 specialist lanes, plus
+            product acceptance: does this deliver what the bet promised?
+            --candidates 2|3 builds the plan in parallel, ranks mechanically, and you
+            pick between two finalists
    ↓
 /ship    →  evidence table, follow-ups, build report; the PR is yours
 

--- a/commands/next.md
+++ b/commands/next.md
@@ -31,7 +31,8 @@ obvious. The user advances the flow; you never do.
 **A piece runs to its next real decision without asking (#371).** Inside a piece, never
 pause to ask "run it now?", "pick up the next task?", or "ready when you are". The stops
 are the decisions this door already names — a stop/rethink token, a Critical waiver, a
-round cap, a fork, a sign-off, the ship verdict — plus `PAUSED` with a named cause.
+round cap, a fork, a sign-off, the pick between `/build` candidates, the ship verdict —
+plus `PAUSED` with a named cause.
 Everything else is a report line, not a question. Measure: human turns per story ≤
 decisions made (`scripts/retro-stats` counts both).
 
@@ -234,7 +235,11 @@ human signs off where an episode cannot verify mechanically.
   pre-mortem register path (its items are what the work episode verifies at the end).
   With no design doc, `/build`'s planning contract attaches the issues, interviews the
   residual forks, drafts `PLAN.md`, lints it, and hands one card per task to the human in
-  viva; `PLAN READY` is the stamp the build proceeds from.
+  viva; `PLAN READY` is the stamp the build proceeds from. Offer `--candidates 2` in
+  the closing block, once, when the stamped plan carries a `Risk:` line or a
+  `### Decisions` block with more than one fork — an implementation search the human
+  opts into, never a default; its pick between finalists is one of this door's named
+  stops.
   Once a feature branch exists, record it — the gate ledger is per-branch, so later pieces
   need it: `work-set --branch "<branch>"`. `/build`
   plans, builds one task at a time, exorcises, then convenes `/review`'s work episode

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -115,7 +115,8 @@ keeps that from being a surprise.
 
 One optional argument: a path to a `PLAN.md`-shaped file, a design doc, **or** one or
 more issue references (`#N`, `owner/repo#N`, URL), defaulting to `PLAN.md` at the target
-project's repo root. The **quick path** is not a
+project's repo root. One optional flag, `--candidates N` (2 or 3), runs the stamped plan
+as an implementation search — see "Candidates" below; absent, one build, as always. The **quick path** is not a
 different input shape — it is simply a plan file containing exactly one
 `### Task` block, hand-authored in the checkpoint-block format below. One
 input contract serves both the quick path and the full cycle; don't invent
@@ -607,6 +608,62 @@ an unrelated `verify` `FAIL`, or from a later task's own first `DEFECT`.
   regardless of any pre-assigned risk tag — that pause is the routine's own
   terminal step, not optional cadence.
 
+## Candidates — implementation search, opt-in
+
+`/build --candidates N` (N = 2 or 3) builds the same stamped plan N times in parallel,
+ranks the results mechanically, and lets the human choose between at most two finalists.
+**Never the default**: run it when the human asks, or when `/next` offers it because the
+stamped plan carries a `Risk:` line or a `### Decisions` block with more than one fork.
+Candidates are independent samples of the same dispatch rules — same model per step 2.2,
+same executor prompt, same plan — so what differs is the search, not the brief. A
+per-candidate model override is not a mode this skill carries today; if the human asks
+for one, say so and run without it.
+
+**Setup (Step 1).** One `worktree-setup` per candidate, `build/<plan-slug>-<ts>-c<k>`,
+all from the same base, each with its own copy of `PLAN.md`. Steps 1.1, 1.4, and 1.5 run
+once; the load-bearing set is shared.
+
+**Per task (Step 2).** Dispatch the task's N executors in one message, one per worktree,
+then verify, inspect, capture, and flip each candidate on its own — evidence and the gate
+ledger are keyed by branch already, so nothing new is recorded. The Failure routine runs
+per candidate. A candidate whose routine resolves to `REPLAN` or `ESCALATE` is
+**eliminated, not paused**: one line naming it and its diagnosis, then the survivors
+continue. Only when every candidate is eliminated does the session report `PAUSED` or
+`ESCALATED`, with the last diagnosis. A risk-tagged pre-dispatch pause still blocks every
+candidate at once — it is the human's acknowledgment, not a candidate's failure.
+
+**Exorcise (Step 3)** runs once per survivor, in its own worktree.
+
+**Pick, mechanically, before any judge runs.** Rank the survivors by these rules in
+order, stopping at the first that separates them:
+
+1. **Eliminate** any candidate with a task not `PASS` in its verify table after
+   exorcise, or whose baseline command is not green after exorcise.
+2. **Fewest out-of-plan files** — files in `git diff --name-only <base>...HEAD` that no
+   task's `Read first:` or `Do:` line names.
+3. **Smallest post-exorcise diff** — added plus removed lines from
+   `git diff --shortstat <base>...HEAD`.
+4. **Fewest Failure-routine dispatches** (FIX plus RESAMPLE) across all tasks.
+5. **Tie** — the lower candidate number.
+
+State the table before proceeding — one row per candidate: tasks `PASS`, suite,
+out-of-plan files, diff size, retries, eliminated or rank. This is bookkeeping: nothing
+here reads a diff for quality, and no candidate is dropped on a judgment call.
+
+**Judge the finalists (Step 4).** Convene the work episode on at most the top two ranked
+survivors, each on its own branch and its own ledger, in parallel. One survivor → the
+ordinary flow from Step 4 on.
+
+**The human picks.** Report one screen per finalist — its table row, the episode's
+verdict and `round R of C — N open, M carried` line, Step 3's concepts removed, and the
+branch — and stop for the human's choice. **Never pick between finalists yourself**: the
+pick is a decision, a named stop, the judgment this search exists to leave with the
+human. The chosen branch is the build's branch (`gate-ledger work-set --branch` when a
+work file matches); once the human has chosen, remove the other candidates
+(`git worktree remove`, then `git branch -D` on each exact branch name this run created)
+and name what was removed. The session verdict then reports as an ordinary build on the
+chosen branch.
+
 ## Step 3 — Exorcise, once, after the last PASS
 
 Runs exactly once per session, only when every task in the plan has reached
@@ -783,7 +840,7 @@ still-open findings to discussion) — the human's call, not this door's.
 
 | Verdict | When |
 |---|---|
-| `BUILT` | Every task in the plan reaches `PASS`, Step 3 has run (or been skipped with its line), and Step 4 closed `PASS`/`NEEDS DISCUSSION`. Report the branch/worktree, Step 3's outcome (concepts removed, the nothing-cast-out line, the Track note, or the skip line), and Step 4's episode verdict on one line each. |
+| `BUILT` | Every task in the plan reaches `PASS`, Step 3 has run (or been skipped with its line), and Step 4 closed `PASS`/`NEEDS DISCUSSION`. Report the branch/worktree, Step 3's outcome (concepts removed, the nothing-cast-out line, the Track note, or the skip line), and Step 4's episode verdict on one line each. Under `--candidates`, the branch is the one the human chose, and the report carries the candidate table. |
 | `PAUSED` | A dirty or missing baseline stopped Setup, or a task's Failure routine resolved to `REPLAN`, or a risk-tagged task is waiting for a pre-dispatch acknowledgment, or a `verify`/`status-flip` usage error persisted after one retry, or Step 4's convened work episode hit its round cap or a convergence refusal. Resumable once the human acts. |
 | `ESCALATED` | A task's Failure routine resolved to `ESCALATE`. Terminal for this session — hand off to `/shape` in revision mode. |
 

--- a/tests/jig/test_build_skill.py
+++ b/tests/jig/test_build_skill.py
@@ -652,3 +652,36 @@ if __name__ == "__main__":
     import sys
 
     sys.exit(unittest.main())
+
+
+class TestCandidatesSearch(unittest.TestCase):
+    """Move 8 (2026-09-09): `/build --candidates N` is an opt-in implementation
+    search — N independent builds of one stamped plan, a mechanical rank, the
+    work episode on at most two finalists, and the human's pick."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.body = SKILL_MD.read_text(encoding="utf-8")
+        start = cls.body.index("## Candidates — implementation search, opt-in")
+        cls.section = cls.body[start:cls.body.index("## Step 3 — Exorcise", start)]
+
+    def test_search_is_opt_in_never_default(self) -> None:
+        self.assertIn("`--candidates N` (2 or 3)", self.body)
+        self.assertIn("**Never the default**", self.section)
+
+    def test_failed_candidates_are_eliminated_not_paused(self) -> None:
+        self.assertIn("**eliminated, not paused**", self.section)
+        self.assertIn("Only when every candidate is eliminated", self.section)
+
+    def test_rank_is_mechanical_and_ordered(self) -> None:
+        order = ("**Eliminate**", "**Fewest out-of-plan files**", "**Smallest post-exorcise diff**",
+                 "**Fewest Failure-routine dispatches**", "**Tie**")
+        positions = [self.section.index(rule) for rule in order]
+        self.assertEqual(positions, sorted(positions))
+        self.assertIn("nothing\nhere reads a diff for quality", self.section)
+
+    def test_judge_at_most_two_finalists_and_the_human_picks(self) -> None:
+        self.assertIn("at most the top two ranked", self.section)
+        self.assertIn("**Never pick between finalists yourself**", self.section)
+        self.assertIn("git branch -D` on each exact branch name this run created", self.section)
+


### PR DESCRIPTION
Stacked on #420 (base `feat/next-intake-viva-write-plan`). Move 6 of the re-evaluation: implementation search via parallel `/build`, judgment kept with the human.

## What changes

- **`/build --candidates N`** (2 or 3), a new section in `skills/build/SKILL.md`. N independent builds of the same stamped plan, one worktree each (`build/<slug>-<ts>-c<k>`), per-task executors dispatched in one message. Evidence and the ledger are keyed by branch already, so nothing new is recorded. A candidate whose Failure routine resolves to `REPLAN`/`ESCALATE` is eliminated, not paused; only when every candidate is eliminated does the session pause. Exorcise runs per survivor.
- **Mechanical rank, before any judge runs:** eliminate (a task not `PASS` after exorcise, suite not green) → fewest out-of-plan files (changed files no task's `Read first`/`Do` names) → smallest post-exorcise diff → fewest Failure-routine dispatches → lower candidate number. The table is stated before proceeding; nothing reads a diff for quality.
- **Work episode on at most the top two**, each on its own branch; the human gets one screen per finalist (table row, episode verdict and readout, concepts removed, branch) and picks. `/build` never picks between finalists. Losers' worktrees and exact branch names are removed after the pick.
- Opt-in only. `/next` offers `--candidates 2` once, in the closing block, when the stamped plan carries a `Risk:` line or more than one interview decision; the pick joins `/next`'s named stops.
- README flow line; four pins in `tests/jig/test_build_skill.py`.

## Open question, not a blocker

Candidates are independent samples under the same model and prompt. Varying by model per candidate, or by plan fork (N stamped plans), are both possible later; the first costs a flag, the second costs the human N interviews. Refs #193 (fan-out opt-in mode) and #199 (parallel executors) in Parked — this is the shape they asked for at story scale; close or re-scope them at merge.

## Verification

jig unittest 505 OK, pytest 345 passed, markdownlint, check_references, check_gate_independence, ruff — green locally. Prose only; no script changed.

Refs #193 #199
