### PR TITLE
fix: gate-ledger refuses a verdict over a self-closed Critical or an unreviewed HEAD

### DIFF
--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -624,11 +624,11 @@ cmd_episode_verdict() {
   # Merge, not replace: keeps round/openedAt, gains the verdict; `sha` is
   # refreshed to HEAD so it matches the sha the dual-write below stamps, and
   # `reviewedSha` keeps the sha the round's judges actually read.
-  # shellcheck disable=SC2016 # jq's own $var syntax, not shell expansion
   # A retry outcome certifies nothing, so it carries no reviewedSha; the
   # terminal verdict freezes the sha its round's judges read.
   local reviewed=""
   if [ "$verdict" != "$EPISODE_RETRY_VERDICT" ]; then reviewed="${round_sha:-$head_now}"; fi
+  # shellcheck disable=SC2016 # jq's own $var syntax, not shell expansion
   json_update "$file" \
     '.episodes[$g] = (.episodes[$g] + {verdict: $v, sha: $s, verdictAt: $t}
                       + (if $rs != "" then {reviewedSha: $rs} else {} end))' \

--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -492,7 +492,7 @@ cmd_episode_round() {
     '.episodes[$g].round = (.episodes[$g].round + 1)
      | .episodes[$g].roundSha = $s
      | .episodes[$g].blockingByRound = ((.episodes[$g].blockingByRound // {}) + {($r): ($b | tonumber)})
-     | .episodes[$g] |= del(.verdict, .verdictAt)' \
+     | .episodes[$g] |= del(.verdict, .verdictAt, .reviewedSha)' \
     --arg g "$gate" --arg r "$round" --arg b "$blocking" --arg s "$(head_sha)"
 }
 
@@ -625,9 +625,14 @@ cmd_episode_verdict() {
   # refreshed to HEAD so it matches the sha the dual-write below stamps, and
   # `reviewedSha` keeps the sha the round's judges actually read.
   # shellcheck disable=SC2016 # jq's own $var syntax, not shell expansion
+  # A retry outcome certifies nothing, so it carries no reviewedSha; the
+  # terminal verdict freezes the sha its round's judges read.
+  local reviewed=""
+  if [ "$verdict" != "$EPISODE_RETRY_VERDICT" ]; then reviewed="${round_sha:-$head_now}"; fi
   json_update "$file" \
-    '.episodes[$g] = (.episodes[$g] + {verdict: $v, sha: $s, reviewedSha: ($rs // $s), verdictAt: $t})' \
-    --arg g "$gate" --arg v "$verdict" --arg s "$head_now" --arg rs "$round_sha" --arg t "$(now_iso)"
+    '.episodes[$g] = (.episodes[$g] + {verdict: $v, sha: $s, verdictAt: $t}
+                      + (if $rs != "" then {reviewedSha: $rs} else {} end))' \
+    --arg g "$gate" --arg v "$verdict" --arg s "$head_now" --arg rs "$reviewed" --arg t "$(now_iso)"
   rc=$?
   [ "$rc" -eq 0 ] || return "$rc"
   # Dual-write the legacy per-gate record through cmd_record itself, not a

--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -391,7 +391,7 @@ cmd_episode_open() {
     '.schemaVersion = (.schemaVersion // 1)
      | .branch = $b
      | (if .episodes[$g] then .episodeHistory[$g] = ((.episodeHistory[$g] // []) + [.episodes[$g]]) else . end)
-     | .episodes[$g] = {sha: $s, round: 1, openedAt: $t}' \
+     | .episodes[$g] = {sha: $s, roundSha: $s, round: 1, openedAt: $t}' \
     --arg b "$(branch_name)" --arg g "$gate" --arg s "$(head_sha)" --arg t "$(now_iso)"
 }
 
@@ -490,9 +490,10 @@ cmd_episode_round() {
   # shellcheck disable=SC2016 # jq's own $var syntax, not shell expansion
   json_update "$file" \
     '.episodes[$g].round = (.episodes[$g].round + 1)
+     | .episodes[$g].roundSha = $s
      | .episodes[$g].blockingByRound = ((.episodes[$g].blockingByRound // {}) + {($r): ($b | tonumber)})
      | .episodes[$g] |= del(.verdict, .verdictAt)' \
-    --arg g "$gate" --arg r "$round" --arg b "$blocking"
+    --arg g "$gate" --arg r "$round" --arg b "$blocking" --arg s "$(head_sha)"
 }
 
 cmd_episode_verdict() {
@@ -577,12 +578,56 @@ cmd_episode_verdict() {
     return 1
   fi
   local file rc; file="$(ledger_dir)/$(branch_slug).json"
+  # Rule 3 (#368): a fix is confirmed by the next round's judges, never by the
+  # round that found the defect. A Critical first recorded in this round and
+  # already `closed` in this round was closed by the session that convened
+  # the judges — nobody with fresh eyes saw the fix. The documented path is
+  # the retry token, episode-round, and a close in the re-entered round.
+  local self_closed
+  # shellcheck disable=SC2016 # jq's own $var syntax, not shell expansion
+  self_closed=$(jq -r --arg g "$gate" --arg r "$round" \
+    '[(.episodes[$g].findings // {}) | to_entries[]
+      | select(.value.severity == "Critical" and .value.status == "closed"
+               and ((.value.round | tostring) == $r) and ((.value.closedRound // "" | tostring) == $r))
+      | .key] | join(", ")' "$file" 2>/dev/null)
+  if [ -n "$self_closed" ] && [ "$verdict" != "$EPISODE_RETRY_VERDICT" ]; then
+    echo "gate-ledger: episode-verdict refused for gate '$gate' — Critical finding(s) $self_closed" \
+         "were found AND closed in round $round: the session that convened the judges closed them," \
+         "and no judge has reviewed the fix. Record '$EPISODE_RETRY_VERDICT', run episode-round to" \
+         "re-enter, dispatch the blocking lanes at the new HEAD, and close them in that round" >&2
+    return 1
+  fi
+  # Rule 4 (#368, #361): a terminal verdict certifies the sha the round's judges
+  # read, so HEAD must still be that sha. Below the cap a moved HEAD is refused
+  # — the retry token and episode-round re-enter at HEAD. At the cap the
+  # terminal verdict is the human's explicit choice over spent rounds, so it
+  # lands, but both shas are recorded and the gap is said aloud.
+  local round_sha head_now
+  # shellcheck disable=SC2016 # jq's own $var syntax, not shell expansion
+  round_sha=$(jq -r --arg g "$gate" '.episodes[$g].roundSha // .episodes[$g].sha // empty' "$file" 2>/dev/null)
+  head_now=$(head_sha)
+  if [ -n "$round_sha" ] && [ "$head_now" != "$round_sha" ] && [ "$verdict" != "$EPISODE_RETRY_VERDICT" ]; then
+    local at_cap_sha=0
+    case "$round" in
+      *[!0-9]*) ;;
+      *) if [ "$round" -ge "$EPISODE_ROUND_CAP" ]; then at_cap_sha=1; fi ;;
+    esac
+    if [ "$at_cap_sha" -eq 0 ]; then
+      echo "gate-ledger: episode-verdict refused for gate '$gate' — round $round judged $round_sha," \
+           "but HEAD is $head_now: no judge has reviewed HEAD. Record '$EPISODE_RETRY_VERDICT' and run" \
+           "episode-round to re-enter at HEAD, or reset to $round_sha before recording" >&2
+      return 1
+    fi
+    echo "gate-ledger: episode-verdict for gate '$gate' lands at HEAD $head_now over round $round's" \
+         "reviewed sha $round_sha — the cap is the operator's explicit choice; both shas are recorded" >&2
+  fi
   # Merge, not replace: keeps round/openedAt, gains the verdict; `sha` is
-  # refreshed to HEAD so it matches the sha the dual-write below stamps.
+  # refreshed to HEAD so it matches the sha the dual-write below stamps, and
+  # `reviewedSha` keeps the sha the round's judges actually read.
   # shellcheck disable=SC2016 # jq's own $var syntax, not shell expansion
   json_update "$file" \
-    '.episodes[$g] = (.episodes[$g] + {verdict: $v, sha: $s, verdictAt: $t})' \
-    --arg g "$gate" --arg v "$verdict" --arg s "$(head_sha)" --arg t "$(now_iso)"
+    '.episodes[$g] = (.episodes[$g] + {verdict: $v, sha: $s, reviewedSha: ($rs // $s), verdictAt: $t})' \
+    --arg g "$gate" --arg v "$verdict" --arg s "$head_now" --arg rs "$round_sha" --arg t "$(now_iso)"
   rc=$?
   [ "$rc" -eq 0 ] || return "$rc"
   # Dual-write the legacy per-gate record through cmd_record itself, not a
@@ -614,6 +659,9 @@ cmd_episode_verdict() {
 # identity across rounds, chosen by the caller and never normalized here:
 #
 #   {lane, severity, status, round, recordedAt, updatedAt}
+#   + {closedRound: N}      stamped when status becomes `closed` — episode-verdict
+#                           refuses a terminal verdict over a Critical found and
+#                           closed in the same round (#368)
 #   + {regressionOf: <fp>}  when first recorded on round 2 as a regression of a
 #                           round-1 finding
 #   + {waiver: <reason>}    when carried under a waiver
@@ -872,6 +920,7 @@ cmd_episode_finding() {
        ((.episodes[$g].findings[$fp]
            // {lane: $lane, severity: $sev, round: ($round | tonumber), recordedAt: $t})
         + {status: $status, updatedAt: $t}
+        + (if $status == "closed" then {closedRound: ($round | tonumber)} else {} end)
         + (if $reg != "" then {regressionOf: $reg} else {} end)
         + (if $waiver != "" then {waiver: $waiver} else {} end))' \
     --arg g "$gate" --arg fp "$fingerprint" --arg lane "$lane" --arg sev "$severity" \
@@ -933,7 +982,7 @@ cmd_episode_get() { # --gate G [--findings | --history] [--branch B] -> one line
        | to_entries[]
        | (.key + 1) as $n | .value.current as $cur | .value.e as $e
        | (($e.findings // {}) | to_entries | sort_by(.key)) as $es
-       | "episode \($n)\(if $cur then " (current)" else "" end) — opened \($e.openedAt // "?") at \($e.sha // "?"), round \($e.round) of \($cap), \(if $e.verdict then "verdict \($e.verdict)" else "no verdict yet" end) — \([$es[].value | select(.status == "open")] | length) open, \([$es[].value | select(.status == "carried")] | length) carried",
+       | "episode \($n)\(if $cur then " (current)" else "" end) — opened \($e.openedAt // "?") at \($e.sha // "?"), round \($e.round) of \($cap), \(if $e.verdict then "verdict \($e.verdict)\(if ($e.reviewedSha // $e.sha) != $e.sha then " (judged \($e.reviewedSha))" else "" end)" else "no verdict yet" end) — \([$es[].value | select(.status == "open")] | length) open, \([$es[].value | select(.status == "carried")] | length) carried",
          (if $e.escalated then "escalated\tround \($e.escalated.round)\t\($e.escalated.blocking) blocking, prior round \($e.escalated.priorBlocking)" else empty end),
          ($es[] | select(.value.waiver) | "waiver\t\(.key)\t\(.value.status)\t\(.value.waiver)")' \
       "$file" 2>/dev/null

--- a/commands/review.md
+++ b/commands/review.md
@@ -743,6 +743,12 @@ re-entry check read exactly what they always have.
 studious episode-verdict --gate audit --verdict "PASS"
 ```
 
+**A Critical is never closed by the round that found it.** If this session fixed one itself,
+record `FIX AND RE-REVIEW`, re-enter with `episode-round`, dispatch the blocking lanes at the
+new HEAD, and close it there — the ledger refuses a terminal verdict over a Critical found and
+closed in the same round, and over a HEAD no round's judges read (#368). The one exception is
+the cap, where the terminal verdict is the operator's explicit choice and both shas are recorded.
+
 **Every Critical must be resolved before a closing verdict is recordable.** The ledger refuses
 a terminal verdict while any Critical is still `open` — each one has to be re-recorded
 `--status closed` (fixed) or set aside with `--waiver <reason>` on the user's own word, per the

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -821,6 +821,11 @@ the episode's `PASS`, in the same message.
 and the episode ran — plus the episode's `NEEDS DISCUSSION` and its concerns. No further
 build work follows from this door; resolving the concern is the human's call.
 
+**The convening session never closes a Critical; only a re-convened round does.** A fix this
+session lands is judged by round 2's lanes at the new HEAD — `bin/gate-ledger` refuses a
+`PASS` over a Critical found and closed in the same round, and over a HEAD the round's judges
+did not read (#368).
+
 **On `FIX AND RE-REVIEW`, this episode's first round:** read the blocking findings
 (`studious episode-get --gate audit --findings`) and apply the Failure routine's own
 FIX/RESAMPLE choice to this batch, exactly as step 1 of that routine describes, retargeted

--- a/tests/python/test_episode_contract.py
+++ b/tests/python/test_episode_contract.py
@@ -33,8 +33,10 @@ VOCABULARY = REPO_ROOT / "reference" / "gate-vocabulary.md"
 
 #: The frozen key sets — exact, not subset: a new field on an episode record is
 #: a contract change and must land here in the same commit that writes it.
-OPEN_EPISODE_KEYS = {"sha", "round", "openedAt"}
-CLOSED_EPISODE_KEYS = {"sha", "round", "openedAt", "verdict", "verdictAt"}
+#: `roundSha` is the sha the current round's judges read (#368): stamped at open,
+#: restamped by episode-round; `reviewedSha` freezes it on the closing verdict.
+OPEN_EPISODE_KEYS = {"sha", "roundSha", "round", "openedAt"}
+CLOSED_EPISODE_KEYS = {"sha", "roundSha", "reviewedSha", "round", "openedAt", "verdict", "verdictAt"}
 LEGACY_GATE_KEYS = {"verdict", "sha", "ranAt"}
 
 #: An advanced episode additionally banks the blocking-finding count the round
@@ -178,12 +180,20 @@ class EpisodeContractTest(unittest.TestCase):
 
     def test_verdict_sha_is_head_at_verdict_time(self) -> None:
         """A stale open-time sha would make `status` flag a just-passed gate
-        as needing a re-run."""
+        as needing a re-run. Since #368 a terminal verdict must also land at
+        the sha the round judged: a commit after open needs the retry token
+        and a re-entered round first."""
         self.ledger("episode-open", "--gate", "audit")
         self._git("commit", "-q", "--allow-empty", "-m", "fix")
+        refused = self.ledger("episode-verdict", "--gate", "audit", "--verdict", "PASS")
+        self.assertEqual(refused.returncode, 1)
+        self.assertIn("no judge has reviewed HEAD", refused.stderr)
+        self.ledger("episode-verdict", "--gate", "audit", "--verdict", RETRY_TOKEN)
+        self.ledger("episode-round", "--gate", "audit")
         self.ledger("episode-verdict", "--gate", "audit", "--verdict", "PASS")
         data = self.gates_file()
         self.assertEqual(data["episodes"]["audit"]["sha"], self.head_sha())
+        self.assertEqual(data["episodes"]["audit"]["reviewedSha"], self.head_sha())
         self.assertEqual(data["gates"]["audit"]["sha"], self.head_sha())
 
     def test_verdict_without_open_episode_is_a_usage_error(self) -> None:

--- a/tests/python/test_episode_contract.py
+++ b/tests/python/test_episode_contract.py
@@ -37,6 +37,8 @@ VOCABULARY = REPO_ROOT / "reference" / "gate-vocabulary.md"
 #: restamped by episode-round; `reviewedSha` freezes it on the closing verdict.
 OPEN_EPISODE_KEYS = {"sha", "roundSha", "round", "openedAt"}
 CLOSED_EPISODE_KEYS = {"sha", "roundSha", "reviewedSha", "round", "openedAt", "verdict", "verdictAt"}
+#: A retry outcome certifies no sha, so it carries no `reviewedSha`.
+RETRY_EPISODE_KEYS = CLOSED_EPISODE_KEYS - {"reviewedSha"}
 LEGACY_GATE_KEYS = {"verdict", "sha", "ranAt"}
 
 #: An advanced episode additionally banks the blocking-finding count the round
@@ -269,7 +271,7 @@ class EpisodeContractTest(unittest.TestCase):
         """`/review` records via episode-verdict only, so the blockingLanes
         narrowing data must ride through it to the dual-written legacy record —
         the shape the next round's re-entry check (`gate-get`) already reads.
-        The episode record itself stays exactly CLOSED_EPISODE_KEYS: the lane
+        The episode record itself stays exactly RETRY_EPISODE_KEYS: the lane
         profile is legacy-record data, not a new episode field."""
         self.ledger("episode-open", "--gate", "audit")
         result = self.ledger(
@@ -283,7 +285,7 @@ class EpisodeContractTest(unittest.TestCase):
             data["gates"]["audit"]["blockingLanes"],
             ["security-auditor", "test-auditor"],
         )
-        self.assertEqual(set(data["episodes"]["audit"]), CLOSED_EPISODE_KEYS)
+        self.assertEqual(set(data["episodes"]["audit"]), RETRY_EPISODE_KEYS)
 
     def test_verdict_without_blocking_lanes_writes_no_lane_field(self) -> None:
         self.ledger("episode-open", "--gate", "audit")

--- a/tests/test_gate_ledger.sh
+++ b/tests/test_gate_ledger.sh
@@ -1546,5 +1546,63 @@ contains "episode-get --branch --findings reads the named branch's digest" $'dig
 contains "episode-get --branch (summary) reads the named branch" "round 1 of" \
   "$(cd "$deb" && "$LEDGER" episode-get --gate audit --branch feat/foo)"
 
+# --- #368: a Critical found and closed in the same round cannot close the episode ---
+d368=$(sandbox)
+f368="$d368/.studious/gates/feat-foo.json"
+( cd "$d368" && "$LEDGER" episode-open --gate audit ) >/dev/null
+( cd "$d368" && "$LEDGER" episode-finding --gate audit --lane product-reviewer \
+    --severity Critical --fingerprint product-reviewer/spec --status open ) >/dev/null
+( cd "$d368" && "$LEDGER" episode-finding --gate audit --fingerprint product-reviewer/spec --status closed ) >/dev/null
+check "closing a finding stamps the round it closed in" "1" "$(jq -r '.episodes.audit.findings["product-reviewer/spec"].closedRound' "$f368")"
+err=$(cd "$d368" && "$LEDGER" episode-verdict --gate audit --verdict "PASS" 2>&1 1>/dev/null; echo "rc=$?")
+contains "a PASS over a same-round-closed Critical is refused" "found AND closed in round 1" "$err"
+contains "the refusal names the fingerprint" "product-reviewer/spec" "$err"
+contains "the refusal names the path: retry, re-enter, close there" "run episode-round to" "$err"
+contains "the same-round refusal exits 1" "rc=1" "$err"
+check "no verdict lands" "null" "$(jq -r '.episodes.audit.verdict // "null"' "$f368")"
+( cd "$d368" && "$LEDGER" episode-verdict --gate audit --verdict "FIX AND RE-REVIEW" ); rc=$?
+check "the retry token still records over it" "0" "$rc"
+( cd "$d368" && "$LEDGER" episode-round --gate audit ) >/dev/null
+( cd "$d368" && "$LEDGER" episode-finding --gate audit --fingerprint product-reviewer/spec --status closed ) >/dev/null
+check "re-closing in round 2 restamps closedRound" "2" "$(jq -r '.episodes.audit.findings["product-reviewer/spec"].closedRound' "$f368")"
+( cd "$d368" && "$LEDGER" episode-verdict --gate audit --verdict "PASS" ); rc=$?
+check "a Critical found in round 1 and closed in round 2 lets round 2 close the episode" "0" "$rc"
+
+# --- #368/#361: a terminal verdict certifies the sha the round's judges read ---
+d361=$(sandbox)
+f361="$d361/.studious/gates/feat-foo.json"
+( cd "$d361" && "$LEDGER" episode-open --gate audit ) >/dev/null
+opened=$(jq -r '.episodes.audit.roundSha' "$f361")
+check "episode-open stamps the sha round 1 judges" "$(git -C "$d361" rev-parse --short HEAD)" "$opened"
+( cd "$d361" && git commit -q --allow-empty -m "a fix nobody reviewed" )
+err=$(cd "$d361" && "$LEDGER" episode-verdict --gate audit --verdict "PASS" 2>&1 1>/dev/null; echo "rc=$?")
+contains "a PASS at a HEAD the round never judged is refused below the cap" "no judge has reviewed HEAD" "$err"
+contains "the sha refusal names both shas" "$opened" "$err"
+contains "the sha refusal exits 1" "rc=1" "$err"
+( cd "$d361" && "$LEDGER" episode-verdict --gate audit --verdict "FIX AND RE-REVIEW" ); rc=$?
+check "the retry token records at the moved HEAD" "0" "$rc"
+( cd "$d361" && "$LEDGER" episode-round --gate audit ) >/dev/null
+check "episode-round restamps the sha round 2 judges" "$(git -C "$d361" rev-parse --short HEAD)" "$(jq -r '.episodes.audit.roundSha' "$f361")"
+( cd "$d361" && "$LEDGER" episode-verdict --gate audit --verdict "PASS" ); rc=$?
+check "a PASS at the re-entered round's sha lands" "0" "$rc"
+check "the verdict records the sha the judges read" "$(jq -r '.episodes.audit.sha' "$f361")" "$(jq -r '.episodes.audit.reviewedSha' "$f361")"
+
+# at the cap the terminal verdict is the operator's explicit choice: it lands, both shas recorded, gap said aloud
+dcap=$(sandbox)
+fcap="$dcap/.studious/gates/feat-foo.json"
+( cd "$dcap" && "$LEDGER" episode-open --gate audit ) >/dev/null
+( cd "$dcap" && "$LEDGER" episode-verdict --gate audit --verdict "FIX AND RE-REVIEW" ) >/dev/null
+( cd "$dcap" && "$LEDGER" episode-round --gate audit ) >/dev/null
+judged=$(jq -r '.episodes.audit.roundSha' "$fcap")
+( cd "$dcap" && "$LEDGER" episode-verdict --gate audit --verdict "FIX AND RE-REVIEW" ) >/dev/null
+( cd "$dcap" && git commit -q --allow-empty -m "fix after round 2" )
+err=$(cd "$dcap" && "$LEDGER" episode-verdict --gate audit --verdict "PASS" 2>&1 1>/dev/null; echo "rc=$?")
+contains "at the cap the terminal verdict lands over a moved HEAD" "rc=0" "$err"
+contains "and says the gap aloud" "the cap is the operator's explicit choice" "$err"
+check "the verdict sha is HEAD" "$(git -C "$dcap" rev-parse --short HEAD)" "$(jq -r '.episodes.audit.sha' "$fcap")"
+check "the reviewed sha is what round 2 judged" "$judged" "$(jq -r '.episodes.audit.reviewedSha' "$fcap")"
+contains "episode-get --history names the judged sha when it differs" "(judged $judged)" \
+  "$(cd "$dcap" && "$LEDGER" episode-get --gate audit --history)"
+
 echo "----"
 if [ "$fails" -eq 0 ]; then echo "all gate-ledger tests passed"; exit 0; else echo "$fails failure(s)"; exit 1; fi


### PR DESCRIPTION
Stacked on #427 (base `feat/plan-drift`). Fourth PR of the story-loop order: two refusals in code for the #368 shape (a session finds a Critical, fixes it, closes it, and records PASS in the same round on a sha no judge read).

## What changes, all in `bin/gate-ledger`

- `episode-open` stamps `roundSha` (HEAD); `episode-round` restamps it at re-entry. `episode-finding` stamps `closedRound` when a finding becomes `closed`.
- `episode-verdict`, terminal tokens only (the retry token is exempt as before):
  - **Rule 3** — refuses when any Critical's `round` and `closedRound` are both the current round: the session that convened the judges closed it, nobody with fresh eyes saw the fix. Message names the fingerprints and the path: retry token → `episode-round` → dispatch the blocking lanes at HEAD → close there.
  - **Rule 4** — refuses when HEAD ≠ `roundSha` below the cap: no judge reviewed HEAD. At the cap the verdict lands (it is the operator's explicit choice over spent rounds, and refusing would re-create the two-refusal wedge #289 fixed) with `reviewedSha` recorded beside `sha` and the gap printed. `episode-get --history` shows `(judged <sha>)` when they differ.
- `commands/review.md` and `/build` Step 4 say it once: the convening session never closes a Critical; only a re-convened round does.
- Tests: three new gate-ledger shell sections (same-round close refused then accepted in round 2; moved HEAD refused below cap, accepted after re-entry; cap path records both shas); `test_episode_contract.py`'s key sets and the verdict-sha test updated to the new contract.

Migration: an episode opened before this change has no `roundSha`; the check falls back to the open sha, so an in-flight episode gets the same rule.

## Verification

gate-ledger shell tests, pytest 351, jig 520, shellcheck, markdownlint, check_gate_independence, evidence-capture and session-start shell tests — green locally.

Closes #368
Refs #361
