### PR TITLE
fix: story-loop survivors — known-red baseline as input, hook arms by the command's tree, ledger write lock, CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -101,6 +104,7 @@ jobs:
         run: |
           curl -fsSL -o /tmp/shellcheck.tar.xz \
             https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz
+          echo "8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198  /tmp/shellcheck.tar.xz" | sha256sum -c -
           tar -xJf /tmp/shellcheck.tar.xz -C /tmp
           sudo install /tmp/shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
       - run: shellcheck bin/gate-ledger hooks/evidence-capture.sh hooks/session-start.sh tests/test_gate_ledger.sh tests/test_evidence_capture.sh tests/test_session_start.sh scripts/install-dev.sh

--- a/.github/workflows/gate-audit-fixtures.yml
+++ b/.github/workflows/gate-audit-fixtures.yml
@@ -4,6 +4,9 @@ name: gate-audit golden fixtures
 # against synthetic fixtures with a live model, so LLM cost and nondeterminism
 # stay out of the merge path. Run by hand after editing any of the 6 audit
 # agents or commands/review.md to catch a verdict/category regression.
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 
@@ -22,7 +25,7 @@ jobs:
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code
+        run: npm install -g @anthropic-ai/claude-code@2.1.266
 
       - name: Run /review against every fixture
         env:

