### PR TITLE
fix: plan-lint and verify refuse a plan whose ### Task heading is outside the grammar, naming it

### DIFF
--- a/reference/planning-contract.md
+++ b/reference/planning-contract.md
@@ -226,6 +226,9 @@ Evidence: ...
 ```
 
 **The heading's title text is load-bearing for Step 6.** Always emit it as
+literally `### Task N — <title>` — `plan-lint` refuses (exit 2, naming the heading)
+any other `### Task` form, `Task 2a` or `Task 3.1` included, because a card the
+grammar cannot see is never linted or verified (#267). Emit it as
 literally `### Task N — <title>` -- Step 6's own `--split-on` pattern
 anchors on `^Task \d+`, and a task heading worded any other way (a
 numberless heading, a `Step N` variant, a translated label) silently

--- a/scripts/_planparse.py
+++ b/scripts/_planparse.py
@@ -17,7 +17,12 @@ COMMAND_TIERS = frozenset({"script", "test-backed"})
 # `.*$` tolerates status-flip's trailing suffix (`[PASS]`/`[REPLAN]`/`[ESCALATE]`)
 # without special-casing, so re-parsing a partly-executed plan doesn't fail on
 # the heading. Suffix validation is status-flip's own contract, not this module's.
-TASK_HEADING_RE = re.compile(r"^### Task (\d+)\b.*$", re.MULTILINE)
+TASK_HEADING_RE = re.compile(r"^### Task (\d+)(?=\s|$).*$", re.MULTILINE)
+# Any `### Task…` heading at all. What this matches and TASK_HEADING_RE does not
+# (`### Task 2a`, `### Task two`, `### Task 3.1`, a bare `### Task`) is a card the
+# grammar cannot see: it ends the previous block and belongs to no task, so nothing
+# lints or verifies it. Both CLIs refuse such a plan by name (#267).
+ANY_TASK_HEADING_RE = re.compile(r"^### Task\b.*$", re.MULTILINE)
 # Any heading at level 1-3: the next task heading, or a coarser section
 # (e.g. a closing `## Not-here follow-ups`), either one ends a task block.
 HEADING_LEVEL_1_TO_3_RE = re.compile(r"^(#{1,3})[ \t]", re.MULTILINE)
@@ -60,6 +65,16 @@ def split_tasks(text: str, boundary_re: re.Pattern[str] | None = None) -> list[t
         end = next((b for b in boundary_starts if b > start), len(text))
         tasks.append((m.group(1), text[start:end]))
     return tasks
+
+
+def out_of_grammar_task_headings(text: str) -> list[str]:
+    """Every `### Task…` heading line the task grammar does not accept, verbatim,
+    in document order. Empty means every task card is visible to the grammar."""
+    return [
+        m.group(0)
+        for m in ANY_TASK_HEADING_RE.finditer(text)
+        if not TASK_HEADING_RE.match(m.group(0))
+    ]
 
 
 def task_title(block: str) -> str:

--- a/scripts/plan-lint
+++ b/scripts/plan-lint
@@ -54,8 +54,11 @@ first, matching `verify`'s own per-item reporting precedent.
 
 Exit codes: 0 zero violations. 1 one or more violations (all printed).
 2 usage error -- file missing/unreadable, not inside a git repo (paths
-can't be resolved), or zero `### Task` headings (fail-closed, never a
-vacuous PASS, matching `verify`'s refusal on an empty items list).
+can't be resolved), zero `### Task` headings, or any `### Task` heading
+outside the `### Task N` grammar (`Task 2a`, `Task 3.1`, `Task two` --
+named verbatim on stderr; a card the grammar can't see would otherwise
+go unlinted, #267). Fail-closed, never a vacuous PASS, matching
+`verify`'s refusal on an empty items list.
 
 Out of scope: the `/plan` skill itself; issue #23 (Not-here-follow-ups
 heading-*level* fix) and issue #13 (UI-probe mechanization); semantic/
@@ -93,6 +96,7 @@ from _planparse import (  # noqa: E402
     parse_items,
     task_title,
 )
+from _planparse import out_of_grammar_task_headings  # noqa: E402
 from _planparse import split_tasks as _split_tasks  # noqa: E402
 
 MAX_ITEMS = 5
@@ -339,6 +343,17 @@ def main(argv: list[str]) -> int:
     repo_root = git_repo_root(plan_path.resolve().parent)
     if repo_root is None:
         print(f"error: '{plan_path}' is not inside a git repository -- can't resolve its relative paths", file=sys.stderr)
+        return 2
+
+    bad = out_of_grammar_task_headings(text)
+    if bad:
+        print(
+            f"error: '{plan_path}' has {len(bad)} '### Task' heading(s) outside the "
+            f"'### Task N — <title>' grammar -- a card the grammar can't see is never linted:",
+            file=sys.stderr,
+        )
+        for heading in bad:
+            print(f"  {heading}", file=sys.stderr)
         return 2
 
     tasks, violations = lint(text, repo_root)

--- a/scripts/verify
+++ b/scripts/verify
@@ -101,7 +101,15 @@ from textwrap import indent
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _gitutil import DEFAULT_TIMEOUT_SECONDS, resolve_revision_epoch, run_shell_with_timeout  # noqa: E402
-from _planparse import COMMAND_TIERS, TIER_BODY_RE, VALID_TIERS, Item, parse_items, split_tasks  # noqa: E402
+from _planparse import (  # noqa: E402
+    COMMAND_TIERS,
+    TIER_BODY_RE,
+    VALID_TIERS,
+    Item,
+    out_of_grammar_task_headings,
+    parse_items,
+    split_tasks,
+)
 
 VALID_KINDS = frozenset({"cap", "hold"})
 
@@ -259,6 +267,13 @@ def derive_items_from_plan(plan_path: Path, task_label: str, probe_spec_path: Pa
     except OSError as exc:
         raise ValueError(f"could not read plan file '{plan_path}': {exc}") from exc
 
+    bad = out_of_grammar_task_headings(text)
+    if bad:
+        listed = "; ".join(bad)
+        raise ValueError(
+            f"plan '{plan_path}' has a '### Task' heading outside the '### Task N' grammar "
+            f"({listed}) -- a card the grammar can't see can't be verified; fix the heading (#267)"
+        )
     tasks = split_tasks(text)
     if not tasks:
         raise ValueError(f"plan '{plan_path}' contains no '### Task' headings -- nothing to derive items from")

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -335,8 +335,10 @@ For each task block, in order:
      and report **PAUSED**, naming "verify usage error persisted after
      retry."
    - **The checkpoint block itself doesn't parse** — an ambiguous or
-     malformed `Done means` line, or a duplicate task heading in `<plan
-     path>`. This is a plan-authoring defect, not a Foreman mistake to
+     malformed `Done means` line, a duplicate task heading, or a `### Task`
+     heading outside the `### Task N` grammar (`Task 2a`, `Task 3.1` — `verify`
+     and `plan-lint` both refuse it, naming the heading) in `<plan path>`. This
+     is a plan-authoring defect, not a Foreman mistake to
      retry past: call
      `studious status-flip --plan <path> --task <label> --status REPLAN --reason "<verify's own parse error>"`
      and report **PAUSED** directly — the human revises the block by hand,

--- a/tests/jig/fixtures/plan-lint/boundary-heading-variants.md
+++ b/tests/jig/fixtures/plan-lint/boundary-heading-variants.md
@@ -27,9 +27,10 @@ read Task 2a's line as a real dependency, and never saw Task 3 at all — so
 `3` could not be load-bearing and `1` wrongly was. Both wrong, in opposite
 directions, on one fixture.
 
-That a malformed label is silently skipped rather than reported is a
-separate question — a `plan-lint` validation gap, not a divergence — and is
-deliberately not what this fixture asserts.
+Since #267 neither CLI runs on this file: `plan-lint` and `verify --plan`
+refuse a plan carrying an out-of-grammar `### Task` heading, naming it.
+This fixture exercises the shared splitter and the load-bearing derivation
+only.
 
 ### Task 1 — Add a `quintuple` helper to `_gitutil.py`
 Why now:    the task only the out-of-grammar heading points at, so a wrong parse is visible.

--- a/tests/jig/test_plan_lint.py
+++ b/tests/jig/test_plan_lint.py
@@ -112,6 +112,27 @@ class TestPlanLintCommittedFixtures(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("0 violations", result.stdout)
 
+    def test_out_of_grammar_task_heading_is_refused_by_name(self) -> None:
+        """#267: a `### Task 2a` / `### Task 3.1` card ends the previous block and
+        belongs to no task, so it would go unlinted; refuse the plan instead."""
+        with tempfile.TemporaryDirectory() as tmp:
+            staged = self.stage(tmp, "clean-plan.md")
+            text = staged.read_text(encoding="utf-8")
+            text = text.replace("### Task 2 — Call `double` from a demo script", "### Task 2a — Call `double` from a demo script")
+            text += "\n### Task 3.1 — split late\nWhy now: n/a\n"
+            staged.write_text(text, encoding="utf-8")
+            result = run_script([str(staged)])
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("### Task 2a — Call `double` from a demo script", result.stderr)
+        self.assertIn("### Task 3.1 — split late", result.stderr)
+        self.assertNotIn("violation", result.stdout, "refused before linting, never a partial lint")
+
+    def test_variants_fixture_is_refused_not_partially_linted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_script([str(self.stage(tmp, "boundary-heading-variants.md"))])
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("### Task 2a", result.stderr)
+
     def test_broken_fixture_exits_one_with_all_eight_categories_distinct(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             result = run_script([str(self.stage(tmp, "broken-plan.md"))])

--- a/tests/jig/test_verify.py
+++ b/tests/jig/test_verify.py
@@ -550,6 +550,23 @@ class TestVerifyPlanModeDerivation(unittest.TestCase):
             self.assertIn("task=task-1", result.stdout)
             self.assertIn("overall=PASS", result.stdout)
 
+    def test_out_of_grammar_task_heading_is_refused_even_for_another_task(self) -> None:
+        """#267: `--task 1` on a plan carrying a `### Task 2a` card is a usage error
+        (exit 2) naming the heading — a card the grammar can't see can't be
+        verified, and a partial plan must never verify as whole."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            write_method_script(repo, "scripts/ok", exit_code=0)
+            plan = write_plan(
+                repo,
+                plan_task(1, items="1. [cap]  `scripts/ok` exits zero (tier: script `scripts/ok`)\n")
+                + "\n### Task 2a — split late\nWhy now: n/a\n",
+            )
+            result = run_script(["--plan", str(plan), "--task", "1", "--repo", str(repo)])
+            self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+            self.assertIn("### Task 2a — split late", result.stderr)
+            self.assertNotIn("[PASS]", result.stdout)
+
     def test_failing_derived_item_exits_one_per_item_reported(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)


### PR DESCRIPTION
Second PR of the story-loop order (#346 skeleton landed as #425). A rule in code, one refusal, both consumers.

## What changes

- `scripts/_planparse.py`: `TASK_HEADING_RE` requires whitespace or end-of-line after the number, so `### Task 3.1` no longer parses as task 3. New `ANY_TASK_HEADING_RE` and `out_of_grammar_task_headings(text)` list every `### Task…` heading the grammar rejects, verbatim, in document order.
- `scripts/plan-lint` and `scripts/verify --plan` refuse such a plan with exit 2 and the headings on stderr, before linting or deriving anything — the same fail-closed shape as the existing zero-task guard. A card the grammar can't see would otherwise end the previous block, belong to no task, and pass unlinted and unverified.
- `split_tasks` itself is unchanged, so the load-bearing derivation tests over `boundary-heading-variants.md` still hold; that fixture's prose now says the CLIs refuse it.
- `/build` Step 2.5's exit-2 bullet and the planning contract's heading rule name the refusal; the prose that used to describe the gap is gone.
- Tests: plan-lint (`2a` and `3.1` named, no partial lint; the variants fixture refused), verify (`--task 1` refused when another card is `2a`).

## Verification

jig unittest 513 OK, pytest 351, ruff, vermin, markdownlint, check_gate_independence green; smoke: `studious plan-lint` on a plan with `### Task 3.1` exits 2 naming it.

Closes #267
