### PR TITLE
fix: verify names the interpreter a test-backed item runs under and refuses one below the project's floor

### DIFF
--- a/scripts/verify
+++ b/scripts/verify
@@ -222,7 +222,39 @@ def parse_item_tier(item: Item) -> tuple[str, str | None]:
     return tier_word, method_path
 
 
-def resolve_command_for_method(method_path: str, repo_root: Path) -> str:
+PYTHON_FLOOR_RE = re.compile(r"""requires-python\s*=\s*["']\s*>=\s*(\d+)\.(\d+)""")
+
+
+def project_python_floor(repo_root: Path) -> tuple[int, int] | None:
+    """The `>=X.Y` half of pyproject.toml's `requires-python`, or None when the
+    project declares no floor. Regex, not a TOML parser: the 3.9 floor has no
+    tomllib, and the one key this reads has one shape."""
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.is_file():
+        return None
+    m = PYTHON_FLOOR_RE.search(pyproject.read_text(encoding="utf-8", errors="ignore"))
+    return (int(m.group(1)), int(m.group(2))) if m else None
+
+
+def interpreter_version(python: str) -> tuple[int, int] | None:
+    """`(major, minor)` of the interpreter a derived test run executes under, or
+    None when it cannot be asked (missing, not a Python)."""
+    if python == sys.executable:
+        return (sys.version_info.major, sys.version_info.minor)
+    try:
+        probe = subprocess.run(
+            [python, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if probe.returncode != 0:
+        return None
+    major, _, minor = probe.stdout.strip().partition(".")
+    return (int(major), int(minor)) if major.isdigit() and minor.isdigit() else None
+
+
+def resolve_command_for_method(method_path: str, repo_root: Path, python: str = sys.executable) -> str:
     """Turn a `script`/`test-backed` item's cited method path into a runnable shell
     command, mechanically -- never a guess (issue #208).
 
@@ -234,9 +266,12 @@ def resolve_command_for_method(method_path: str, repo_root: Path) -> str:
     - Executable on disk: unchanged, verbatim.
     - A `.py` file under one of this repo's two test trees (CLAUDE.md's "Two test
       runners, deliberately"): runs that one file through the runner owning its
-      tree -- `pytest <path> -q` for `tests/python/`, `python3 -m unittest
-      discover -s <dir> -p <basename>` for `tests/jig/` (unittest has no
+      tree -- `<python> -m pytest <path> -q` for `tests/python/`, `<python> -m
+      unittest discover -s <dir> -p <basename>` for `tests/jig/` (unittest has no
       single-file invocation; `-p` narrows discovery to that one filename).
+      `<python>` is `--python`, defaulting to the interpreter running verify --
+      never a bare `python3` resolved by whatever PATH the caller had (#248), so
+      results.json can say which interpreter every test-backed item ran under.
 
     Anything else falls through to the path itself, unchanged -- a `test-backed`
     item citing neither case is a plan-authoring problem for `plan-lint` to catch,
@@ -251,14 +286,16 @@ def resolve_command_for_method(method_path: str, repo_root: Path) -> str:
         except ValueError:
             parts = ()
         if parts[:2] == ("tests", "python"):
-            return f"python3 -m pytest {shlex.quote(method_path)} -q"
+            return f"{shlex.quote(python)} -m pytest {shlex.quote(method_path)} -q"
         if parts[:2] == ("tests", "jig"):
             directory = str(PurePosixPath(*parts[:-1]))
-            return f"python3 -m unittest discover -s {shlex.quote(directory)} -p {shlex.quote(parts[-1])}"
+            return f"{shlex.quote(python)} -m unittest discover -s {shlex.quote(directory)} -p {shlex.quote(parts[-1])}"
     return method_path
 
 
-def derive_items_from_plan(plan_path: Path, task_label: str, probe_spec_path: Path | None, repo_root: Path) -> dict:
+def derive_items_from_plan(
+    plan_path: Path, task_label: str, probe_spec_path: Path | None, repo_root: Path, python: str = sys.executable
+) -> dict:
     """Build an ITEMS_SCHEMA document mechanically from `plan_path`'s named
     task block; raises ValueError (a usage error, exit 2) on any problem —
     fail closed, never a silently partial item list."""
@@ -317,8 +354,11 @@ def derive_items_from_plan(plan_path: Path, task_label: str, probe_spec_path: Pa
 
     def derive(item: Item, tier: str, method_path: str | None) -> dict:
         if tier in COMMAND_TIERS:
-            command = resolve_command_for_method(method_path, repo_root)
-            return {"id": int(item.num), "kind": item.kind, "tier": tier, "command": command}
+            command = resolve_command_for_method(method_path, repo_root, python)
+            derived = {"id": int(item.num), "kind": item.kind, "tier": tier, "command": command}
+            if command.startswith(shlex.quote(python) + " -m "):
+                derived["interpreter"] = python
+            return derived
         entry = probe_spec[item.num]
         derived = {"id": int(item.num), "kind": item.kind, "tier": tier, "artifact": entry["artifact"]}
         if "pattern" in entry:
@@ -470,6 +510,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "results still print in item order, and each item keeps its own full --timeout"
         ),
     )
+    parser.add_argument(
+        "--python",
+        default=sys.executable,
+        help=(
+            "interpreter a derived test-backed item runs under (only with --plan; default: the one "
+            "running verify). Pass the project's own -- the one its baseline command uses -- so a "
+            "below-floor ambient python3 cannot fail a real item with an ImportError (#248)"
+        ),
+    )
     parser.add_argument("--out", default=None, help="path to write a JSON results document")
     args = parser.parse_args(argv)
 
@@ -481,6 +530,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         parser.error("--task only makes sense with --plan")
     if args.probe_spec and not args.plan:
         parser.error("--probe-spec only makes sense with --plan")
+    if args.python != sys.executable and not args.plan:
+        parser.error("--python only makes sense with --plan")
     return args
 
 
@@ -490,7 +541,9 @@ def main(argv: list[str]) -> int:
 
     try:
         data = (
-            derive_items_from_plan(Path(args.plan), args.task, Path(args.probe_spec) if args.probe_spec else None, repo)
+            derive_items_from_plan(
+                Path(args.plan), args.task, Path(args.probe_spec) if args.probe_spec else None, repo, args.python
+            )
             if args.plan
             else load_items(Path(args.items))
         )
@@ -500,6 +553,29 @@ def main(argv: list[str]) -> int:
 
     items = data["items"]
     has_probe = any(item["tier"] == "probe" for item in items)
+
+    # Environment refusal (#248): a derived test run under an interpreter below
+    # the project's declared floor would FAIL real items with an ImportError
+    # that names nothing about the capability. Refuse before running anything,
+    # naming the interpreter -- exit 2, the "fix the environment and re-invoke"
+    # code, never an item FAIL that enters a fix cycle.
+    interpreter: dict | None = None
+    if any("interpreter" in item for item in items):
+        version = interpreter_version(args.python)
+        interpreter = {"path": args.python, "version": "%d.%d" % version if version else "unknown"}
+        floor = project_python_floor(repo)
+        if version is None:
+            print(f"error: --python '{args.python}' is not an interpreter this run can ask for its version", file=sys.stderr)
+            return 2
+        if floor and version < floor:
+            print(
+                f"error: environment refusal -- the interpreter for test-backed items, {args.python} "
+                f"(Python {interpreter['version']}), is below the project's requires-python floor "
+                f"{floor[0]}.{floor[1]} (pyproject.toml). Nothing ran: a below-floor ImportError would "
+                "read as a capability FAIL. Re-run with --python <the project's interpreter>",
+                file=sys.stderr,
+            )
+            return 2
 
     since_ts: float | None = None
     if args.since is not None:
@@ -530,13 +606,15 @@ def main(argv: list[str]) -> int:
     print(f"verify: task={data.get('task', '?')} overall={overall} ({passed}/{len(results)} items pass)")
 
     if args.out:
-        Path(args.out).write_text(
-            json.dumps(
-                {"task": data.get("task"), "overall": overall, "items": [asdict(r) for r in results]},
-                indent=2,
-            ),
-            encoding="utf-8",
-        )
+        by_id = {item["id"]: item for item in items}
+        dumped = [
+            {**asdict(r), **({"interpreter": by_id[r.id]["interpreter"]} if "interpreter" in by_id.get(r.id, {}) else {})}
+            for r in results
+        ]
+        document: dict = {"task": data.get("task"), "overall": overall, "items": dumped}
+        if interpreter is not None:
+            document["interpreter"] = interpreter
+        Path(args.out).write_text(json.dumps(document, indent=2), encoding="utf-8")
 
     return 0 if overall == "PASS" else 1
 

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -312,7 +312,15 @@ For each task block, in order:
    worktree it shows up as untracked in `git status --porcelain`, and the
    very next call in this same task — not just a later one — refuses
    (issue #45). Then call
-   `studious verify --plan <plan path> --task <this task's heading number> [--probe-spec <scratch-path>/probe-spec.json] --since <this attempt's dispatch timestamp from step 2.2> --repo <worktree> --out <scratch-path>/results.json`.
+   `studious verify --plan <plan path> --task <this task's heading number> [--probe-spec <scratch-path>/probe-spec.json] --since <this attempt's dispatch timestamp from step 2.2> --repo <worktree> --python <interpreter> --out <scratch-path>/results.json`.
+   `--python` is the interpreter the project's own baseline command runs under
+   when `CLAUDE.md`'s convention names one (a `uv run` / venv python), else
+   omit it and `verify` uses its own; either way `results.json` records the
+   path and version every test-backed item ran under (#248). A `verify` exit 2
+   naming an **environment refusal** — the interpreter is below the project's
+   `requires-python` floor — is not a task FAIL and never enters the Failure
+   routine: report **PAUSED**, resume action "re-invoke `/build` under the
+   project's interpreter".
    **Never the executor's own reported commit SHA** for `--since` — a
    `probe` artifact is written to disk *before* it is committed, so its
    mtime is always at or before that very commit's own timestamp; using the

--- a/tests/jig/test_verify.py
+++ b/tests/jig/test_verify.py
@@ -44,6 +44,7 @@ import importlib.machinery
 import importlib.util
 import json
 import os
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -567,6 +568,66 @@ class TestVerifyPlanModeDerivation(unittest.TestCase):
             self.assertIn("### Task 2a — split late", result.stderr)
             self.assertNotIn("[PASS]", result.stdout)
 
+    def test_derived_test_backed_item_records_its_interpreter(self) -> None:
+        """#248: results.json says which interpreter every test-backed item ran
+        under -- per item and at the top -- and honours --python."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            target = repo / "tests" / "python" / "test_thing.py"
+            target.parent.mkdir(parents=True)
+            target.write_text("def test_ok():\n    pass\n", encoding="utf-8")
+            plan = write_plan(
+                repo,
+                plan_task(1, items="1. [cap]  the test passes (tier: test-backed `tests/python/test_thing.py`)\n"
+                                   "2. [hold] n/a (tier: probe)\n"),
+            )
+            spec = repo / "spec.json"
+            spec.write_text(json.dumps({"2": {"artifact": "tests/python/test_thing.py"}}), encoding="utf-8")
+            out = repo / "results.json"
+            result = run_script([
+                "--plan", str(plan), "--task", "1", "--repo", str(repo), "--probe-spec", str(spec),
+                "--since", "2000-01-01T00:00:00Z", "--python", sys.executable, "--out", str(out),
+            ])
+            self.assertIn(result.returncode, (0, 1), result.stdout + result.stderr)
+            doc = json.loads(out.read_text(encoding="utf-8"))
+        self.assertEqual(doc["interpreter"]["path"], sys.executable)
+        self.assertRegex(doc["interpreter"]["version"], r"^\d+\.\d+$")
+        by_id = {item["id"]: item for item in doc["items"]}
+        self.assertEqual(by_id[1]["interpreter"], sys.executable)
+        self.assertNotIn("interpreter", by_id[2], "a probe item runs under no interpreter")
+
+    def test_interpreter_below_the_project_floor_is_an_environment_refusal(self) -> None:
+        """#248: never an item FAIL -- exit 2 naming the interpreter, the floor, and
+        that nothing ran."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            target = repo / "tests" / "python" / "test_thing.py"
+            target.parent.mkdir(parents=True)
+            target.write_text("def test_ok():\n    pass\n", encoding="utf-8")
+            (repo / "pyproject.toml").write_text('[project]\nrequires-python = ">=3.11"\n', encoding="utf-8")
+            fake = repo / "fakepy"
+            fake.write_text("#!/bin/sh\necho 3.8\n", encoding="utf-8")
+            fake.chmod(0o755)
+            plan = write_plan(repo, plan_task(1, items="1. [cap]  t (tier: test-backed `tests/python/test_thing.py`)\n"))
+            result = run_script(["--plan", str(plan), "--task", "1", "--repo", str(repo), "--python", str(fake)])
+            self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+            self.assertIn("environment refusal", result.stderr)
+            self.assertIn("Python 3.8", result.stderr)
+            self.assertIn("floor 3.11", result.stderr)
+            self.assertNotIn("[FAIL]", result.stdout)
+            # no floor declared: the same interpreter runs
+            (repo / "pyproject.toml").unlink()
+            ok = run_script(["--plan", str(plan), "--task", "1", "--repo", str(repo), "--python", str(fake)])
+            self.assertNotEqual(ok.returncode, 2, ok.stdout + ok.stderr)
+
+    def test_python_flag_needs_plan_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            items = write_items(repo, [{"id": 1, "kind": "cap", "tier": "script", "command": "true"}])
+            result = run_script(["--items", str(items), "--repo", str(repo), "--python", "/usr/bin/env"])
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("--python only makes sense with --plan", result.stderr)
+
     def test_failing_derived_item_exits_one_per_item_reported(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)
@@ -738,7 +799,7 @@ class TestResolveCommandForMethod(unittest.TestCase):
             target.write_text("def test_ok():\n    pass\n", encoding="utf-8")
             self.assertEqual(
                 self.module.resolve_command_for_method("tests/python/test_thing.py", repo),
-                "python3 -m pytest tests/python/test_thing.py -q",
+                f"{shlex.quote(sys.executable)} -m pytest tests/python/test_thing.py -q",
             )
 
     def test_a_non_executable_py_file_under_tests_jig_maps_to_unittest_discover(self) -> None:
@@ -749,7 +810,7 @@ class TestResolveCommandForMethod(unittest.TestCase):
             target.write_text("import unittest\n", encoding="utf-8")
             self.assertEqual(
                 self.module.resolve_command_for_method("tests/jig/test_thing.py", repo),
-                "python3 -m unittest discover -s tests/jig -p test_thing.py",
+                f"{shlex.quote(sys.executable)} -m unittest discover -s tests/jig -p test_thing.py",
             )
 
     def test_a_non_executable_py_file_outside_either_test_tree_is_unchanged(self) -> None:


### PR DESCRIPTION
Replaces #430, which GitHub closed when its branch was briefly deleted during the restack. Sixth and last of the head-of-queue story-loop fixes.

## What changes

- **`scripts/verify --plan`** derives a test-backed `.py` item's runner as `<python> -m pytest …` / `<python> -m unittest discover …`, where `<python>` is the new `--python` (default: the interpreter running verify), never a bare `python3` resolved off whatever PATH the caller had.
- **`results.json`** carries `interpreter: {path, version}` at the top and `interpreter` on every derived test-backed item — the acceptance's first half.
- **Environment refusal** — the second half: when `pyproject.toml` declares `requires-python = ">=X.Y"` and the interpreter is below it, verify exits 2 naming the interpreter, its version, and the floor, and runs nothing. Exit 2 rather than the issue's suggested exit 1: exit 1 is the item-FAIL code that enters `/build`'s Failure routine and dispatches a fixer, which is exactly what an environment gap must not do; exit 2 is "fix the environment and re-invoke", and `/build` Step 2.5 now reports it as `PAUSED` with that resume action. `--python` is refused outside `--plan` mode.
- `/build` Step 2.5 passes `--python` as the interpreter the project's baseline command runs under when `CLAUDE.md` names one.
- Tests: interpreter recorded per item and top-level (a probe item carries none); a fake 3.8 interpreter against a 3.11 floor is refused by name and runs with no floor; `--python` without `--plan` is a usage error; the two derivation pins now expect `sys.executable`.

## Verification

jig 527 OK, pytest 351, ruff, vermin, markdownlint, check_gate_independence — green locally.

Closes #248