--- a/bin/gate-ledger
+++ b/bin/gate-ledger
@@ -107,13 +107,33 @@ json_update() { # file, jq filter, then any --arg name value ... pairs for jq
   # below is an explicit branch instead.
   local file="$1" filter="$2"
   shift 2
-  local dir tmp rc
+  local dir tmp rc lock i
   dir=$(dirname -- "$file")
+  # A lock around read→jq→mv (#399): the rename is atomic, the read-modify-
+  # write is not, so two writers — the candidates search's per-branch episodes
+  # share nothing, but two verbs on one branch in one session can race — would
+  # let the last mv win the whole file. `mkdir` is the portable atomic
+  # primitive (no flock on stock macOS). A lock older than a minute is a
+  # crashed writer's and is reclaimed; a live one is waited on for ~5s, then refused.
+  lock="$file.lock"
+  i=0
+  until mkdir "$lock" 2>/dev/null; do
+    if [ -d "$lock" ] && [ -n "$(find "$lock" -maxdepth 0 -mmin +1 2>/dev/null)" ]; then
+      rmdir "$lock" 2>/dev/null; continue
+    fi
+    i=$((i + 1))
+    if [ "$i" -ge 100 ]; then
+      echo "gate-ledger: $file is locked by another writer ($lock) — retry, or remove the lock if no ledger command is running" >&2
+      return 1
+    fi
+    sleep 0.05
+  done
   tmp=$(mktemp "$dir/.tmp.XXXXXX")
   # Capture $? as its own statement, not an `if` condition: POSIX defines a
   # no-branch-taken `if` as exit 0, which would silently swallow a jq/mv failure.
   jq "$@" "$filter" "$file" > "$tmp" && mv "$tmp" "$file"
   rc=$?
+  rmdir "$lock" 2>/dev/null
   if [ "$rc" -eq 0 ]; then
     return 0
   fi

--- a/hooks/evidence-capture.sh
+++ b/hooks/evidence-capture.sh
@@ -53,12 +53,28 @@ done
 pattern="(^|[^A-Za-z0-9])(${alt})(\$|[^A-Za-z0-9])"
 printf '%s' "$command_str" | grep -Eq "$pattern" || exit 0
 
+# --- the command's own tree (#377): a verification command that starts with
+# `cd <path> &&`, `git -C <path>`, or carries `--repo <path>` ran THERE, not in
+# this hook's cwd. The build door works in a build/<slug> worktree while the
+# session sits in the main checkout, so arming by the hook's own branch missed
+# every record. First form found wins; no form means the hook's cwd.
+tree=""
+for form in 's/^[[:space:]]*cd[[:space:]]+([^[:space:];&|]+)[[:space:]]*(&&|;).*/\1/p' \
+            's/.*git[[:space:]]+-C[[:space:]]+([^[:space:]]+).*/\1/p' \
+            's/.*--repo(=|[[:space:]]+)([^[:space:]]+).*/\2/p'; do
+  candidate=$(printf '%s' "$command_str" | sed -nE "$form" | head -1 | tr -d "'\"")
+  if [ -n "$candidate" ] && [ -d "$candidate" ] && git -C "$candidate" rev-parse --git-dir >/dev/null 2>&1; then
+    tree="$candidate"; break
+  fi
+done
+[ -n "$tree" ] || tree="$PWD"
+
 # --- armed check: branch must be one gate-ledger already knows about (a work
 # file's .branch, written by /next). work-list's column 3
 # is the branch; exact string match against full branch names.
-branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+branch=$(git -C "$tree" rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
 [ -n "$branch" ] && [ "$branch" != "HEAD" ] || exit 0
-armed=$("$ledger" work-list 2>/dev/null | cut -f3 | grep -qxF "$branch" && echo yes || echo no)
+armed=$(cd "$tree" && "$ledger" work-list 2>/dev/null | cut -f3 | grep -qxF "$branch" && echo yes || echo no)
 [ "$armed" = "yes" ] || exit 0
 
 # --- origin: agent_id is present only when the hook fires inside a subagent
@@ -110,6 +126,8 @@ esac
 
 args=(--command "$command_str" --exit-code "$exit_code" --output-digest "sha256:$digest" --origin "$origin")
 [ -n "$agent_type" ] && args+=(--agent-type "$agent_type")
-"$ledger" evidence-append "${args[@]}" >/dev/null 2>&1
+# Run from the command's tree so the record lands on that branch's log
+# (the store itself is anchored to the main checkout either way).
+( cd "$tree" && "$ledger" evidence-append "${args[@]}" ) >/dev/null 2>&1
 
 exit 0

--- a/scripts/run_gate_audit_fixtures.py
+++ b/scripts/run_gate_audit_fixtures.py
@@ -260,6 +260,20 @@ def run_claude_headless(
     return text
 
 
+ALLOWED_TOOLS_RE = re.compile(r"^allowed-tools:\s*(.+)$", re.MULTILINE)
+
+
+def review_allowed_tools(plugin_root: Path) -> str:
+    """The tool allowlist for the headless run, read from commands/review.md's own
+    frontmatter so the harness grants exactly what the door declares and nothing
+    wider (#414) -- never `--dangerously-skip-permissions`."""
+    text = (plugin_root / "commands" / "review.md").read_text(encoding="utf-8")
+    m = ALLOWED_TOOLS_RE.search(text.split("---", 2)[1] if text.startswith("---") else text)
+    if not m:
+        raise ValueError("commands/review.md declares no allowed-tools frontmatter")
+    return ",".join(tool.strip() for tool in m.group(1).split(",") if tool.strip())
+
+
 def run_claude_headless_json(
     cwd: Path, timeout_seconds: int = 900, plugin_root: Path = REPO_ROOT
 ) -> tuple[str, float | None]:
@@ -279,7 +293,8 @@ def run_claude_headless_json(
         "claude",
         "-p",
         "/review",
-        "--dangerously-skip-permissions",
+        "--allowedTools",
+        review_allowed_tools(plugin_root),
         "--output-format",
         "json",
     ]

--- a/scripts/worktree-setup
+++ b/scripts/worktree-setup
@@ -57,6 +57,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--branch", required=True, help="new branch name to create")
     parser.add_argument("--path", required=True, help="filesystem path for the new worktree")
     parser.add_argument(
+        "--known-red",
+        default=None,
+        metavar="REASON",
+        help=(
+            "accept a failing baseline as pre-existing and continue, on the human's word only "
+            "-- the reason is printed with the failure so the session report carries it; "
+            "never a Foreman default (#364)"
+        ),
+    )
+    parser.add_argument(
         "--baseline",
         required=True,
         help=(
@@ -149,6 +159,23 @@ def main(argv: list[str]) -> int:
             file=sys.stderr,
         )
         return 1
+
+    if baseline_result.returncode != 0 and args.known_red:
+        print(
+            "BASELINE KNOWN-RED (pre-existing failure accepted as input, not overridden):\n"
+            f"  command:   {args.baseline}\n"
+            f"  exit code: {baseline_result.returncode}\n"
+            f"  worktree:  {worktree_path}\n"
+            f"  reason:    {args.known_red}\n"
+            "Every verify run in this worktree inherits a red baseline; the session report "
+            "must carry this reason beside every task's evidence.",
+            file=sys.stderr,
+        )
+        print(
+            f"worktree-setup: branch '{branch}' and worktree '{worktree_path}' are ready; "
+            f"baseline is KNOWN-RED ({args.known_red})."
+        )
+        return 0
 
     if baseline_result.returncode != 0:
         print(

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -173,7 +173,12 @@ may appear anywhere in the block. No `Risk:` line means `LOW` — see Cadence.
    a dirty baseline or a setup failure: stop before dispatching any
    executor and report **PAUSED** — the worktree is left in place (per
    `worktree-setup`'s own design) for inspection; the pre-existing failure
-   is the human's to resolve outside `/build`. Note the **base branch** the
+   is the human's to resolve outside `/build`. **A known-red baseline is an
+   input, never an override (#364):** when the human says the failure is
+   pre-existing and names why, re-run with `--known-red "<their reason>"`
+   — the script accepts it, prints the reason with the failure, and the
+   session report carries that reason beside every task's evidence. You
+   never pass `--known-red` on your own judgment. Note the **base branch** the
    worktree was cut from (`--base` if you passed one, else the branch that
    was checked out) as a branch name, never a sha — Step 3 hands it to
    exorcise.

--- a/tests/jig/test_worktree_setup.py
+++ b/tests/jig/test_worktree_setup.py
@@ -121,6 +121,26 @@ class TestWorktreeSetupTimeout(unittest.TestCase):
     """Issue #49: a hung baseline command is killed and reported distinctly
     from an ordinary non-zero-exit BASELINE FAILURE."""
 
+    def test_known_red_accepts_a_failing_baseline_as_input_and_names_the_reason(self) -> None:
+        """#364: a red baseline on a consuming project is an input the human gives,
+        never an override the Foreman improvises; without the flag exit 1 stands."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            repo.mkdir()
+            init_repo(repo)
+            worktree = Path(tmp) / "wt"
+            without = run_script(["--branch", "b/red", "--path", str(worktree), "--baseline", "exit 3", "--repo", str(repo)])
+            self.assertEqual(without.returncode, 1, without.stderr)
+            worktree2 = Path(tmp) / "wt2"
+            with_flag = run_script([
+                "--branch", "b/red2", "--path", str(worktree2), "--baseline", "exit 3", "--repo", str(repo),
+                "--known-red", "test_x flakes on CI runners; tracked in #12",
+            ])
+            self.assertEqual(with_flag.returncode, 0, with_flag.stderr)
+            self.assertIn("BASELINE KNOWN-RED", with_flag.stderr)
+            self.assertIn("tracked in #12", with_flag.stderr)
+            self.assertIn("baseline is KNOWN-RED", with_flag.stdout)
+
     def test_baseline_exceeding_timeout_is_killed_and_reported_distinctly(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp) / "repo"

--- a/tests/python/test_run_gate_audit_fixtures.py
+++ b/tests/python/test_run_gate_audit_fixtures.py
@@ -292,3 +292,15 @@ def test_extract_section_on_a_nested_report_counts_the_finding() -> None:
 
 def test_extract_section_missing_heading_returns_none() -> None:
     assert extract_section(NESTED_REPORT, "Nonexistent findings") is None
+
+
+def test_headless_run_grants_exactly_the_doors_declared_tools() -> None:
+    """#414: the allowlist is review.md's own frontmatter, never a skip-permissions flag."""
+    import inspect
+
+    import run_gate_audit_fixtures as m
+
+    assert m.review_allowed_tools(m.REPO_ROOT) == "Read,Glob,Grep,Bash,Task,Write,Skill"
+    source = inspect.getsource(m.run_claude_headless_json)
+    assert "--dangerously-skip-permissions" not in source
+    assert "--allowedTools" in source

--- a/tests/test_evidence_capture.sh
+++ b/tests/test_evidence_capture.sh
@@ -156,6 +156,25 @@ out9=$(cd "$d9" && PATH="$fakebin" CLAUDE_PLUGIN_ROOT="$ROOT" bash "$HOOK" \
 check "jq unavailable: hook exits 0 with no output" "rc=0" "$out9"
 check "jq unavailable: no evidence dir created" "no" "$([ -d "$d9/.studious/evidence" ] && echo yes || echo no)"
 
+# --- #377: a command that cd's into an armed worktree is recorded on that branch,
+# even though the hook's own cwd sits on an unarmed one ---
+d377=$(sandbox feat/unarmed)
+wt377="$d377-wt"
+git -C "$d377" worktree add -q -b build/story "$wt377" >/dev/null 2>&1
+arm "$d377" build/story
+out377=$(run_hook "$d377" "$(posttooluse "cd $wt377 && pytest tests/")")
+check "cd-into-worktree command: hook stays silent on stdout" "" "$out377"
+check "cd-into-worktree command: one record on the worktree's branch" "1" \
+  "$(wc -l < "$(evidence_file "$d377" build/story)" | tr -d ' ')"
+check "cd-into-worktree command: nothing on the hook's own branch" "no" \
+  "$([ -f "$(evidence_file "$d377" feat/unarmed)" ] && echo yes || echo no)"
+run_hook "$d377" "$(posttooluse "git -C $wt377 status && pytest -q")" >/dev/null
+check "git -C form: second record on the worktree's branch" "2" \
+  "$(wc -l < "$(evidence_file "$d377" build/story)" | tr -d ' ')"
+run_hook "$d377" "$(posttooluse "pytest tests/")" >/dev/null
+check "no tree form: the hook's own unarmed cwd still produces no record" "no" \
+  "$([ -f "$(evidence_file "$d377" feat/unarmed)" ] && echo yes || echo no)"
+
 # --- CLAUDE_PLUGIN_ROOT missing/unresolved: silent no-op ---
 d10=$(sandbox feat/foo); arm "$d10" feat/foo
 out10=$(cd "$d10" && bash "$HOOK" <<<"$(posttooluse "pytest tests/")" 2>&1; echo "rc=$?")

--- a/tests/test_gate_ledger.sh
+++ b/tests/test_gate_ledger.sh
@@ -1604,5 +1604,22 @@ check "the reviewed sha is what round 2 judged" "$judged" "$(jq -r '.episodes.au
 contains "episode-get --history names the judged sha when it differs" "(judged $judged)" \
   "$(cd "$dcap" && "$LEDGER" episode-get --gate audit --history)"
 
+# --- #399: concurrent writers on one branch both land (json_update takes a lock) ---
+d399=$(sandbox)
+f399="$d399/.studious/gates/feat-foo.json"
+( cd "$d399" && "$LEDGER" record --gate audit --verdict PASS ) >/dev/null
+for i in $(seq 1 8); do
+  ( cd "$d399" && "$LEDGER" work-set --slug "s$i" --title "t$i" --source "#$i" --phase build ) >/dev/null &
+  ( cd "$d399" && "$LEDGER" record --gate "g$i" --verdict OK ) >/dev/null &
+done
+wait
+check "eight concurrent record calls all land on one gates file" "9" "$(jq '.gates | length' "$f399")"
+check "eight concurrent work-set calls all land" "8" "$(cd "$d399" && "$LEDGER" work-list | wc -l | tr -d ' ')"
+check "no lock directory is left behind" "no" "$([ -d "$f399.lock" ] && echo yes || echo no)"
+mkdir "$f399.lock"; touch -t 202001010000 "$f399.lock"
+( cd "$d399" && "$LEDGER" record --gate stale --verdict OK ) >/dev/null; rc=$?
+check "a stale lock (crashed writer) is reclaimed" "0" "$rc"
+check "the write behind the reclaimed lock landed" "OK" "$(jq -r '.gates.stale.verdict' "$f399")"
+
 echo "----"
 if [ "$fails" -eq 0 ]; then echo "all gate-ledger tests passed"; exit 0; else echo "$fails failure(s)"; exit 1; fi


### PR DESCRIPTION
The last four rescoped survivors of the story-loop milestone. Independent of #434 (different files).

- **#364** — `worktree-setup --known-red "<reason>"`: a failing baseline is accepted as a pre-existing input, printed with the failure and the reason, exit 0; without the flag exit 1 stands exactly as before. `/build` Step 1.3: the flag is passed only on the human's word, never the Foreman's judgment, and the session report carries the reason beside every task's evidence.
- **#377** — `hooks/evidence-capture.sh` arms by the command's own tree: a leading `cd <path> &&`, a `git -C <path>`, or a `--repo <path>` names where the verification actually ran, and the record lands on that tree's branch. The hook's cwd is the fallback. Test: hook cwd on an unarmed branch, command `cd <armed worktree> && pytest …` → one record on the worktree's branch, none on the cwd's; the `git -C` form; the no-form case still silent.
- **#399** — `json_update` takes a `mkdir` lock around read→jq→mv (no `flock` on stock macOS): waits ~5 s on a live writer then refuses by name, reclaims a lock older than a minute as a crashed writer's. Test: eight concurrent `record` and eight `work-set` calls on one branch all land; no lock left behind; a stale lock is reclaimed.
- **#414** — both workflows declare `permissions: contents: read`; the shellcheck tarball is sha256-checked; `@anthropic-ai/claude-code` is pinned (2.1.266) in the fixture workflow; the fixture runner replaces `--dangerously-skip-permissions` with `--allowedTools` read from `commands/review.md`'s own frontmatter, so the headless run gets exactly what the door declares. The SessionStart bullet was dropped at rescope (the hook emits slug and phase only).

## Verification

gate-ledger, evidence-capture, and session-start shell tests; jig 538 OK; pytest 353; shellcheck; ruff; vermin; markdownlint; check_references; check_gate_independence — green locally.

Closes #364
Closes #377
Closes #399
Closes #414
