### PR TITLE
fix: story-loop survivors — dispatch isolation ban, /bet writes the work file, plan-lint refuses a misspelt Risk tag

### DIFF
--- a/commands/bet.md
+++ b/commands/bet.md
@@ -113,6 +113,17 @@ studious record --gate should-we-build --verdict "BUILD"
 the door was renamed remain readable, and `reference/gate-vocabulary.md` maps the key to the
 episode name.
 
+**On `BUILD` or `BUILD SMALLER`, write the work file too (#355)** — unless `studious
+work-list` already shows one whose branch is the current branch, in which case `/next`
+made it and owns it. A bet with no work file is invisible to a bare `/next`:
+
+```bash
+studious work-set --slug "<slug>" --title "<title, the scoped-down one on BUILD SMALLER>" --source "idea" --phase build
+```
+
+`--phase design` instead when the user asked, in the same breath, to design before
+building. The slug is derived from the title the way `/next` derives it.
+
 The ledger is local and gitignored — it never enters the repo. If `studious` is not found
 (the plugin's `bin/` isn't on `PATH` in this environment), tell the user the verdict could not
 be recorded to the gate ledger — do not skip silently.

--- a/reference/planning-contract.md
+++ b/reference/planning-contract.md
@@ -244,8 +244,9 @@ item's behavior text is a single checkable claim, not a compound sentence
 hiding two checks in one item. A block that needs scrolling to judge is a
 block hiding something -- tighten it or split the task.
 
-**Risk tagging.** An optional `Risk:` line (`REPLAN-RISK` or
-`ESCALATE-RISK`) may appear in any block; absence means `LOW`. Tag
+**Risk tagging.** An optional `Risk:` line (`REPLAN-RISK` or `ESCALATE-RISK`,
+exactly — `plan-lint`'s `invalid-risk` refuses any other value, #227) may
+appear in any block; absence means `LOW`. Tag
 `REPLAN-RISK` when a task's `Done means` rests on an assumption Step 1a
 could only partially confirm (a call site inventoried, but the design's
 *behavioral* claim about it -- not just its existence -- is inferred, not

--- a/scripts/_planparse.py
+++ b/scripts/_planparse.py
@@ -43,6 +43,9 @@ TIER_BODY_RE = re.compile(r"^([\w-]+)(?:\s+`([^`]+)`)?$")
 # that marks a token as a concrete, checkable path (plan-lint's "backtick
 # convention"). Shared by plan-lint and plan-drift so the two read one grammar.
 READ_FIRST_RE = re.compile(r"^Read first:[ \t]*(.*)$", re.MULTILINE)
+RISK_RE = re.compile(r"^Risk:[ \t]*(.*?)[ \t]*$", re.MULTILINE)
+# The two tags skills/build/SKILL.md's Cadence honours; absence means LOW.
+VALID_RISKS = frozenset({"REPLAN-RISK", "ESCALATE-RISK"})
 RESTS_ON_RE = re.compile(r"^Rests on:[ \t]*(.*)$", re.MULTILINE)
 DO_RE = re.compile(r"^Do:[ \t]*(.*)$", re.MULTILINE)
 BACKTICK_RE = re.compile(r"`([^`]+)`")
@@ -57,6 +60,12 @@ def extract_field(block: str, pattern: re.Pattern[str]) -> str:
 
 def strip_line_locator(span: str) -> str:
     return LINE_LOCATOR_SUFFIX_RE.sub("", span)
+
+
+def task_risk(block: str) -> str | None:
+    """The block's `Risk:` value verbatim, or None when the line is absent."""
+    m = RISK_RE.search(block)
+    return m.group(1) if m else None
 
 
 def method_paths(block: str) -> list[str]:

--- a/scripts/plan-lint
+++ b/scripts/plan-lint
@@ -20,7 +20,7 @@ LOAD-BEARING cap concreteness. Prose outside backticks is never inspected --
 guessing which prose "really" names a path is a judgment call a zero-model
 linter can't make.
 
-**Violation categories** (eight; map 1:1 to acceptance criteria, per-item
+**Violation categories** (nine; map 1:1 to acceptance criteria, per-item
 where an item is the unit, per-task otherwise):
 
 - `cap-count`    -- a task's Done means has zero `[cap]` items.
@@ -40,6 +40,9 @@ where an item is the unit, per-task otherwise):
   heading (any `#` depth -- located by text, not depth, since issue #23's
   heading-level fix is a sibling story's job) is empty or one of a short
   placeholder set (`""`, `"todo"`, `"tbd"`, `"..."`, case-insensitive).
+- `invalid-risk` -- a `Risk:` line whose value is not `REPLAN-RISK` or
+  `ESCALATE-RISK`. Absence means LOW by contract; a misspelt tag would read
+  as LOW too, silently skipping the pre-dispatch pause it asked for (#227).
 - `load-bearing-cap-vague` -- a `[cap]` item on a LOAD-BEARING task (a task
   some *other* task's `Rests on:` line names, derived mechanically, never
   declared -- the handoff's own §5.3 decision 8) has no backtick span in
@@ -102,9 +105,11 @@ from _planparse import (  # noqa: E402
     LINE_LOCATOR_SUFFIX_RE,  # noqa: F401  (re-export; the grammar lives in _planparse)
     READ_FIRST_RE,
     RESTS_ON_RE,
+    VALID_RISKS,
     extract_field,
     out_of_grammar_task_headings,
     strip_line_locator,
+    task_risk,
 )
 from _planparse import split_tasks as _split_tasks  # noqa: E402
 
@@ -249,6 +254,12 @@ def check_task(
 
     for item in items:
         violations.extend(check_item_tier(task_num, item, repo_root, earlier_do_lines))
+
+    risk = task_risk(block)
+    if risk is not None and risk not in VALID_RISKS:
+        violations.append(
+            Violation(task_num, "invalid-risk", f"Risk: '{risk}' is not one of {sorted(VALID_RISKS)} -- a tag the pause would not honour")
+        )
 
     if is_load_bearing:
         violations.extend(

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -244,7 +244,7 @@ For each task block, in order:
      you have. The design doc, the full PLAN.md, and every other task's
      history are out of scope for you. Before writing any implementation
      code, or claiming this task's Done means is satisfied, invoke the
-     task-execution-discipline skill. Commit your change yourself as your
+     task-execution-discipline skill. Work in `<worktree>` exactly as given — never the Agent tool's own worktree isolation, which would land this dispatch in a fresh tree on the wrong branch (#365). Commit your change yourself as your
      last act, and end your final message with the commit SHA you just
      created."*
 
@@ -413,7 +413,7 @@ For each task block, in order:
      re-litigating `verify`'s own PASS/FAIL — those belong to scripts or to
      studious's `/review`. The full `PLAN.md`, any other task's
      history, and this session's own conversation are out of scope for
-     you. Return exactly one verdict — `CLEAR`, `DEFECT`, or `CONCERN` —
+     you. Work in `<worktree>` exactly as given — never the Agent tool's own worktree isolation, which would land this dispatch in a fresh tree on the wrong branch (#365). Return exactly one verdict — `CLEAR`, `DEFECT`, or `CONCERN` —
      naming the lens (if any) it turns on and your reasoning cited against
      the diff."*
 
@@ -638,7 +638,10 @@ an unrelated `verify` `FAIL`, or from a later task's own first `DEFECT`.
   straight to the next task with no pause.
 - A task tagged `Risk: REPLAN-RISK` or `Risk: ESCALATE-RISK` in its
   checkpoint block gets a pre-dispatch pause: acknowledge with the human
-  *before* dispatching that task's executor, not only after a failure.
+  *before* dispatching that task's executor, not only after a failure. The
+  pause is a human act and stays prose; the tag's grammar is code —
+  `studious plan-lint`'s `invalid-risk` category refuses any other `Risk:`
+  value, so a typo cannot read as `LOW` (#227).
 - A REPLAN or ESCALATE outcome from the Failure routine always pauses,
   regardless of any pre-assigned risk tag — that pause is the routine's own
   terminal step, not optional cadence.
@@ -658,8 +661,10 @@ for one, say so and run without it.
 all from the same base, each with its own copy of `PLAN.md`. Steps 1.1, 1.4, and 1.5 run
 once; the load-bearing set is shared.
 
-**Per task (Step 2).** Dispatch the task's N executors in one message, one per worktree,
-then verify, inspect, capture, and flip each candidate on its own — evidence and the gate
+**Per task (Step 2).** Dispatch the task's N executors in one message, one per worktree —
+each prompt naming its own candidate's path, with step 2.2's boundary line and its ban on
+the Agent tool's worktree isolation intact — then verify, inspect, capture, and flip each
+candidate on its own — evidence and the gate
 ledger are keyed by branch already, so nothing new is recorded. The Failure routine runs
 per candidate. A candidate whose routine resolves to `REPLAN` or `ESCALATE` is
 **eliminated, not paused**: one line naming it and its diagnosis, then the survivors
@@ -730,7 +735,7 @@ with the build proceeding to its verdict.
      it after (`git branch --unset-upstream`). Run `/exorcist:exorcise`
      with the intent above as its argument, in this worktree. Edit the
      working tree only: never commit, never `git checkout --` or `git
-     reset`. Return the report exorcise prints, verbatim, and nothing else —
+     reset`. Work in `<worktree>` exactly as given — never the Agent tool's own worktree isolation, which would land this dispatch in a fresh tree on the wrong branch (#365). Return the report exorcise prints, verbatim, and nothing else —
      not a review of your own."*
 
    Nothing else goes into the prompt — not `PLAN.md` in full, not any task's

--- a/tests/jig/fixtures/plan-lint/broken-plan.md
+++ b/tests/jig/fixtures/plan-lint/broken-plan.md
@@ -100,6 +100,7 @@ Read first: `scripts/_gitutil.py`
 Rests on:   Task 7
 Do:         nothing real -- fixture only.
 Not here:   n/a
+Risk:       HIGH
 
 Done means:
 1. [cap]  `clean` item with a concrete referent   (tier: script `scripts/_gitutil.py`)

--- a/tests/jig/test_build_skill.py
+++ b/tests/jig/test_build_skill.py
@@ -685,3 +685,15 @@ class TestCandidatesSearch(unittest.TestCase):
         self.assertIn("**Never pick between finalists yourself**", self.section)
         self.assertIn("git branch -D` on each exact branch name this run created", self.section)
 
+
+class TestDispatchIsolationBan(unittest.TestCase):
+    """#365: every dispatch prompt /build builds names its worktree and forbids the
+    Agent tool's own worktree isolation — executor, Inspector, exorcise, and each
+    --candidates executor."""
+
+    def test_the_ban_rides_every_boundary_line(self) -> None:
+        body = SKILL_MD.read_text(encoding="utf-8")
+        needle = "never the Agent tool's own worktree isolation"
+        self.assertGreaterEqual(body.count(needle), 3, "executor, Inspector, and exorcise boundary lines")
+        self.assertIn("its ban on\nthe Agent tool's worktree isolation intact", body)
+

--- a/tests/jig/test_plan_lint.py
+++ b/tests/jig/test_plan_lint.py
@@ -51,6 +51,7 @@ ALL_CATEGORIES = frozenset(
         "read-first-unresolved",
         "not-here-followup-undrafted",
         "load-bearing-cap-vague",
+        "invalid-risk",
     }
 )
 
@@ -133,7 +134,7 @@ class TestPlanLintCommittedFixtures(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertIn("### Task 2a", result.stderr)
 
-    def test_broken_fixture_exits_one_with_all_eight_categories_distinct(self) -> None:
+    def test_broken_fixture_exits_one_with_all_nine_categories_distinct(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             result = run_script([str(self.stage(tmp, "broken-plan.md"))])
         self.assertEqual(result.returncode, 1)
@@ -144,7 +145,7 @@ class TestPlanLintCommittedFixtures(unittest.TestCase):
         self.assertEqual(set(categories_seen), ALL_CATEGORIES)
         # No category suppressed by an earlier failure on the same task (premortem risk #6).
         self.assertEqual(len(categories_seen), len(set(categories_seen)))
-        self.assertEqual(len(lines), 8)
+        self.assertEqual(len(lines), 9)
 
 
 class TestPlanLintUsageErrors(unittest.TestCase):
@@ -198,6 +199,19 @@ def _minimal_task(num: int, *, items: str, read_first: str = "`README.md`", rest
 
 
 class TestPlanLintItemBudget(unittest.TestCase):
+    def test_misspelt_risk_tag_is_invalid_risk_and_a_valid_one_is_clean(self) -> None:
+        bad = _minimal_task(1, items="1. [cap] x (tier: probe)\n2. [hold] y (tier: probe)\n").replace("Not here:   n/a\n", "Not here:   n/a\nRisk:       HIGH\n")
+        good = bad.replace("Risk:       HIGH", "Risk:       REPLAN-RISK")
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            init_repo(repo)
+            plan = write(repo / "PLAN.md", bad)
+            result = run_script([str(plan)])
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("[invalid-risk] task 1: Risk: 'HIGH'", result.stdout)
+            write(repo / "PLAN.md", good)
+            self.assertEqual(run_script([str(plan)]).returncode, 0)
+
     def test_missing_cap_item_is_cap_count_violation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp) / "repo"

--- a/tests/python/test_bet_work_file.py
+++ b/tests/python/test_bet_work_file.py
@@ -1,0 +1,17 @@
+"""#355: a standalone `/bet <idea>` that lands BUILD / BUILD SMALLER writes the work
+file itself, so a bare `/next` afterwards finds it."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BET = (REPO_ROOT / "commands" / "bet.md").read_text(encoding="utf-8")
+
+
+def test_bet_writes_the_work_file_on_a_build_verdict() -> None:
+    section = BET[BET.index("## Record the verdict"):BET.index("## Journal the decision")]
+    assert "On `BUILD` or `BUILD SMALLER`, write the work file too" in section
+    assert 'studious work-set --slug "<slug>" --title' in section
+    assert '--source "idea" --phase build' in section
+    assert "unless `studious\nwork-list` already shows one" in section, "a /next-made work file is /next's"


### PR DESCRIPTION
Three of the seven rescoped survivors, each the smallest change that puts the rule where it belongs.

- **#365** — every dispatch prompt `/build` builds (executor, Inspector, exorcise, and each `--candidates` executor) carries one sentence: work in `<worktree>` exactly, never the Agent tool's own worktree isolation, which lands the dispatch in a fresh tree on the wrong branch. Pinned by count in `test_build_skill.py`.
- **#355** — `/bet` on `BUILD` / `BUILD SMALLER` writes the work file itself (`studious work-set … --source "idea" --phase build`, the scoped title on the smaller verdict) unless `/next` already made one for this branch. A bet with no work file was invisible to a bare `/next`. Pinned in `test_bet_work_file.py`.
- **#227**, decided — the tag's grammar is code, the pause stays a human act. `plan-lint` gains a ninth category, `invalid-risk`: a `Risk:` value other than `REPLAN-RISK` / `ESCALATE-RISK` used to read as `LOW` and silently skip the pre-dispatch pause it asked for. `_planparse.task_risk()`; the broken fixture carries the ninth category; Cadence names the split.

## Verification

jig 537 OK, pytest 352, ruff, markdownlint, check_references, check_gate_independence — green locally.

Closes #365
Closes #355
Closes #227
